### PR TITLE
Route eval paths through data_dir() to match download_dataset

### DIFF
--- a/.github/ISSUE_TEMPLATE/submission.yml
+++ b/.github/ISSUE_TEMPLATE/submission.yml
@@ -11,14 +11,9 @@ body:
         Incomplete submissions will be closed without review.
 
         Metric definitions follow the paper (Section 4.4 / Appendix A):
-        - **Skill Score (S)** = relative error reduction over the track
-          baseline (Track 1: LINEAR; Track 2: LOCF; Track 3: Seasonal
-          Naive). Reported as a **percentage**, e.g. `12.5` means +12.5 %
-          (not `0.125`).
-        - **Fairness-adjusted Skill Score** = `S − λ·D̄`, where `D̄` is the
-          mean of per-attribute disparities (one per sensitive attribute:
-          age and sex), and each attribute's disparity is the max−min
-          skill score across that attribute's groups (λ = 0.5).
+
+        - **Skill Score (S)** = relative error reduction over the track baseline (Track 1: LINEAR; Track 2: LOCF; Track 3: Seasonal Naive). Reported as a **percentage**, e.g. `12.5` means +12.5 % (not `0.125`).
+        - **Fairness-adjusted Skill Score** = `S − λ·D̄`, where `D̄` is the mean of per-attribute disparities (one per sensitive attribute: age and sex), and each attribute's disparity is the max−min skill score across that attribute's groups (λ = 0.5).
         - **Average Rank** = mean rank across sub-tasks (1 = best).
 
   - type: input

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ env/
 # Cached data
 ~/.cache/
 .cache/
+data/.hf_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ env/
 ~/.cache/
 .cache/
 data/.hf_cache/
+data/processed/

--- a/DATASET.md
+++ b/DATASET.md
@@ -79,7 +79,7 @@ $MHC_DATA_DIR/
     └── day_remain_mask.json      # per-user retain mask
 ```
 
-The eval API resolves these paths through ``openmhc._evaluate._DatasetPaths`` — every entry above is derived from a single root (``MHC_DATA_DIR`` / explicit ``data_dir=`` arg / ``~/.cache/openmhc/data``). If your dataset uses a different layout, the simplest fix is to symlink or rearrange the unpacked files to match.
+The eval API derives every entry above from a single dataset root, resolved (in priority order) from: an explicit ``data_dir=`` argument to ``evaluate_*`` / ``download_dataset``, the ``MHC_DATA_DIR`` env var, or the default ``~/.cache/openmhc/data``. ``openmhc.data_dir()`` returns the resolved root and ``openmhc.download_dataset()`` writes to that same root, so the API and the downloader always agree. If your dataset uses a different layout, the simplest fix is to symlink or rearrange the unpacked files to match.
 
 The schema-only registry files (`label_types.json`, `ordinal_dictionary.json`, `validity_config.json`) ship with this code repo at `data/labels/` and don't need to be downloaded.
 

--- a/DATASET.md
+++ b/DATASET.md
@@ -56,20 +56,27 @@ After download, `$MHC_DATA_DIR` should look like:
 
 ```
 $MHC_DATA_DIR/
-├── labels/
+├── labels/                       # Track 1
 │   ├── last_labels.json          # participant-level outcome labels
 │   ├── context_labels.json       # participant-level covariates
-│   ├── healthkit_daily.json      # daily-resolution HealthKit metrics
 │   ├── label_validity.json       # which (user, label) pairs pass validity
-│   └── clip_dates.json           # per-task date clipping (longitudinal labels)
+│   └── clip_dates.json           # per-task date clipping (longitudinal labels — optional)
 ├── splits/
 │   └── sharable_users_seed42_2026.json   # canonical user-level splits
-└── processed/
-    ├── daily_hourly_hf/          # daily ×24h sensor tensors (HuggingFace Arrow)
-    ├── daily_hf/                 # daily ×1440min sensor tensors (HuggingFace Arrow)
-    ├── window_index_w7_s7_d5.parquet     # 7-day weekly window index
-    ├── weekly_labels_lookup_stride7.parquet  # weekly labels lookup
-    └── normalization_stats_hourly.json   # global z-score statistics
+├── processed/                    # Tracks 1 + 2
+│   ├── daily_hourly_hf/          # daily ×24h sensor tensors (HuggingFace Arrow) — Track 1
+│   ├── daily_hf/                 # daily ×1440min sensor tensors (HuggingFace Arrow) — Track 2
+│   ├── window_index_w7_s7_d5.parquet         # 7-day weekly window index — Track 1
+│   ├── weekly_labels_lookup_stride7.parquet  # weekly labels lookup — Track 1
+│   ├── daily_labels_lookup.parquet           # daily labels lookup — Track 1
+│   └── normalization_stats_hourly.json       # global z-score statistics
+├── hourly_trajectory/            # Track 3 — hourly-resolution per-user trajectories
+└── forecasting_sample_index/     # Track 3
+    ├── sample_index_raw.json     # forecast-window sample index
+    ├── sample_index_P_48_raw.json
+    ├── sample_index_MH_7_3S_100.json
+    ├── sample_index_P_48_M_H_7_3_S_100.json
+    └── day_remain_mask.json      # per-user retain mask
 ```
 
 The eval API resolves these paths through ``openmhc._evaluate._DatasetPaths`` — every entry above is derived from a single root (``MHC_DATA_DIR`` / explicit ``data_dir=`` arg / ``~/.cache/openmhc/data``). If your dataset uses a different layout, the simplest fix is to symlink or rearrange the unpacked files to match.

--- a/DATASET.md
+++ b/DATASET.md
@@ -60,7 +60,8 @@ $MHC_DATA_DIR/
 │   ├── last_labels.json          # participant-level outcome labels
 │   ├── context_labels.json       # participant-level covariates
 │   ├── healthkit_daily.json      # daily-resolution HealthKit metrics
-│   └── label_validity.json       # which (user, label) pairs pass validity
+│   ├── label_validity.json       # which (user, label) pairs pass validity
+│   └── clip_dates.json           # per-task date clipping (longitudinal labels)
 ├── splits/
 │   └── sharable_users_seed42_2026.json   # canonical user-level splits
 └── processed/
@@ -70,6 +71,8 @@ $MHC_DATA_DIR/
     ├── weekly_labels_lookup_stride7.parquet  # weekly labels lookup
     └── normalization_stats_hourly.json   # global z-score statistics
 ```
+
+The eval API resolves these paths through ``openmhc._evaluate._DatasetPaths`` — every entry above is derived from a single root (``MHC_DATA_DIR`` / explicit ``data_dir=`` arg / ``~/.cache/openmhc/data``). If your dataset uses a different layout, the simplest fix is to symlink or rearrange the unpacked files to match.
 
 The schema-only registry files (`label_types.json`, `ordinal_dictionary.json`, `validity_config.json`) ship with this code repo at `data/labels/` and don't need to be downloaded.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ class MeanPoolEncoder:
         # weekly_tensors: (B, 168, 38). Return (B, D) embeddings.
         return weekly_tensors[:, :, :19].mean(axis=1).astype(np.float32)
 
-results = openmhc.evaluate_downstream(MeanPoolEncoder())
+results = openmhc.evaluate_prediction(MeanPoolEncoder())
 print(results.summary())
 print("global score (mean AUROC over binary tasks):", results.global_score)
 ```
@@ -86,7 +86,7 @@ Submissions must follow the standard evaluation protocol — same split file, ma
 
 | Path | What's there |
 |---|---|
-| `src/openmhc/` | Public API (`evaluate_downstream`, `evaluate_imputation`, `download_dataset`, …) |
+| `src/openmhc/` | Public API (`evaluate_prediction`, `evaluate_imputation`, `download_dataset`, …) |
 | `src/downstream_evaluation/` | Track 1 internals (linear probes, time-window selection, metrics) |
 | `src/imputation_evaluation/` | Track 2 internals (masking scenarios, per-channel metrics) |
 | `src/labels/` | Label registry + type lookup |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ body = results.to_submission_yaml(
 print(body)
 ```
 
-`to_submission_yaml` returns a paste-ready body matching the textareas in the [submission issue template](../../issues/new?template=submission.yml). For Track 2 imputation, skill scores and per-category subgroup scores are computed locally against the frozen LOCF baseline; for Track 1, those fields are filled in by the maintainers from `raw_metrics` during ingestion. The HuggingFace Space ingests merged submissions and the public leaderboard rebuilds automatically.
+`to_submission_yaml` returns a paste-ready body matching the textareas in the [submission issue template](../../issues/new?template=submission.yml). For Track 2 imputation, skill scores and per-category subgroup scores are computed locally against the frozen LOCF baseline; for Tracks 1 and 3, those fields are filled in by the maintainers from `raw_metrics` during ingestion (Linear + Seasonal Naive baseline files aren't shipped yet). The HuggingFace Space ingests merged submissions and the public leaderboard rebuilds automatically.
 
 Submissions must follow the standard evaluation protocol — same split file, masking config, and label-validity criterion as the paper. The submission template enforces required fields.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import openmhc
 openmhc.download_dataset(version="tiny")
 ```
 
-Then evaluate a model. Models implement one of two duck-typed protocols — no inheritance required.
+Then evaluate a model. Models implement one of three duck-typed protocols — no inheritance required.
 
 ### Track 1 — outcome prediction (`Encoder`)
 
@@ -64,6 +64,22 @@ results = openmhc.evaluate_imputation(MeanImputer())
 print(results.summary())
 ```
 
+### Track 3 — forecasting (`Forecaster`)
+
+```python
+import numpy as np
+import openmhc
+
+class LastValueForecaster:
+    def predict(self, history: np.ndarray, horizon: int) -> np.ndarray:
+        # history: (n_channels, history_length); returns (n_channels, horizon)
+        last = np.nan_to_num(history[:, -1:], nan=0.0)
+        return np.tile(last, (1, horizon)).astype(np.float32)
+
+results = openmhc.evaluate_forecasting(LastValueForecaster(), forecasting_length=24)
+print(results.summary())
+```
+
 A more complete walkthrough is in [`notebooks/quickstart.ipynb`](notebooks/quickstart.ipynb).
 
 ## Submit to the leaderboard
@@ -86,9 +102,10 @@ Submissions must follow the standard evaluation protocol — same split file, ma
 
 | Path | What's there |
 |---|---|
-| `src/openmhc/` | Public API (`evaluate_prediction`, `evaluate_imputation`, `download_dataset`, …) |
+| `src/openmhc/` | Public API (`evaluate_prediction`, `evaluate_imputation`, `evaluate_forecasting`, `download_dataset`, …) |
 | `src/downstream_evaluation/` | Track 1 internals (linear probes, time-window selection, metrics) |
 | `src/imputation_evaluation/` | Track 2 internals (masking scenarios, per-channel metrics) |
+| `src/forecasting_evaluation/` | Track 3 internals (window cache, point + quantile metrics) |
 | `src/labels/` | Label registry + type lookup |
 | `data/labels/` | Schema-only registry files (label types, ordinal vocab, validity config) |
 | `notebooks/quickstart.ipynb` | End-to-end example |

--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -3,19 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# OpenMHC Quickstart\n",
-    "\n",
-    "End-to-end walkthrough of the public evaluation API:\n",
-    "\n",
-    "1. Download the tiny dataset\n",
-    "2. Define a trivial `Imputer` (mean imputation)\n",
-    "3. Run `evaluate_imputation` and inspect the results\n",
-    "4. Define a trivial `Encoder` (mean-pool over the sensor channels)\n",
-    "5. Run `evaluate_prediction` and inspect the results\n",
-    "\n",
-    "This notebook is the smallest end-to-end loop. It runs on CPU and finishes in a few minutes against the tiny version."
-   ]
+   "source": "# OpenMHC Quickstart\n\nEnd-to-end walkthrough of the public evaluation API:\n\n1. Download the tiny dataset\n2. Track 2 — define a trivial `Imputer` and run `evaluate_imputation`\n3. Track 1 — define a trivial `Encoder` and run `evaluate_prediction`\n4. Track 3 — define a trivial `Forecaster` and run `evaluate_forecasting`\n5. Generate a paste-ready submission body\n\nThis notebook is the smallest end-to-end loop. It runs on CPU and finishes in a few minutes against the tiny version."
   },
   {
    "cell_type": "markdown",
@@ -131,11 +119,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 5. Run downstream evaluation\n",
-    "\n",
-    "`evaluate_prediction` extracts your embeddings, then fits a linear probe per task (logistic regression for binary, ordinal logistic for ordinal, ridge regression for continuous)."
-   ]
+   "source": "## 5. Run prediction evaluation (Track 1)\n\n`evaluate_prediction` extracts your embeddings, then fits a linear probe per task (logistic regression for binary, ordinal logistic for ordinal, ridge regression for continuous)."
   },
   {
    "cell_type": "code",
@@ -147,6 +131,20 @@
     "results = openmhc.evaluate_prediction(MeanPoolEncoder(), tasks=[\"BiologicalSex\", \"age\"])\n",
     "results.summary()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "902af8f7",
+   "source": "## 7. Generate a leaderboard submission\n\n`results.to_submission_yaml(...)` produces a paste-ready body matching the textareas in the [submission issue template](https://github.com/AshleyLab/myheartcounts-dataset/issues/new?template=submission.yml).\n\nFor Track 2 imputation, skill scores and per-category subgroup scores are computed locally against the frozen LOCF baseline (`data/baselines/imputation_locf.json`). For Track 1 and Track 3, those fields are emitted as `—` and filled in by the maintainers from `raw_metrics` during ingestion.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "1ce0f091",
+   "source": "class LastValueForecaster:\n    \"\"\"Repeat the most recent observed value across the forecast horizon.\"\"\"\n\n    def predict(self, history: np.ndarray, horizon: int) -> np.ndarray:\n        # history: (n_channels, history_length); returns (n_channels, horizon)\n        last = np.nan_to_num(history[:, -1:], nan=0.0)\n        return np.tile(last, (1, horizon)).astype(np.float32)\n\n\n# max_samples keeps this fast on the tiny dataset; remove for full eval\nforecast_results = openmhc.evaluate_forecasting(\n    LastValueForecaster(), forecasting_length=24, max_samples=20\n)\nforecast_results.summary()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -12,7 +12,7 @@
     "2. Define a trivial `Imputer` (mean imputation)\n",
     "3. Run `evaluate_imputation` and inspect the results\n",
     "4. Define a trivial `Encoder` (mean-pool over the sensor channels)\n",
-    "5. Run `evaluate_downstream` and inspect the results\n",
+    "5. Run `evaluate_prediction` and inspect the results\n",
     "\n",
     "This notebook is the smallest end-to-end loop. It runs on CPU and finishes in a few minutes against the tiny version."
    ]
@@ -134,7 +134,7 @@
    "source": [
     "## 5. Run downstream evaluation\n",
     "\n",
-    "`evaluate_downstream` extracts your embeddings, then fits a linear probe per task (logistic regression for binary, ordinal logistic for ordinal, ridge regression for continuous)."
+    "`evaluate_prediction` extracts your embeddings, then fits a linear probe per task (logistic regression for binary, ordinal logistic for ordinal, ridge regression for continuous)."
    ]
   },
   {
@@ -144,7 +144,7 @@
    "outputs": [],
    "source": [
     "# tasks=\"all\" is fine on the tiny dataset; restrict if you want a faster loop\n",
-    "results = openmhc.evaluate_downstream(MeanPoolEncoder(), tasks=[\"BiologicalSex\", \"age\"])\n",
+    "results = openmhc.evaluate_prediction(MeanPoolEncoder(), tasks=[\"BiologicalSex\", \"age\"])\n",
     "results.summary()"
    ]
   },

--- a/src/forecasting_evaluation/CODEREVIEW.md
+++ b/src/forecasting_evaluation/CODEREVIEW.md
@@ -1,0 +1,374 @@
+# Forecasting Evaluation
+
+## 1. Data Preprocessing
+
+### 1.1 Raw Inputs
+
+Evaluation depends on two HuggingFace datasets that are already materialized on disk:
+
+- `data/processed/daily_hf`: day-level data, used to build the day-level retain mask.
+- `data/hourly_trajectory`: user-organized hourly trajectories, used for evaluation, window slicing, and metric ground truth.
+
+Each record in `hourly_trajectory` must include at least:
+
+- `user_id`
+- `values`, with shape `(T, C)`
+- `timestamps`
+- `channel_names`
+
+### 2.1.1 How hourly trajectory is built
+
+`data/hourly_trajectory` is not read directly from raw files. It is produced by [scripts/data/build_hourly_trajectory_res.py](../../scripts/data/build_hourly_trajectory_res.py#L65), which calls [build_hourly_trajectory_res()](../data/processing/hourly_trajectory_res.py#L19). The Imperial PBS entrypoint is [build_hourly_trajectory.pbs](../../jobs/imperial/pbs/forecasting/build_hourly_trajectory.pbs#L1).
+
+The full processing chain is:
+
+1. Raw HDF5 -> `data/processed/daily_hf`:
+2. `data/processed/daily_hf` -> `data/hourly_trajectory`: then [build_hourly_trajectory()](../data/processing/hourly_hf_trajectory.py#L116) is called. Data is sorted by `user_id, date`, then concatenated user by user in a streaming way. Each user's daily `(19, 1440)` minute-level values are aggregated by [resample_day_to_hourly()](../data/processing/daily_hf_to_daily_hourly_hf.py#L90) into `(19, 24)`:
+   - Binary channels (sleep/workout), i.e., channels `7-18`, use hourly `nanmax`: if any minute in an hour is 1, the hour is 1; if the whole hour is missing, it is `NaN`.
+   - Accumulation channels (for example steps, distance, flights, active energy) use hourly `nansum`; if the whole hour is missing, it is `NaN`.
+   - Rate channels (heart rate) use hourly `nanmean`.
+Existing calendar dates are inserted as real aggregated 24-hour blocks; missing calendar days in between are filled with all-`NaN` blocks of shape `(24, 19)` to keep a continuous timeline.
+3. Finally, one trajectory record is output per user:
+   - `values`: `(T, 19)`, where `T = number_of_calendar_days_from_first_to_last * 24`
+   - `timestamps`: ISO hourly timestamps of length `T`
+   - `channel_names`: canonical 19-channel names
+   - `user_id`
+
+Important: this hourly trajectory build path itself does not perform forecasting sample filtering and does not create train/val/test splits. It only organizes raw minute-level daily data into continuous user-level hourly sequences. Which days can be used as forecasting start points is decided later by the day retain mask and sample index.
+
+Default paths are defined in [configs/forecasting_eval/default.yaml](../../configs/forecasting_eval/default.yaml#L1) and [config.py](config.py#L13).
+
+### 2.2 Day retain mask
+
+[generate_day_drop_mask()](data/day_retain_mask_generator.py#L19) is built from daily HF data and outputs:
+
+```text
+data/forecasting_sample_index/day_remain_mask.json
+```
+
+Format:
+
+```json
+{
+  "user_id": ["YYYY-MM-DD", "..."]
+}
+```
+
+It represents which days for each user pass day-level quality control. Default day-level filtering in code includes:
+
+- `WearTimeFilter(min_wear_fraction=0.5)`
+- `LowChannelVarianceFilter`
+
+Note: [scripts/precompute_forecasting_inputs.py](../../scripts/precompute_forecasting_inputs.py#L105) currently parses arguments like `--min_wear_fraction` and `--disable_variance_filter`, but does not pass them through when calling [generate_day_drop_mask()](data/day_retain_mask_generator.py#L19), so function defaults are still used in practice.
+
+### 2.3 Sample index
+
+[SampleIndexGenerator](data/sample_index_generator.py#L24) reads hourly trajectory and day retain mask, and produces:
+
+```text
+data/forecasting_sample_index/sample_index_P_24_M_H_7_3_S_100.json
+```
+
+Format:
+
+```json
+{
+  "user_id": [1, 2, 3]
+}
+```
+
+Each integer is a forecast-start day index. Generation logic:
+
+1. Raw candidates: for each user, generate `1..max_start_day` first.
+   `max_start_day = (total_hours - forecasting_length) // 24`, so a full prediction horizon must remain from that day boundary.
+2. `missing_mask` filter (the `_M` in filename): all future calendar days covered by the prediction window must appear in `day_remain_mask`. Here, `M` is a missing-mask constraint that limits forecast-target future days to day-level QC-retained days. It is not a strong constraint requiring every channel in hourly targets to be observed; hourly missing values are still excluded later by `NaN`/observed-mask handling in metrics. If `forecasting_length=48`, the next 2 days are checked.
+3. `historical_check` filter: among the most recent `recent_day_count` days before target day, at least `minimum_valid_day` days must appear in `day_remain_mask`. For example, default `H_7_3` means at least 3 valid days in the previous 7 days.
+4. `maximum_sample_count_per_user` filter: keep up to the configured number of candidate days per user; if exceeded, randomly sample. Default `_S_100`.
+5. Users with empty candidate lists are dropped when saving.
+
+Imperial entrypoint example is in [generate_sample_index.slurm](../../jobs/imperial/slurm/forecasting/generate_sample_index.slurm#L1):
+
+```bash
+python scripts/precompute_forecasting_inputs.py \
+  --daily_hf_dir data/processed/daily_hf \
+  --hourly_trajectory_path data/hourly_trajectory \
+  --sample_index_path data/forecasting_sample_index/sample_index.json \
+  --day_remain_mask_path data/forecasting_sample_index/day_remain_mask.json \
+  --forecasting_length 24 \
+  --filter_parameters_json '{"missing_mask": true, "historical_check": {"recent_day_count": 7, "minimum_valid_day": 3}, "maximum_sample_count_per_user": 100}' \
+  --seed 42
+```
+
+## 3. Walk Through the Evaluation Flow Step by Step via ForecastingEvaluator.run()
+
+This section is organized by the execution order of [ForecastingEvaluator.run()](evaluation/evaluator.py#L51), so you can map it directly to code.
+
+### 3.1 Step 0: Print config and create model
+
+The entry first calls [print_config()](config.py#L327), then instantiates a model via [create_forecasting_model()](models/registry.py#L23).
+
+Three config blocks are passed together into model construction:
+
+- `model`
+- `forecasting`
+- `features`
+
+So downstream behavior such as window length, quantile output capability, and whether fixed history windows are required (PyPOTS) is determined here.
+
+### 3.2 Step 1: Load train/val/test together (not test-only)
+
+`run()` enters [_load_evaluation_data()](evaluation/evaluator.py#L84), then calls [ForecastingDataLoader.load_splits()](data/data_loader.py#L59).
+
+`load_splits()` does:
+
+1. Validate that `data.sample_index_file` exists.
+2. Read hourly trajectory from `data.trajectory_hf_dir`.
+3. If `data.max_samples` is set, apply HF dataset prefix truncation first (for debugging).
+4. Read sample index and keep only users appearing in the sample index.
+5. Prefer loading user split from `data.split_file`; if missing, perform random split using `train_ratio / val_ratio / split_seed`.
+6. Intersect each split with sample-index-eligible users.
+7. Return `train_ds, val_ds, test_ds`.
+
+Even though predictions are written only for `test_ds`, the evaluator must load all three splits at once because cache/scaler statistics are prepared at this stage.
+
+### 3.4 Step 2: Build/reuse history_cf cache bundle
+
+Then [prepare_history_cf_cache_bundle()](forecasting_training/cache_bundle.py#L52) is used to prepare cache and row-group manifests for all three splits in one shot.
+
+Typical directory layout:
+
+```text
+data/processed/forecasting_eval_h5/history_cf_cache/<hash>/
+  train.h5
+  train_standard.h5
+  val.h5
+  val_standard.h5
+  test.h5
+  test_standard.h5
+  train_manifest.json
+  val_manifest.json
+  test_manifest.json
+  config.yaml
+  standard_scaler_stats.json
+```
+
+The evaluator stores two key objects in context for later sequential inference:
+
+- `test_cache_path`: the actual test H5 selected for the current model
+- `test_row_groups`: window list grouped by trajectory row
+
+### 3.5 Step 3: Initialize writers and enter sequential inference
+
+`run()` then creates [PublicWriter](io/predict_result_writer.py#L120) and calls [_run_sequential()](evaluation/evaluator.py#L164).
+
+Inside `_run_sequential()`:
+
+1. Resolve runtime offset first, via [_resolve_runtime_daily_start_hour_offset()](evaluation/evaluator.py#L278).
+2. Open H5 at `test_cache_path` (shared read).
+3. Iterate over `test_row_groups` (each row group usually corresponds to one test trajectory/user).
+4. For each user, create [PredictResultWriter](io/predict_result_writer.py#L220) and append multiple windows row by row into parquet.
+
+### 3.6 Step 4: Compute real window boundaries per window and run prediction
+
+For each `current_day` in a row group, evaluator calls [_resolve_window_hours()](forecasting_training/online_dataset.py#L361):
+
+```python
+history_end_hour = current_day * 24 + daily_start_hour_offset
+pred_end_hour = history_end_hour + forecasting_length
+```
+
+Runtime validity filtering is applied again:
+
+- Skip if `history_end_hour <= 0`
+- Skip if PyPOTS and `history_end_hour < n_steps`
+- Skip if `pred_end_hour > trajectory_length`
+
+Window semantics depend on model type:
+
+- Non-PyPOTS: `history_window = history_cf[:, :history_end_hour]`
+- PyPOTS: `history_window = history_cf[:, history_end_hour - n_steps:history_end_hour]`
+- Shared target: `target_window = history_cf[:, history_end_hour:pred_end_hour]`
+
+Then it builds [SubTrajectoryInput](data/types.py#L16) and calls `model.predict_wrapper(...)`.
+
+When writing each prediction row, `history_length` is persisted as the absolute forecast origin `history_end_hour` (not model-consumed context length). This guarantees unambiguous reconstruction of ground-truth slices in offline metrics.
+
+## 5. Prediction output
+
+[PublicWriter](io/predict_result_writer.py#L120) and [PredictResultWriter](io/predict_result_writer.py#L220) write to:
+
+```text
+results/forecasting_eval/<experiment_name>/<model_name>/<user_id>.parquet
+```
+
+If `experiment_name` starts with `Test`, the model directory name appends a timestamp.
+
+Default is `output.overwrite_existing_parquet=false`. If a user parquet already exists, that user is skipped. Set to `true` to overwrite.
+
+Each row corresponds to one forecasting window, with major fields:
+
+- `user_id`
+- `model`
+- `history_length`: absolute hour index of forecast origin in the full trajectory.
+- `point_predictions`: expected shape `(n_features, forecasting_length)`.
+- `quantile_predictions`: expected shape `(n_features, forecasting_length, n_quantiles)`, can be empty.
+- `performance`: auxiliary inference metadata recorded by model, such as runtime and memory.
+
+Entrypoint example:
+
+```bash
+python scripts/run_forecasting_eval.py \
+  --config configs/forecasting_eval/default.yaml \
+  --config configs/forecasting_eval/model_config/seasonalNaive.yaml \
+  --config configs/forecasting_eval/forecasting_setup/final_eval_24.yaml
+```
+
+Imperial array entrypoint is [run_forecasting_eval.slurm](../../jobs/imperial/slurm/forecasting/run_forecasting_eval.slurm#L1), typically stacking base config, model config, and forecasting setup config.
+
+## 6. Supported model types
+
+Current supported `model.type` values:
+
+- `seasonal_naive`
+- `seasonal_naive_average_history`
+- `autoARIMA`
+- `autoETS`
+- `chronos2`
+- `toto`
+- `mixlinear`
+- `dlinear`
+- `segrnn`
+
+If `model.name` is empty, output directory naming and parquet `model` field default to `model.type`.
+
+## 7. Offline metric computation
+
+Entrypoint:
+
+```bash
+python src/forecasting_evaluation/metrics/offline_calculate.py \
+  --evaluation-result-paths seasonal_naive=results/forecasting_eval/Final_Eval_24/seasonal_naive \
+  --metrics-output-path results/metrics
+```
+
+`--evaluation-result-paths` uses `run_key=prediction_model_dir`. `run_key` becomes the output directory name for offline metrics.
+
+### 7.1 Reconstructing offline pipeline inputs
+
+For each run, [OfflineMetricsPipeline](metrics/offline/pipeline.py#L57) does:
+
+1. Read `config.yaml` from prediction directory.
+2. Re-run [ForecastingDataLoader.load_splits()](data/data_loader.py#L59) with that config.
+3. Reuse the same evaluator path [prepare_history_cf_cache_bundle()](forecasting_training/cache_bundle.py#L52) to load raw test history.
+4. Scan user parquet files under prediction directory.
+5. Build offline context only for test users that also have prediction parquet.
+
+This shares the same split/cache/manifest data path as evaluator, avoiding reinterpretation of raw trajectory logic during metrics.
+
+### 7.2 Channel merge
+
+Before metric computation, offline metrics applies fixed channel merge via [resolve_channel_merges()](metrics/offline/channel_merge.py#L26) and [merge_channel_first_array()](metrics/offline/channel_merge.py#L51):
+
+- `(0, 3)`
+- `(1, 4)`
+
+Rule: do element-wise `nanmean` between primary and secondary channel, write result back to primary channel, and zero out the secondary channel. Corresponding secondary feature rows in metric outputs are also zeroed by [zero_out_metrics_output()](metrics/offline/channel_merge.py#L74).
+
+### 7.3 Ground truth and observed mask
+
+For each prediction row, [slice_ground_truth()](metrics/offline/metric_core.py#L29) does:
+
+```python
+start = row["history_length"]
+end = start + config.forecasting.forecasting_length
+ground_truth = history[:, start:end]
+ground_truth_observed_mask = np.isfinite(ground_truth)
+```
+
+If `history_length` is missing, not a non-negative integer, or `end` exceeds trajectory length, that row is skipped and counted.
+
+All point/quantile metrics ignore missing positions using `ground_truth_observed_mask`. Missing ground truth is stored as `NaN` in output matrices.
+
+### 7.4 Benchmark-level scale
+
+Before calculating MASE/sQL, pipeline scans all actual prediction windows in that run and estimates scales from all valid seasonal pairs. Relevant implementation entrypoints are [accumulate_hour_of_day_scale_statistics()](evaluation/point_metrics.py#L151), [finalize_hour_of_day_scales()](evaluation/point_metrics.py#L83), [accumulate_global_scale_statistics()](evaluation/point_metrics.py#L265), and [finalize_global_scales()](evaluation/point_metrics.py#L118):
+
+- Seasonal lag is fixed at 24 hours.
+- Only positions where both `target_idx` and `target_idx - 24` are finite are used.
+- `mase`/`sql` use scales by `(feature, hour-of-day)`, shape `(n_features, 24)`.
+- `mase_all` uses one global scale per feature, shape `(n_features,)`.
+- Entries with count 0 or scale 0 are set to `NaN`.
+
+### 7.5 Metric definitions and output shapes
+
+Each prediction row is passed to [MetricsComputer.compute()](metrics/offline/metric_core.py#L87), producing one metric matrix of shape `(n_features, forecasting_length)`:
+
+- `mae = abs(pred - gt)`
+- `mase = abs(pred - gt) / scale[feature, target_hour % 24]`, core function [compute_mase()](evaluation/point_metrics.py#L365).
+- `ql`: standard pinball quantile loss, averaged over quantile dimension, core function [compute_ql()](evaluation/quantiles_metrics.py#L26).
+- `sql = ql / scale[feature, target_hour % 24]`, core function [compute_sql()](evaluation/quantiles_metrics.py#L68).
+
+If a model has no quantile predictions, offline code wraps point predictions as a single quantile. If quantile levels are missing, default levels are uniformly generated in `(0, 1)` based on quantile count.
+
+Offline outputs are saved by metric directory using [save_metrics_result_by_metric()](metrics/offline/parquet_io.py#L72):
+
+```text
+results/metrics/<run_key>/
+  config.yaml
+  mae/<user_id>.parquet
+  mse/<user_id>.parquet
+  mase/<user_id>.parquet
+  mase_all/<user_id>.parquet
+  ql/<user_id>.parquet
+  sql/<user_id>.parquet
+```
+
+Each metric parquet keeps only one metric column plus:
+
+- `user_id`
+- `model`
+- `history_length`
+- `forecasting_length`
+
+Current skip policy: if `results/metrics/<run_key>/mae/<user_id>.parquet` already exists, that user is skipped for that run.
+
+## 8. Aggregation and paper results
+
+### 8.1 Hourly summary
+
+[summary_metrics_result.py](metrics/summary_metrics_result.py#L457) targets one specific metric directory, for example `results/metrics/<run_key>/mae`:
+
+```bash
+python src/forecasting_evaluation/metrics/summary_metrics_result.py \
+  --model seasonal_naive=results/metrics/seasonal_naive/mae \
+  --output-dir results/metrics_summary
+```
+
+Outputs:
+
+- `mae_by_model_channel_hour.csv`
+- `statistical_result.csv`
+
+It aggregates mean/std/n by `model, channel, channel_idx, hour`, and reports user count, sample count, and average inference time.
+
+### 8.2 paper_result
+
+[paper_result/](paper_result) is a second-stage aggregation layer for paper tables and figures. Common entrypoints include:
+
+- [run_hour_group_metric_summary.py](../../scripts/forecasting/run_hour_group_metric_summary.py#L1)
+- [plot_model_metric_combined.py](../../scripts/forecasting/plot_model_metric_combined.py#L578)
+- [get_hour_group_metric_summary.slurm](../../jobs/imperial/slurm/forecasting/paper_result/get_hour_group_metric_summary.slurm#L1)
+- [plot_model_metric_combined.slurm](../../jobs/imperial/slurm/forecasting/paper_result/plot_model_metric_combined.slurm#L1)
+
+[hour_group_metric_summary.py](paper_result/hour_group_metric_summary.py#L438) reads `results/metrics/<model>/<metric>/<user>.parquet`, first performs NaN-aware averaging across multiple metric matrices for the same user, then aggregates by channel and 3-hour groups `0-2, 3-5, ..., 21-23`.
+
+## 9. Common caveats
+
+- `data.day_remain_mask` is mainly used to generate sample index; what evaluation truly requires is `data.sample_index_file`.
+- `forecasting.daily_start_hour_offset` only affects runtime window slicing, not sample index, manifest, or cache key.
+- The semantic meaning of `history_length` is now unified as forecast origin; do not treat it as fixed `n_steps` for PyPOTS.
+- [SubTrajectoryGenerator](data/generator.py#L25) is still present in code, but evaluator main path has converged to `history_cf cache + row-group manifest`.
+- `features.covariate_types` is currently interface-only; code does not actually build hour/day covariates.
+- Zeros are converted to `NaN` first, so all downstream observed masks depend on finite values.
+- If prediction parquet or metric parquet already exists, default skip policy may make reruns look like they did not update; check `overwrite_existing_parquet` or clean target outputs.
+- Binary metrics are computed in a separate pipeline [binary_offline_calculate.py](metrics/binary_offline_calculate.py#L421); this document focuses on the main continuous forecasting metrics path.

--- a/src/forecasting_evaluation/README.md
+++ b/src/forecasting_evaluation/README.md
@@ -1,0 +1,427 @@
+# Forecasting Evaluation
+
+This module implements trajectory-level multivariate forecasting evaluation on held-out users.
+
+Current scope in code:
+
+- Load trajectory data from Hugging Face disk format.
+- Split by user into train/validation/test (evaluation runs on test split only).
+- Build sub-trajectories from pre-generated per-user day indices.
+- Run one configured forecasting model per task.
+- Persist predictions to parquet.
+- Compute offline metrics from saved prediction outputs.
+- Summarize metrics across models/channels/horizons.
+
+Main entrypoints:
+
+- `scripts/run_forecasting_eval.py` (prediction generation)
+- `src/forecasting_evaluation/metrics/offline_calculate.py` (offline metric calculation)
+- `src/forecasting_evaluation/metrics/summary_metrics_result.py` (offline metric summary export)
+
+---
+
+## 1. Execution Flow (Code-Aligned)
+
+Core orchestrator: `ForecastingEvaluator` in `evaluation/evaluator.py`.
+
+`ForecastingEvaluator.run()` executes:
+
+1. Print resolved config.
+2. Load dataset and user splits via `ForecastingDataLoader.load_splits()`.
+3. Create run directory and save run config via `PublicWriter`.
+4. Run configured model on test trajectories (sequential only).
+5. For each `(model, trajectory)`:
+   - extract features using `MultivariateFeatureExtractor.extract()`
+   - generate sub-trajectories using `SubTrajectoryGenerator.generate()`
+   - call `model.predict_wrapper(sub_traj)`
+   - append one prediction record per sub-trajectory with `PredictResultWriter.append()`
+6. Finalize run output.
+
+Important behavior in current implementation:
+
+- Only `test_ds` is evaluated.
+- One prediction parquet file is maintained per `(model_name, user_id)`.
+- Evaluator does not compute metrics online.
+- `SubTrajectoryGenerator` requires a precomputed sample index and has no fallback generation path.
+
+---
+
+## 2. Runtime Config
+
+Root schema: `ForecastingEvalConfig` in `config.py`.
+
+Top-level fields:
+
+- `seed`
+- `experiment_name`
+- `debug_mode`
+- `time_granularity`
+- `data`
+- `forecasting`
+- `model`
+- `features`
+- `evaluator`
+- `output`
+
+Model configuration is single-model:
+
+```yaml
+model:
+  type: seasonal_naive | seasonal_naive_average_history | autoARIMA | autoETS | chronos2
+  name: str | null
+  seasonal_naive:
+    season_length: int
+    quantile_levels: list[float]
+  seasonal_naive_average_history:
+    season_length: int
+  autoARIMA:
+    start_p: int
+    start_q: int
+    max_p: int
+    max_q: int
+    seasonal: bool
+    start_P: int
+    start_Q: int
+    max_P: int
+    max_Q: int
+    max_d: int
+    max_D: int
+    information_criterion: str
+    suppress_warnings: bool
+    trace: bool
+    error_action: str
+    stepwise: bool
+    n_jobs: int
+    max_history_length: int | null
+  autoETS:
+    auto: bool
+    sp: int
+    information_criterion: str
+    n_jobs: int
+    max_history_length: int | null
+  chronos2:
+    temp: int
+```
+
+Core nested fields:
+
+```yaml
+data:
+  trajectory_hf_dir: str
+  task_name: str
+  split_file: str | null
+  day_remain_mask: str | null
+  sample_index_file: str
+  train_ratio: float
+  val_ratio: float
+  split_seed: int
+  num_workers: int
+  max_samples: int | null
+
+forecasting:
+  forecasting_length: int
+
+features:
+  covariate_types: list[hour_in_day | day_in_week] | null
+  channel: all
+
+evaluator:
+  mode: sequential
+
+output:
+  results_dir: str
+  save_config: bool
+  overwrite_existing_parquet: bool
+```
+
+---
+
+## 3. Input/Output Contracts
+
+### 3.1 Trajectory Input (from HF dataset)
+
+Required fields used in pipeline:
+
+- `user_id` (str)
+- `values` (array-like, shape `(T, C)`)
+- `channel_names` (list[str], length `C`)
+
+Additional required preprocessing artifact:
+
+- `data.sample_index_file`: required JSON mapping `user_id -> [day indices]`
+- Generate it before evaluation with `scripts/precompute_forecasting_inputs.py`
+
+Important note:
+
+- Forecasting evaluation does not support missing `sample_index_file`
+- There is currently no fallback sampling path in `SubTrajectoryGenerator`
+- If the file is missing, runtime validation will fail fast and instruct you to generate it first
+
+### 3.2 Feature Extractor Output
+
+`MultivariateFeatureExtractor.extract()` returns:
+
+```python
+{
+  "history": np.ndarray,               # (n_features, T)
+  "variable_names": list[str],
+  "past_covariates": dict[str, np.ndarray],
+  "future_covariates": dict[str, np.ndarray],
+  "static_covariates": dict[str, object] | None,
+}
+```
+
+Channel selection is controlled by `features.channel`:
+
+- `all` -> fixed 19-channel feature set
+
+### 3.3 Sub-Trajectory Output
+
+`SubTrajectoryGenerator.generate()` yields `SubTrajectoryInput` with:
+
+- `history`: `(n_features, index_hours)`
+- `ground_truth`: `(n_features, forecasting_length)`
+- `variable_names`
+- optional covariates
+- `index_days`
+- `prediction_hours`
+
+Slicing logic:
+
+- `index_hours = index_days * 24 + daily_start_hour_offset`
+- `history = series[:, :index_hours]`
+- `ground_truth = series[:, index_hours:index_hours + forecasting_length]`
+
+`daily_start_hour_offset` is a runtime-only forecasting setup parameter. It
+does not change `sample_index_file`, cache/storage layout, or persisted
+manifests; it only shifts the effective slice boundary when samples are cut
+from loaded trajectories.
+
+### 3.4 Prediction Parquet Row
+
+`PredictResultWriter` stores one parquet file per `(model_name, user_id)`:
+
+`{results_dir}/{experiment_name}/{model_name}/{user_id}.parquet`
+
+Special rule for test experiments:
+
+- If `experiment_name` starts with `Test`, model directory becomes
+  `{model_name}_{YYYYMMDDHHMM}`.
+
+Overwrite rule:
+
+- `output.overwrite_existing_parquet = false` (default): if `{user_id}.parquet` already exists,
+  evaluator skips this user.
+- `output.overwrite_existing_parquet = true`: evaluator rewrites existing `{user_id}.parquet`.
+
+One row per sample, with columns:
+
+- `user_id`
+- `model`
+- `history_length`
+- `point_predictions` (nested list or null)
+- `quantile_predictions` (nested list or null)
+- `performance` (dict, e.g. prediction time and memory usage)
+
+---
+
+## 4. Offline Metrics Calculate
+
+Entry script: `src/forecasting_evaluation/metrics/offline_calculate.py`
+
+### 4.1 CLI
+
+```bash
+python src/forecasting_evaluation/metrics/offline_calculate.py \
+  --evaluation-result-paths runA=results/forecasting_eval/ExpA/seasonal_naive \
+                            runB=results/forecasting_eval/ExpB/chronos2 \
+  --metrics-output-path results/metrics
+```
+
+Arguments:
+
+- `--evaluation-result-paths` (alias `--run-dirs`): one or more `name=path` mappings.
+- `--metrics-output-path` (alias `--output-dir`): root output dir for offline metrics.
+- `--max-user`: optional sequential cap on how many user parquet metrics files to compute per run.
+
+### 4.2 What It Does
+
+For each run mapping:
+
+1. Load `config.yaml` from forecasting model directory.
+2. Rebuild dataset split and iterate unique users in test split.
+3. Index prediction parquet files by user.
+4. Re-extract history from trajectory and reconstruct GT by:
+   - `start = history_length`
+   - `end = history_length + forecasting_length`
+5. Compute:
+   - `mae`: element-wise absolute error matrix `(feature, horizon)`
+   - `mse`: element-wise Mean Squared Error matrix `(feature, horizon)`
+   - `mase`: hour-of-day scaled absolute error matrix `(feature, horizon)`
+   - `mase_all`: globally scaled absolute error matrix `(feature, horizon)`
+   - `ql`: quantile loss matrix `(feature, horizon)`
+   - `sql`: hour-of-day scaled quantile loss matrix `(feature, horizon)`
+6. Flatten performance dict into `perf_*` columns.
+7. Save per-user parquet into per-metric subdirectories.
+
+If quantile levels are absent in prediction rows, levels are auto-generated as evenly spaced values.
+
+### 4.3 Output Layout
+
+```text
+results/metrics/
+  {model_name}/
+    config.yaml
+    mae/
+      {sanitized_user_id}.parquet
+    mse/
+      {sanitized_user_id}.parquet
+    mase/
+      {sanitized_user_id}.parquet
+    mase_all/
+      {sanitized_user_id}.parquet
+    ql/
+      {sanitized_user_id}.parquet
+    sql/
+      {sanitized_user_id}.parquet
+```
+
+Each per-metric parquet row includes:
+
+- `user_id`
+- `model`
+- `history_length`
+- `forecasting_length`
+- exactly one metric column from `{mae, mse, mase, mase_all, ql, sql}`
+- optional `perf_*` scalar columns
+
+Current skip policy:
+
+- Metrics are skipped per user if `mae/{user_id}.parquet` already exists for the target model.
+- Invalid rows (for example missing history length or out-of-range slice) are skipped and counted.
+
+---
+
+## 5. Offline Metrics Summary
+
+Entry script: `src/forecasting_evaluation/metrics/summary_metrics_result.py`
+
+### 5.1 CLI
+
+```bash
+python src/forecasting_evaluation/metrics/summary_metrics_result.py \
+  --model SeasonalNaive=results/metrics/SeasonalNaive/mae \
+  --model Chronos2=results/metrics/Chronos2/mae \
+  --output-dir results/metrics_summary \
+  --max-user 200 \
+  --random-seed 42
+```
+
+Arguments:
+
+- `--model`: repeatable mapping in format `MODEL_NAME=/path/to/one_metric_dir`.
+  For example, use `results/metrics/<model_name>/mae` when summarizing `mae`.
+- `--output-dir`: output folder for summary CSV files.
+- `--max-user`: optional random user cap per model (for quick small-scale analysis).
+- `--random-seed`: random seed for user sampling.
+
+### 5.2 Summary Outputs
+
+The script writes two CSV files:
+
+1. `mae_by_model_channel_hour.csv`
+2. `statistical_result.csv`
+
+`mae_by_model_channel_hour.csv` columns:
+
+- `model`
+- `channel`
+- `channel_idx`
+- `hour`
+- `mae_mean`
+- `mae_std`
+- `n`
+
+`statistical_result.csv` columns:
+
+- `model`
+- `user_count`
+- `sample_count`
+- `avg_prediction_time_seconds`
+
+Implementation notes:
+
+- Aggregation is streaming and does not materialize a full long MAE table.
+- User IDs are collected from parquet rows.
+- Channel names are inferred from run config (`features.channel`) when available; otherwise fallback names are used.
+- Because metrics are now saved into separate per-metric directories, this summary script should be pointed at the directory for the metric being summarized.
+
+---
+
+## 6. Supported Model Types
+
+Supported `model.type` values:
+
+- `seasonal_naive`
+- `seasonal_naive_average_history`
+- `autoARIMA`
+- `autoETS`
+- `chronos2`
+
+If `name` is missing, evaluator uses `model.type` as the model name.
+
+---
+
+## 7. Quick Start
+
+### 7.1 Data Preparation
+
+Recommend:
+```bash
+dvc pull data/hourly_trajectory.dvc
+dvc pull data/forecasting_sample_index.dvc
+```
+
+Or if you have raw HDF5 data, you can generate above data with scripts, reference: `jobs/imperial/pbs/forecasting/build_hourly_trajectory.pbs` and `jobs/imperial/pbs/forecasting/build_sample_index.pbs`.
+
+
+
+### 7.2 Run evaluation
+Run forecasting prediction generation:
+
+```bash
+python scripts/run_forecasting_eval.py \
+  --config configs/forecasting_eval/default.yaml
+```
+
+Layered config override:
+
+```bash
+python scripts/run_forecasting_eval.py \
+  --config configs/forecasting_eval/default.yaml \
+  --config configs/forecasting_eval/test.yaml
+```
+
+Run offline metrics calculation:
+
+```bash
+python src/forecasting_evaluation/metrics/offline_calculate.py \
+  --evaluation-result-paths ExpA=results/forecasting_eval/ExpA/20260324_120000 \
+  --metrics-output-path results/metrics
+```
+
+Run offline metrics summary:
+
+```bash
+python src/forecasting_evaluation/metrics/summary_metrics_result.py \
+  --model ExpA=results/metrics/seasonal_naive/mae \
+  --output-dir results/metrics_summary
+```
+
+---
+
+## 8. Current Caveats
+
+- `SubTrajectoryGenerator` requires user entries in `data.sample_index_file` and does not implement fallback candidate generation.
+- `forecasting.valid_prediction_window.valid_day_threshold` and `valid_hour_threshold` are configured but not enforced in sample generation.
+- `valid_prediction_window.history_length` is configured but current slicing still uses all history before `index_hours`.

--- a/src/forecasting_evaluation/__init__.py
+++ b/src/forecasting_evaluation/__init__.py
@@ -1,0 +1,3 @@
+"""Forecasting evaluation module for time series prediction tasks."""
+
+__version__ = "0.1.0"

--- a/src/forecasting_evaluation/config.py
+++ b/src/forecasting_evaluation/config.py
@@ -1,0 +1,322 @@
+"""Configuration dataclasses for downstream forecasting evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields, is_dataclass
+from typing import Literal
+
+
+@dataclass
+class DataConfig:
+    """Data source and splitting configuration."""
+    trajectory_hf_dir: str = "data/hourly_trajectory"
+    task_name: str = "hourly_trajectory_forecasting"
+    split_file: str | None = "data/splits/sharable_users_seed42_2026.json"
+    day_remain_mask: str | None = "data/forecasting_sample_index/day_remain_mask.json"
+    # Required for forecasting evaluation. Generate it with scripts/precompute_forecasting_inputs.py.
+    sample_index_file: str = "data/forecasting_sample_index/sample_index_P_24_M_H_7_3_S_100.json"
+    train_ratio: float = 0.8
+    val_ratio: float = 0.1
+    split_seed: int = 42
+    num_workers: int = 4
+    max_samples: int | None = None
+
+ModelType = Literal[
+    "seasonal_naive",
+    "seasonal_naive_average_history",
+    "autoARIMA",
+    "autoETS",
+    "chronos2",
+    "toto",
+    "mixlinear",
+    "dlinear",
+    "segrnn",
+]
+
+@dataclass
+class SeasonalNaiveModelConfig:
+    """seasonal_naive model hyperparameters."""
+
+    season_length: int = 24
+    quantile_levels: list[float] = field(
+        default_factory=lambda: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+    )
+
+
+@dataclass
+class SeasonalNaiveAverageHistoryModelConfig:
+    """seasonal_naive_average_history model hyperparameters."""
+
+    season_length: int = 24
+
+
+@dataclass
+class AutoARIMAModelConfig:
+    """autoARIMA model hyperparameters."""
+
+    start_p: int = 2
+    start_q: int = 2
+    max_p: int = 5
+    max_q: int = 5
+    seasonal: bool = True
+    start_P: int = 1
+    start_Q: int = 1
+    max_P: int = 2
+    max_Q: int = 2
+    max_d: int = 2
+    max_D: int = 1
+    information_criterion: str = "aic"
+    suppress_warnings: bool = True
+    trace: bool = False
+    error_action: str = "ignore"
+    stepwise: bool = False
+    n_jobs: int = -1
+    max_history_length: int | None = 24 * 14  # Limit to recent 336 hours (14 days)
+
+
+@dataclass
+class AutoETSModelConfig:
+    """autoETS model hyperparameters."""
+
+    auto: bool = True
+    sp: int = 24
+    information_criterion: str = "aic"
+    n_jobs: int = -1
+    max_history_length: int | None = 24 * 14  # Limit to recent 336 hours (14 days)
+
+
+@dataclass
+class Chronos2ModelConfig:
+    """chronos2 model hyperparameters."""
+
+    temp: int = 1
+    pretrained_model_name_or_path: str = "amazon/chronos-2"
+    checkpoint_path: str | None = None
+    training_output_dir: str | None = None
+    finetuned_ckpt_name: str | None = None
+    device: str = "cuda"
+    torch_dtype: Literal["auto", "float32", "float16", "bfloat16"] = "auto"
+
+
+@dataclass
+class TotoModelConfig:
+    """Toto model hyperparameters."""
+
+    pretrained_model_name_or_path: str = "Datadog/Toto-Open-Base-1.0"
+    checkpoint_path: str | None = None
+    lora_alpha: float | None = None
+    device: str = "cuda"
+    context_length: int = 2048
+    num_samples: int = 256
+    samples_per_batch: int = 256
+    use_kv_cache: bool = True
+    time_interval_seconds: int = 3600  # 1 hour for hourly wearable data
+
+
+@dataclass
+class MixLinearModelConfig:
+    """mixlinear model hyperparameters."""
+
+    checkpoint_path: str | None = None
+    device: str = "cuda"
+    batch_size: int = 64
+    n_steps: int | None = None
+    n_pred_steps: int | None = None
+    n_features: int | None = None
+    period_len: int = 24
+    lpf: int = 2
+    alpha: float = 0.5
+    rank: int = 2
+
+
+@dataclass
+class DLinearModelConfig:
+    """dlinear model hyperparameters."""
+
+    checkpoint_path: str | None = None
+    device: str = "cuda"
+    batch_size: int = 64
+    n_steps: int | None = None
+    n_pred_steps: int | None = None
+    n_features: int | None = None
+    moving_avg_window_size: int = 25
+    individual: bool = False
+    d_model: int | None = None
+
+
+@dataclass
+class SegRNNModelConfig:
+    """segrnn model hyperparameters."""
+
+    checkpoint_path: str | None = None
+    device: str = "cuda"
+    batch_size: int = 64
+    n_steps: int | None = None
+    n_pred_steps: int | None = None
+    n_features: int | None = None
+    seg_len: int = 24
+    d_model: int = 64
+    dropout: float = 0.1
+
+
+@dataclass
+class ForecastingModelConfig:
+    """Model configuration using type + per-model nested sub-configs.
+
+    Mirrors the imputation style: choose `type`, then tune fields under the
+    corresponding nested config block.
+    """
+
+    type: ModelType = "seasonal_naive"
+    name: str | None = None
+
+    seasonal_naive: SeasonalNaiveModelConfig = field(default_factory=SeasonalNaiveModelConfig)
+    seasonal_naive_average_history: SeasonalNaiveAverageHistoryModelConfig = field(
+        default_factory=SeasonalNaiveAverageHistoryModelConfig
+    )
+    autoARIMA: AutoARIMAModelConfig = field(default_factory=AutoARIMAModelConfig)
+    autoETS: AutoETSModelConfig = field(default_factory=AutoETSModelConfig)
+    chronos2: Chronos2ModelConfig = field(default_factory=Chronos2ModelConfig)
+    toto: TotoModelConfig = field(default_factory=TotoModelConfig)
+    mixlinear: MixLinearModelConfig = field(default_factory=MixLinearModelConfig)
+    dlinear: DLinearModelConfig = field(default_factory=DLinearModelConfig)
+    segrnn: SegRNNModelConfig = field(default_factory=SegRNNModelConfig)
+
+@dataclass
+class OutputConfig:
+    """Output configuration for results."""
+
+    results_dir: str = "results/forecasting_eval"
+    save_config: bool = True
+    overwrite_existing_parquet: bool = False
+
+
+@dataclass
+class EvaluatorConfig:
+    """Evaluator execution configuration (sequential-only)."""
+
+    mode: Literal["sequential"] = "sequential"
+
+@dataclass
+class ForecastingConfig:
+    """Configuration for forecasting-specific parameters."""
+
+    forecasting_length: int = 24  # Number of hours to forecast
+    daily_start_hour_offset: int = 0
+
+@dataclass
+class FeaturesConfig:
+    """Feature extraction configuration."""
+
+    # type: Literal["covariate", "multivariate"] = "multivariate"
+    covariate_types: list[Literal["hour_in_day", "day_in_week"]] | None = None
+    # Forecasting evaluation currently supports the full 19-channel feature set only.
+    channel: Literal["all"] = "all"
+
+
+@dataclass
+class ForecastingEvalConfig:
+    """Root configuration for downstream evaluation."""
+
+    seed: int = 42
+    experiment_name: str | None = "Default_Test"
+    debug_mode: bool = True
+    time_granularity: Literal["minutely","hourly","daily"] = "hourly"
+    data: DataConfig = field(default_factory=DataConfig)
+    forecasting: ForecastingConfig = field(default_factory=ForecastingConfig)
+    model: ForecastingModelConfig = field(default_factory=ForecastingModelConfig)
+    features: FeaturesConfig = field(default_factory=FeaturesConfig)
+    evaluator: EvaluatorConfig = field(default_factory=EvaluatorConfig)
+    output: OutputConfig = field(default_factory=OutputConfig)
+
+
+def print_config(config: ForecastingEvalConfig) -> None:
+    """Print configuration in a clean, automatically structured format.
+
+    This function automatically adapts to changes in the configuration classes,
+    so adding/removing fields doesn't require manual updates here.
+
+    Args:
+        config: The forecasting evaluation configuration to display.
+    """
+
+    def format_value(value, indent: int = 0) -> str:
+        """Format a value for display with proper indentation."""
+        indent_str = "  " * indent
+
+        if value is None:
+            return "None"
+        elif isinstance(value, bool):
+            return str(value)
+        elif isinstance(value, int | float):
+            return str(value)
+        elif isinstance(value, str):
+            return f'"{value}"'
+        elif isinstance(value, list | tuple):
+            if not value:
+                return "[]"
+            return f"[{', '.join(repr(v) if isinstance(v, str) else str(v) for v in value)}]"
+        elif is_dataclass(value):
+            # Recursively format nested dataclass
+            lines = []
+            for fld in fields(value):
+                field_name = fld.name.replace("_", " ").title()
+                field_value = getattr(value, fld.name)
+                formatted = format_value(field_value, indent + 1)
+                lines.append(f"{indent_str}  - {field_name}: {formatted}")
+            return "\n" + "\n".join(lines)
+        else:
+            return str(value)
+
+    def format_field_name(name: str) -> str:
+        """Convert snake_case to Title Case."""
+        return name.replace("_", " ").title()
+
+    def emit(line: str = "") -> None:
+        """Print immediately even when stdout is redirected (e.g. SLURM logs)."""
+        print(line, flush=True)
+
+    # Print header
+    emit("\n" + "=" * 80)
+    emit("FORECASTING EVALUATION CONFIGURATION".center(80))
+    emit("=" * 80 + "\n")
+
+    # Automatically iterate through all top-level fields
+    config_fields = fields(config)
+    for i, fld in enumerate(config_fields):
+        field_name = format_field_name(fld.name)
+        field_value = getattr(config, fld.name)
+
+        # Determine the tree character
+        if i == 0:
+            tree_char = "┌─"
+        elif i == len(config_fields) - 1:
+            tree_char = "└─"
+        else:
+            tree_char = "├─"
+
+        # For nested dataclasses, print section header
+        if is_dataclass(field_value):
+            emit(f"{tree_char} {field_name}")
+            # Print all fields of the nested dataclass
+            for nested_field in fields(field_value):
+                nested_name = format_field_name(nested_field.name)
+                nested_value = getattr(field_value, nested_field.name)
+                formatted_value = format_value(nested_value)
+
+                # Handle multi-line formatted values (nested dataclasses)
+                if "\n" in formatted_value:
+                    emit(f"│  • {nested_name}:{formatted_value}")
+                else:
+                    # Align values nicely
+                    emit(f"│  • {nested_name:<20} {formatted_value}")
+        else:
+            # Simple field - print directly
+            formatted_value = format_value(field_value)
+            emit(f"{tree_char} {field_name:<20} {formatted_value}")
+
+        # Add blank line between sections (except for the last one)
+        if i < len(config_fields) - 1:
+            emit("│")
+
+    emit("\n" + "=" * 80 + "\n")

--- a/src/forecasting_evaluation/data/__init__.py
+++ b/src/forecasting_evaluation/data/__init__.py
@@ -1,0 +1,5 @@
+"""Data utilities and types for forecasting evaluation."""
+
+from forecasting_evaluation.data.types import SubTrajectoryInput
+
+__all__ = ["SubTrajectoryInput"]

--- a/src/forecasting_evaluation/data/data_loader.py
+++ b/src/forecasting_evaluation/data/data_loader.py
@@ -1,0 +1,176 @@
+"""Data loading utilities for downstream evaluation.
+
+Reuses label attachment and user split logic from baseline_datamodule.py
+for consistency with the Lightning-based pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import is_dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import datasets as hf_ds
+import datasets.features.features as hf_features
+
+from downstream_evaluation.data.splits import load_split_file, random_split_users
+
+if TYPE_CHECKING:
+    from forecasting_evaluation.config import DataConfig
+
+logger = logging.getLogger(__name__)
+
+SAMPLE_INDEX_REQUIRED_MSG = (
+    "Forecasting evaluation requires data.sample_index_file. "
+    "Please generate it first with scripts/precompute_forecasting_inputs.py."
+)
+
+
+def _ensure_legacy_hf_list_feature_compat() -> None:
+    """Allow old saved datasets with ``"_type": "List"`` to load on newer datasets."""
+    list_type = getattr(hf_features, "List", None)
+    sequence_type = getattr(hf_features, "Sequence", None)
+    if sequence_type is None or list_type is sequence_type:
+        return
+    if is_dataclass(sequence_type) and not is_dataclass(list_type):
+        hf_features.List = sequence_type
+        logger.warning(
+            "Patched datasets.features.features.List to Sequence for legacy HF dataset metadata"
+        )
+
+
+class ForecastingDataLoader:
+    """Unified data loading with label attachment and user splits.
+
+    Reuses patterns from baseline_datamodule.py to ensure consistency
+    with the Lightning-based pipeline.
+    """
+
+    def __init__(self, config: DataConfig):
+        """Initialize data loader.
+
+        Args:
+            config: Data configuration with paths and split parameters.
+        """
+        self.config = config
+        self.trajectory_hf_dir = Path(config.trajectory_hf_dir)
+        self.task_name = config.task_name
+
+    def load_splits(self) -> tuple[hf_ds.Dataset, hf_ds.Dataset, hf_ds.Dataset]:
+        """Load data, attach labels, filter, and split by user.
+
+        Returns:
+            Tuple of (train_ds, val_ds, test_ds) HuggingFace datasets.
+        """
+        sample_index_path = self._require_sample_index_file()
+
+        # 1. Load full dataset
+        logger.info(f"Loading trajectory dataset from {self.trajectory_hf_dir}")
+        _ensure_legacy_hf_list_feature_compat()
+        full_ds = hf_ds.load_from_disk(str(self.trajectory_hf_dir))
+        logger.info(f"Loaded {len(full_ds)} trajectory samples")
+
+        if (
+            hasattr(self.config, "max_samples")
+            and self.config.max_samples
+            and len(full_ds) > self.config.max_samples
+        ):
+            logger.info(f"Subsampling to max_samples={self.config.max_samples}")
+            full_ds = full_ds.select(range(self.config.max_samples))
+
+
+        all_users = sorted({str(user_id) for user_id in full_ds["user_id"]})
+
+        # 2. Filter
+        sample_index_data = {}
+        with sample_index_path.open("r", encoding="utf-8") as f:
+            sample_index_data = json.load(f)
+
+        allowed_user_ids = set(map(str, sample_index_data.keys()))
+        all_users = [user_id for user_id in all_users if user_id in allowed_user_ids]
+
+
+        # 4. Get user splits
+        user_splits = self._get_user_splits(all_users)
+
+        # Enforce both split file and sample-index/full-dataset availability.
+        eligible_users = set(all_users)
+        user_splits = {
+            split_name: {str(user_id) for user_id in split_users} & eligible_users
+            for split_name, split_users in user_splits.items()
+        }
+
+        train_sample_count = sum(len(sample_index_data.get(uid, [])) for uid in user_splits["train"])
+        val_sample_count = sum(len(sample_index_data.get(uid, [])) for uid in user_splits["validation"])
+        test_sample_count = sum(len(sample_index_data.get(uid, [])) for uid in user_splits["test"])
+
+        logger.info(
+            "Effective split users after sample_index/full_ds filter: "
+            "train=%d, val=%d, test=%d; sample_index samples: train=%d, val=%d, test=%d",
+            len(user_splits["train"]),
+            len(user_splits["validation"]),
+            len(user_splits["test"]),
+            train_sample_count,
+            val_sample_count,
+            test_sample_count,
+        )
+
+        # 5. Filter by split
+        # Passing num_proc=1 still enables the datasets multiprocessing path.
+        # Keep single-worker runs truly serial so restricted test runners do not
+        # need to create a multiprocessing manager socket.
+        filter_num_proc = self.config.num_workers if self.config.num_workers > 1 else None
+        train_ds = full_ds.filter(
+            lambda ex: ex["user_id"] in user_splits["train"],
+            num_proc=filter_num_proc,
+        )
+        val_ds = full_ds.filter(
+            lambda ex: ex["user_id"] in user_splits["validation"],
+            num_proc=filter_num_proc,
+        )
+        test_ds = full_ds.filter(
+            lambda ex: ex["user_id"] in user_splits["test"],
+            num_proc=filter_num_proc,
+        )
+
+        logger.info(f"Split: train={len(train_ds)}, val={len(val_ds)}, test={len(test_ds)} samples")
+
+        return train_ds, val_ds, test_ds
+
+    def _require_sample_index_file(self) -> Path:
+        """Return a validated sample-index path required by forecasting evaluation."""
+        sample_index_value = self.config.sample_index_file
+        if not sample_index_value:
+            raise ValueError(SAMPLE_INDEX_REQUIRED_MSG)
+
+        sample_index_path = Path(sample_index_value)
+        if not sample_index_path.exists():
+            raise FileNotFoundError(
+                f"sample_index_file not found: {sample_index_path}. {SAMPLE_INDEX_REQUIRED_MSG}"
+            )
+
+        return sample_index_path
+
+    def _get_user_splits(self, user_ids: list[str]) -> dict[str, set[str]]:
+        """Load or generate user splits.
+
+        Uses the same functions as baseline_datamodule.py to ensure consistency.
+        """
+        if self.config.split_file:
+            split_path = Path(self.config.split_file)
+            if split_path.exists():
+                logger.info(f"Loading splits from {split_path}")
+                return load_split_file(split_path)
+
+        # Generate random split
+        logger.info(
+            f"Generating random split for {len(user_ids)} users (seed={self.config.split_seed})"
+        )
+        return random_split_users(
+            user_ids,
+            self.config.train_ratio,
+            self.config.val_ratio,
+            self.config.split_seed,
+        )

--- a/src/forecasting_evaluation/data/day_retain_mask_generator.py
+++ b/src/forecasting_evaluation/data/day_retain_mask_generator.py
@@ -1,0 +1,125 @@
+"""Generate and persist day-level retain masks for forecasting sample selection."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import datasets as hf_ds
+
+if TYPE_CHECKING:
+    from data.filters.daily_filters import Filter
+
+logger = logging.getLogger(__name__)
+
+
+def generate_day_drop_mask(
+    daily_hf_dir: str | Path,
+    min_wear_fraction: float = 0.5,
+    variance_filter_enabled: bool = True,
+    variance_thresholds: dict[int, float] | None = None,
+    num_proc: int = 4,
+    use_cache: bool = False,
+) -> dict[str, list[str]]:
+    """Generate a keep-mask for day-level samples after QA filtering.
+
+    The returned mask contains only days that survive filtering:
+    ``{user_id: [date1, date2, ...]}``.
+
+    Args:
+        daily_hf_dir: Path to daily HuggingFace dataset directory.
+        min_wear_fraction: Minimum wear-time fraction for ``WearTimeFilter``.
+        variance_filter_enabled: Whether to apply ``LowChannelVarianceFilter``.
+        variance_thresholds: Optional channel variance thresholds.
+        num_proc: Number of processes passed to ``apply_filters``.
+        use_cache: Whether to load HF filter results from cache.
+
+    Returns:
+        Dict mapping user_id to sorted list of kept day timestamps (date strings).
+    """
+    print(f"Loading daily HF dataset from {daily_hf_dir}")
+    logger.info(f"Loading daily HF dataset from {daily_hf_dir}")
+    ds = hf_ds.load_from_disk(daily_hf_dir)
+    logger.info(f"Loaded {len(ds)} samples")
+
+    # Import lazily to avoid circular import during module initialization.
+    from data.filters.daily_filters import LowChannelVarianceFilter, WearTimeFilter, apply_filters
+
+    filters: list[Filter] = []
+    if min_wear_fraction > 0.0:
+        filters.append(WearTimeFilter(min_wear_fraction=min_wear_fraction))
+
+    if variance_filter_enabled:
+        filters.append(LowChannelVarianceFilter(thresholds=variance_thresholds))
+
+    filtered = apply_filters(ds, filters, num_proc=num_proc, use_cache=use_cache) if filters else ds
+
+    user_ids = filtered["user_id"]
+    dates = filtered["date"]
+
+    kept_days: dict[str, list[str]] = defaultdict(list)
+    for user_id, date in zip(user_ids, dates):
+        kept_days[str(user_id)].append(str(date))
+
+    # Ensure deterministic output for reproducible JSON artifacts.
+    mask = {
+        user_id: sorted(set(day_list))
+        for user_id, day_list in sorted(kept_days.items(), key=lambda x: x[0])
+    }
+
+    logger.info(
+        "Generated day-drop mask: %d users, %d kept days",
+        len(mask),
+        sum(len(v) for v in mask.values()),
+    )
+    return mask
+
+
+def save_day_drop_mask(mask: dict[str, list[str]], output_path: str | Path) -> Path:
+    """Persist day-drop mask as JSON."""
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(mask, indent=2, ensure_ascii=False))
+    logger.info("Saved day-drop mask to %s", output)
+    return output
+
+
+def read_day_drop_mask(file_path: str | Path) -> dict[str, list[str]]:
+    """Load day-drop mask JSON from disk."""
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Mask file not found: {path}")
+    data = json.loads(path.read_text())
+    return {str(k): [str(x) for x in v] for k, v in data.items()}
+
+
+# def parse_args() -> argparse.Namespace:
+#     """Parse CLI arguments."""
+#     parser = argparse.ArgumentParser(description="Generate day-level keep-mask from daily_hf")
+#     parser.add_argument("--daily-hf-dir", required=True, type=Path)
+#     parser.add_argument("--output-json", required=True, type=Path)
+#     parser.add_argument("--min-wear-fraction", type=float, default=0.5)
+#     parser.add_argument("--disable-variance-filter", action="store_true")
+#     parser.add_argument("--num-proc", type=int, default=1)
+#     parser.add_argument("--use-cache", action="store_true")
+#     return parser.parse_args()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    # args = parse_args()
+
+    # day_mask = generate_day_drop_mask(
+    #     daily_hf_dir=args.daily_hf_dir,
+    #     min_wear_fraction=args.min_wear_fraction,
+    #     variance_filter_enabled=not args.disable_variance_filter,
+    #     num_proc=args.num_proc,
+    #     use_cache=args.use_cache,
+    # )
+    day_mask = generate_day_drop_mask(
+        daily_hf_dir="/rds/general/user/lp925/home/code/MHC-benchmark/data/processed/daily_hf"
+    )
+    save_day_drop_mask(day_mask, "/rds/general/user/lp925/home/code/MHC-benchmark/data/forecasting_sample_index/new_day_drop_mask.json")

--- a/src/forecasting_evaluation/data/generator.py
+++ b/src/forecasting_evaluation/data/generator.py
@@ -1,0 +1,192 @@
+"""Sub-trajectory generator for forecasting evaluation.
+
+Generates sub-trajectories with sliding index and valid data checking.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from data.transforms.nan_transforms import ZeroToNaNTransform
+from forecasting_evaluation.data.types import SubTrajectoryInput
+
+logger = logging.getLogger(__name__)
+
+SAMPLE_INDEX_REQUIRED_MSG = (
+    "Forecasting evaluation requires a precomputed sample index. "
+    "Please generate it first with scripts/precompute_forecasting_inputs.py."
+)
+
+
+class SubTrajectoryGenerator:
+    """Generate day-sliding forecasting samples from extracted trajectory features."""
+
+    def __init__(
+        self,
+        prediction_hours: int,
+        random_seed: int = 42,
+        pre_sample_path: str = "",
+        daily_start_hour_offset: int = 0,
+    ):
+        """Initialize generator with forecasting configuration.
+
+        Args:
+            prediction_hours: Forecast horizon in hours.
+            random_seed: Seed used for deterministic sampling-related behavior.
+            pre_sample_path: JSON path containing precomputed day indices per user.
+            daily_start_hour_offset: Runtime hour offset applied to each
+                precomputed day boundary.
+        """
+        self.prediction_hours = int(prediction_hours)
+        self.hours_per_day = 24
+        self.pre_sample_path = pre_sample_path
+        self.random_seed = random_seed
+        self.daily_start_hour_offset = int(daily_start_hour_offset)
+        self._pre_sample_index: dict[str, list[int]] | None = None
+
+        if not 0 <= self.daily_start_hour_offset < self.hours_per_day:
+            raise ValueError(
+                "daily_start_hour_offset must be within [0, 24), "
+                f"but received {self.daily_start_hour_offset}"
+            )
+
+        self.zero_to_nan_transform = ZeroToNaNTransform()
+
+        np.random.seed(self.random_seed)
+
+    def _load_pre_sample_index(self) -> None:
+        """Load pre-generated sample indices from JSON, once per generator instance."""
+        if self._pre_sample_index is not None:
+            return
+
+        self._pre_sample_index = {}
+        if not self.pre_sample_path:
+            raise ValueError(SAMPLE_INDEX_REQUIRED_MSG)
+
+        sample_path = Path(self.pre_sample_path)
+        if not sample_path.exists():
+            raise FileNotFoundError(
+                f"Sample index file not found: {sample_path}. {SAMPLE_INDEX_REQUIRED_MSG}"
+            )
+
+        loaded = json.loads(sample_path.read_text(encoding="utf-8"))
+        if not isinstance(loaded, dict):
+            logger.warning("Sample index file format invalid (expect dict): %s", sample_path)
+            return
+
+        normalized: dict[str, list[int]] = {}
+        for user_id, day_indices in loaded.items():
+            if not isinstance(day_indices, list):
+                continue
+            parsed_days: set[int] = set()
+            for day in day_indices:
+                try:
+                    day_int = int(day)
+                except (TypeError, ValueError):
+                    continue
+                if day_int >= 1:
+                    parsed_days.add(day_int)
+            valid_days = sorted(parsed_days)
+            normalized[str(user_id)] = valid_days
+
+        self._pre_sample_index = normalized
+        # logger.info("Loaded pre-sample index for %d users from %s", len(normalized), sample_path)
+
+    def _resolve_candidate_days(self, user_id: str | None) -> list[int]:
+        """Get candidate day indices for a user.
+
+        Candidate days come from the required pre-generated sample index JSON.
+        """
+        self._load_pre_sample_index()
+        if user_id is None:
+            raise ValueError("user_id is required when resolving sample-index candidate days")
+        return [day for day in self._pre_sample_index[user_id]]
+
+    def generate(
+        self,
+        features: dict,
+        user_id: str | None = None,
+    ) -> Iterator[SubTrajectoryInput]:
+        """Generate sub-trajectories for forecasting evaluation.
+
+        Args:
+            features: Feature dictionary containing:
+                - history: (n_features, trajectory_length) array
+                - history_mask: (n_features, trajectory_length) bool/int array
+                - variable_names: list[str] with len == n_features
+                - past_covariates: dict of (trajectory_length,) arrays, optional
+                - future_covariates: dict of (trajectory_length + prediction_length,) arrays, optional
+                - static_covariates: user-level non-temporal covariates, optional
+            user_id: User identifier used to resolve candidate day indices from
+                precomputed sample-index data.
+        
+        Yields:
+            SubTrajectoryInput objects containing:
+                - history and ground_truth in channel-first layout
+                - history_mask and ground_truth_mask aligned with each segment
+                - covariate slices aligned to the emitted history/prediction window
+        """
+        history = features["history"]  # (n_features, trajectory_length)
+        # TODO preprocessing on minute level
+        history = self.zero_to_nan_transform(torch.from_numpy(history)).numpy()
+
+        variable_names = features["variable_names"]
+        past_covariates = features.get("past_covariates") or {}
+        future_covariates = features.get("future_covariates") or {}
+        static_covariates = features.get("static_covariates")
+
+        prediction_hours = self.prediction_hours
+        candidate_days = self._resolve_candidate_days(user_id=user_id)
+
+        for current_day in candidate_days:
+            index_hours = current_day * self.hours_per_day + self.daily_start_hour_offset
+
+            # Emit sample using all data before index as history.
+            history_start = 0
+            history_end = index_hours
+            pred_end = index_hours + prediction_hours
+
+            if history_end <= history_start:
+                continue
+            if pred_end > history.shape[1]:
+                logger.debug(
+                    "Skip sample (user=%s, day=%s): pred_end=%s exceeds trajectory_length=%s",
+                    user_id,
+                    current_day,
+                    pred_end,
+                    history.shape[1],
+                )
+                continue
+
+            # Extract history target (all data before index)
+            history_target = history[:, history_start:history_end]  # (n_features, index_hours)
+
+            # Extract ground truth (future values for prediction)
+            ground_truth = history[:, history_end:pred_end]  # (n_features, prediction_hours)
+
+            # Extract past covariates (same length as history)
+            sub_past_covariates = {}
+            for key, values in past_covariates.items():
+                sub_past_covariates[key] = values[history_start:history_end]
+
+            # Extract future covariates (history + prediction length)
+            sub_future_covariates = {}
+            for key, values in future_covariates.items():
+                sub_future_covariates[key] = values[history_start:pred_end]
+
+            yield SubTrajectoryInput(
+                history=history_target,
+                variable_names=variable_names,
+                past_covariates=sub_past_covariates,
+                future_covariates=sub_future_covariates,
+                static_covariates=static_covariates,
+                ground_truth=ground_truth,
+                index_days=current_day,
+                prediction_hours=prediction_hours
+            )

--- a/src/forecasting_evaluation/data/sample_index_generator.py
+++ b/src/forecasting_evaluation/data/sample_index_generator.py
@@ -1,0 +1,369 @@
+
+"""Build per-user forecasting sample-index files from hourly trajectories."""
+
+
+import argparse
+import json
+import logging
+import math
+import os
+import random
+from datetime import datetime
+
+import datasets as hf_ds
+import numpy as np
+from tqdm import tqdm
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+class SampleIndexGenerator:
+    """Generate and persist candidate forecasting start-day indices by user."""
+
+    def __init__(
+        self, 
+        hourly_trajectory_path: str,
+        sample_index_path: str,
+        day_remain_mask_path: str,
+        filter_parameters: dict,
+        forecasting_length: int = 24,
+    ):
+        """Initialize sample-index generation inputs and validation state.
+
+        Args:
+            hourly_trajectory_path: HuggingFace hourly trajectory dataset path.
+            sample_index_path: Base output path used to save generated index JSON files.
+            day_remain_mask_path: JSON path for day-level retain mask keyed by user.
+            filter_parameters: Dict describing optional filtering stages and parameters.
+            forecasting_length: Forecast horizon in hours used to bound valid start days.
+        """
+        self.hourly_trajectory_path = hourly_trajectory_path
+        self.sample_index_path = sample_index_path
+        self.day_remain_mask_path = day_remain_mask_path
+        self.filter_parameters = filter_parameters
+        self.forecasting_length = int(forecasting_length)
+
+        if self.forecasting_length <= 0:
+            raise ValueError("forecasting_length must be a positive integer")
+
+        self.sample_index = {}
+        
+        self._check_all_data()
+
+        logger.info("Loading hourly trajectory data from %s", hourly_trajectory_path)
+        logger.info("Will saving generated sample index to %s", sample_index_path)
+        logger.info("Loading day remain mask from %s", day_remain_mask_path)
+        logger.info("Initialized SampleIndexGenerator with parameters: %s", filter_parameters)
+        logger.info("Forecasting length (hours): %d", self.forecasting_length)
+
+    def _check_all_data(self):
+        if not os.path.exists(self.hourly_trajectory_path):
+            raise FileNotFoundError(f"Hourly trajectory dataset not found at {self.hourly_trajectory_path}")
+        
+        if not os.path.exists(self.day_remain_mask_path):
+            raise FileNotFoundError(f"Day remain mask file not found at {self.day_remain_mask_path}")
+        else:
+            with open(self.day_remain_mask_path, encoding="utf-8") as f:
+                self.day_remain_mask = json.load(f)
+
+    def _load_sample_index(self, name):
+        # Read the parent directory of self.sample_index_path.
+        output_dir = os.path.dirname(self.sample_index_path)
+
+        # Build output filename as name + .json.
+        filename = f"{name}.json" if not str(name).endswith(".json") else str(name)
+        output_path = os.path.join(output_dir, filename)
+        if os.path.exists(output_path):
+            with open(output_path, encoding="utf-8") as f:
+                self.sample_index = json.load(f)
+            return True
+        return False
+
+    def _save_sample_index(self, name):
+        # Before saving/stats, drop users with empty index lists.
+        self.sample_index = {
+            user_id: indices for user_id, indices in self.sample_index.items() if len(indices) > 0
+        }
+
+        # Read the parent directory of self.sample_index_path.
+        output_dir = os.path.dirname(self.sample_index_path)
+
+        # Build output filename as name + .json.
+        filename = f"{name}.json" if not str(name).endswith(".json") else str(name)
+        output_path = os.path.join(output_dir, filename)
+
+        # Save self.sample_index to the computed output path.
+        if not os.path.exists(self.sample_index_path):
+            os.makedirs(output_dir, exist_ok=True)
+            with open(output_path, "w", encoding="utf-8") as f:
+                json.dump(self.sample_index, f, ensure_ascii=False, indent=2)
+
+            logger.info("Saved sample index to %s", output_path)
+        
+        logger.info("****Sample index stats for %s:****", name)
+
+        # Log user count, total sample count, and per-user quantiles (10%..90%).
+        user_count = len(self.sample_index)
+        per_user_counts = np.array([len(v) for v in self.sample_index.values()], dtype=np.int64)
+        total_samples = int(per_user_counts.sum()) if per_user_counts.size > 0 else 0
+
+        logger.info("Sample index stats: users=%d, total_samples=%d", user_count, total_samples)
+
+        if per_user_counts.size > 0:
+            quantile_levels = np.arange(0.1, 1.0, 0.1)
+            quantile_values = np.quantile(per_user_counts, quantile_levels)
+            quantile_pairs = ", ".join(
+                [f"q{int(q * 100)}={int(v)}" for q, v in zip(quantile_levels, quantile_values)]
+            )
+            logger.info("Per-user sample count quantiles: %s", quantile_pairs)
+        else:
+            logger.info("Per-user sample count quantiles: empty sample index")
+
+    def _missing_mask_filter(self, ds, sample_index):
+        filtered_sample_index: dict[str, list[int]] = {user_id: [] for user_id in sample_index}
+        forecast_day_count = math.ceil(self.forecasting_length / 24)
+
+        # Stream records and filter on the fly to avoid loading a full map in memory.
+        for example in ds:
+            user_id = str(example["user_id"])
+            if user_id not in sample_index:
+                continue
+
+            indices = sample_index[user_id]
+            timestamps = example["timestamps"]
+            allowed_days = set(self.day_remain_mask.get(user_id, []))
+
+            kept_indices: list[int] = []
+            for i in indices:
+                target_day_idx = int(i)
+                all_future_days_valid = True
+
+                for day_offset in range(forecast_day_count):
+                    day_idx = target_day_idx + day_offset
+                    target_hour_idx = day_idx * 24
+                    if target_hour_idx >= len(timestamps):
+                        all_future_days_valid = False
+                        break
+
+                    ts = timestamps[target_hour_idx]
+                    day_str = str(ts).split("T", 1)[0]
+
+                    if day_str not in allowed_days:
+                        all_future_days_valid = False
+                        break
+
+                if all_future_days_valid:
+                    kept_indices.append(i)
+
+            filtered_sample_index[user_id] = kept_indices
+        return filtered_sample_index
+
+    def _historical_check_filter(self, ds, sample_index, parameters):
+        filtered_sample_index: dict[str, list[int]] = {user_id: [] for user_id in sample_index}
+
+        recent_day_count = int(parameters["recent_day_count"])
+        minimum_valid_day = int(parameters["minimum_valid_day"])
+
+        for example in ds:
+            user_id = str(example["user_id"])
+            if user_id not in sample_index:
+                continue
+
+            indices = sample_index[user_id]
+            timestamps = example["timestamps"]
+            allowed_days = set(self.day_remain_mask.get(user_id, []))
+
+            kept_indices: list[int] = []
+
+            for i in indices:
+                target_day_idx = int(i)
+
+                history_start_day = max(0, target_day_idx - recent_day_count)
+                valid_day_count = 0
+
+                for day_idx in range(history_start_day, target_day_idx):
+                    ts_idx = day_idx * 24
+                    if ts_idx >= len(timestamps):
+                        continue
+
+                    ts = timestamps[ts_idx]
+                    day_str = str(ts).split("T", 1)[0]
+
+                    if day_str in allowed_days:
+                        valid_day_count += 1
+
+                    if valid_day_count >= minimum_valid_day:
+                        kept_indices.append(i)
+                        break
+
+            filtered_sample_index[user_id] = kept_indices
+
+        return filtered_sample_index
+
+    def _maximum_sample_count_filter(self, sample_index, max_count):
+        filtered_sample_index: dict[str, list[int]] = {}
+        for user_id, indices in sample_index.items():
+            if len(indices) <= max_count:
+                filtered_sample_index[user_id] = indices
+            else:
+                filtered_sample_index[user_id] = random.sample(indices, max_count)
+        return filtered_sample_index
+
+    def _filter_name_suffix(self, key, value):
+        if key == "missing_mask":
+            return "_M"
+        
+        if key == "historical_check":
+            return f"_H_{value['recent_day_count']}_{value['minimum_valid_day']}"
+
+        if key == "maximum_sample_count_per_user":
+            return f"_S_{value}"
+
+
+    def generate(self):
+        """Generate sample indices, apply optional filters, and persist outputs.
+
+        Returns:
+            Dict mapping user IDs to retained forecast start-day indices.
+        """
+        if os.path.exists(self.sample_index_path):
+            logger.info(
+                "Sample index file already exists at %s; loading and returning it.",
+                self.sample_index_path,
+            )
+            with open(self.sample_index_path, encoding="utf-8") as f:
+                self.sample_index = json.load(f)
+            return self.sample_index
+        
+        # Load hourly trajectory dataset
+        logger.info("Loading hourly trajectory Hugging Face dataset from %s", self.hourly_trajectory_path)
+        ds = hf_ds.load_from_disk(self.hourly_trajectory_path)
+        if isinstance(ds, hf_ds.DatasetDict):
+            ds = hf_ds.concatenate_datasets(list(ds.values()))
+
+        logger.info("Loaded dataset with %d user trajectories", len(ds))
+
+        # Generate sample index in format:
+        # {
+        #   "user_id": [1, 2, 3, ...],
+        #   ...
+        # }
+        if not self._load_sample_index(f"sample_index_P_{self.forecasting_length}_raw"):
+            raw_sample_index: dict[str, list[int]] = {}
+            for row_idx, example in enumerate(tqdm(ds, desc="Generating sample index")):
+                values = np.asarray(example["values"], dtype=np.float32)
+                user_id = str(example["user_id"])
+
+                total_hours = int(values.shape[0])
+                max_start_day = (total_hours - self.forecasting_length) // 24
+                candidate_indices = list(range(1, max_start_day + 1)) if max_start_day >= 1 else []
+
+                raw_sample_index[user_id] = candidate_indices
+
+            self.sample_index = raw_sample_index
+        self._save_sample_index(f"sample_index_P_{self.forecasting_length}_raw")
+
+        # implement filtering logic based on self.filter_parameters
+        if self.filter_parameters:
+            sample_index_name = f"sample_index_P_{self.forecasting_length}"
+            for key, value in self.filter_parameters.items():
+                logger.info("Applying filter: %s = %s", key, value)
+                sample_index_name += self._filter_name_suffix(key, value)
+
+                if key == "missing_mask":
+                    if not self._load_sample_index(sample_index_name):
+                        self.sample_index = self._missing_mask_filter(ds, self.sample_index.copy())
+                    self._save_sample_index(sample_index_name)
+
+                if key == "historical_check":
+                    if not self._load_sample_index(sample_index_name):
+                        self.sample_index = self._historical_check_filter(ds, self.sample_index.copy(), value)
+                    self._save_sample_index(sample_index_name)
+
+                if key == "maximum_sample_count_per_user":
+                    if not self._load_sample_index(sample_index_name):
+                        self.sample_index = self._maximum_sample_count_filter(self.sample_index.copy(), value)
+                    self._save_sample_index(sample_index_name)
+
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M")
+        self._save_sample_index(f"sample_index_final_{timestamp}")
+        return self.sample_index
+
+
+def _build_cli_parser():
+    parser = argparse.ArgumentParser(description="Generate forecasting sample index with configurable filters.")
+    parser.add_argument("--hourly_trajectory_path", type=str, required=True)
+    parser.add_argument("--sample_index_path", type=str, required=True)
+    parser.add_argument("--day_remain_mask_path", type=str, required=True)
+    parser.add_argument(
+        "--forecasting_length",
+        type=int,
+        default=24,
+        help="Forecast horizon in hours (e.g. 24 or 48).",
+    )
+    parser.add_argument(
+        "--filter_parameters_json",
+        type=str,
+        default=None,
+        help="JSON string for filter parameters, e.g. '{\"missing_mask\": true}'.",
+    )
+    parser.add_argument(
+        "--filter_parameters_path",
+        type=str,
+        default=None,
+        help="Path to JSON file containing filter parameters.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Optional random seed for deterministic sampling.",
+    )
+    return parser
+
+
+def _load_filter_parameters(filter_parameters_json=None, filter_parameters_path=None):
+    if filter_parameters_json and filter_parameters_path:
+        raise ValueError("Please provide only one of --filter_parameters_json or --filter_parameters_path")
+
+    if filter_parameters_json:
+        return json.loads(filter_parameters_json)
+
+    if filter_parameters_path:
+        with open(filter_parameters_path, encoding="utf-8") as f:
+            return json.load(f)
+
+    return {}
+
+
+def main():
+    """CLI entry point for generating forecasting sample-index artifacts."""
+    parser = _build_cli_parser()
+    args = parser.parse_args()
+
+    if args.seed is not None:
+        random.seed(args.seed)
+
+    filter_parameters = _load_filter_parameters(
+        filter_parameters_json=args.filter_parameters_json,
+        filter_parameters_path=args.filter_parameters_path,
+    )
+
+    generator = SampleIndexGenerator(
+        hourly_trajectory_path=args.hourly_trajectory_path,
+        sample_index_path=args.sample_index_path,
+        day_remain_mask_path=args.day_remain_mask_path,
+        filter_parameters=filter_parameters,
+        forecasting_length=args.forecasting_length,
+    )
+    generator.generate()
+
+
+
+if __name__ == "__main__":
+    main()

--- a/src/forecasting_evaluation/data/types.py
+++ b/src/forecasting_evaluation/data/types.py
@@ -1,0 +1,84 @@
+"""Typed data containers for forecasting evaluation data flow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(slots=True)
+class SubTrajectoryInput:
+    """Container for a single forecasting sub-trajectory.
+
+    Attributes:
+        history: Historical target values with shape (n_features, history_length).
+        history_mask: Optional observed-value mask for history with shape
+            (n_features, history_length). True indicates observed.
+        variable_names: Names of target variables/channels.
+        past_covariates: Optional past-only covariates with shape (history_length,) per key.
+        future_covariates: Optional covariates available for both history and forecast horizon
+            with shape (history_length + prediction_hours,) per key.
+        static_covariates: Optional user-level covariates (non-temporal), kept as a
+            placeholder interface for model-specific encoding.
+        ground_truth: Future target values with shape (n_features, prediction_hours).
+        ground_truth_mask: Optional observed-value mask for forecast horizon with shape
+            (n_features, prediction_hours). True indicates observed.
+        index_days: Sliding index position (in days) where forecast starts.
+        prediction_hours: Forecast horizon in hours.
+    """
+
+    history: np.ndarray
+    variable_names: list[str]
+    past_covariates: dict[str, np.ndarray] | None
+    future_covariates: dict[str, np.ndarray] | None
+    static_covariates: dict[str, Any] | None
+    ground_truth: np.ndarray
+    index_days: int
+    prediction_hours: int
+    history_mask: np.ndarray | None = None
+    ground_truth_mask: np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        """Validate shape consistency for downstream model/evaluation logic."""
+        if self.history.ndim != 2:
+            raise ValueError("history must be 2D with shape (n_features, history_length)")
+        if self.ground_truth.ndim != 2:
+            raise ValueError("ground_truth must be 2D with shape (n_features, prediction_hours)")
+
+        n_features, history_length = self.history.shape
+        if self.ground_truth.shape[0] != n_features:
+            raise ValueError("history and ground_truth must have the same number of features")
+        if self.ground_truth.shape[1] != self.prediction_hours:
+            raise ValueError("ground_truth second dimension must match prediction_hours")
+
+        if len(self.variable_names) != n_features:
+            raise ValueError("variable_names length must match number of history features")
+
+        if self.history_mask is not None:
+            if self.history_mask.shape != self.history.shape:
+                raise ValueError("history_mask shape must match history shape")
+
+        if self.ground_truth_mask is not None:
+            if self.ground_truth_mask.shape != self.ground_truth.shape:
+                raise ValueError("ground_truth_mask shape must match ground_truth shape")
+
+        # Normalize optional covariates to empty dicts for downstream iteration safety.
+        if self.past_covariates is None:
+            self.past_covariates = {}
+        if self.future_covariates is None:
+            self.future_covariates = {}
+
+        for key, values in self.past_covariates.items():
+            if values.shape[0] != history_length:
+                raise ValueError(
+                    f"past_covariates['{key}'] length {values.shape[0]} does not match history length {history_length}"
+                )
+
+        expected_future_length = history_length + self.prediction_hours
+        for key, values in self.future_covariates.items():
+            if values.shape[0] != expected_future_length:
+                raise ValueError(
+                    f"future_covariates['{key}'] length {values.shape[0]} does not match expected length {expected_future_length}"
+                )

--- a/src/forecasting_evaluation/evaluation/__init__.py
+++ b/src/forecasting_evaluation/evaluation/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluation utilities for forecasting experiments."""

--- a/src/forecasting_evaluation/evaluation/evaluator.py
+++ b/src/forecasting_evaluation/evaluation/evaluator.py
@@ -1,0 +1,339 @@
+"""Main orchestrator for forecasting evaluation."""
+
+from __future__ import annotations
+
+import logging
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import h5py
+import numpy as np
+
+from forecasting_evaluation.config import print_config
+from forecasting_evaluation.data.data_loader import ForecastingDataLoader
+from forecasting_evaluation.data.types import SubTrajectoryInput
+from forecasting_evaluation.forecasting_training.cache_bundle import (
+    prepare_history_cf_cache_bundle,
+)
+from forecasting_evaluation.forecasting_training.online_dataset import _resolve_window_hours
+from forecasting_evaluation.io.predict_result_writer import PredictResultWriter, PublicWriter
+from forecasting_evaluation.models.deep_learning_model.pypots_forecasting_base import (
+    BasePyPOTSForecastingModel,
+)
+from forecasting_evaluation.models.registry import create_forecasting_model
+
+if TYPE_CHECKING:
+    from forecasting_evaluation.config import ForecastingEvalConfig
+    from forecasting_evaluation.models.base import BasePredictionModel
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class EvaluationDataContext:
+    """Unified evaluation-time data context prepared before model execution."""
+
+    train_ds: object
+    val_ds: object
+    test_ds: object
+    test_cache_path: Path | None = None
+    test_row_groups: list | None = None
+
+
+class ForecastingEvaluator:
+    """Main orchestrator for prediction generation and persistence."""
+
+    def __init__(self, config: ForecastingEvalConfig):
+        """Initialize evaluator.
+
+        Args:
+            config: Full forecasting evaluation configuration.
+        """
+        self.config = config
+
+        # Set random seeds for reproducibility
+        np.random.seed(config.seed)
+        random.seed(config.seed)
+
+    def run(self) -> dict:
+        """Execute full evaluation pipeline.
+
+        Returns:
+            Run metadata with output path and saved sample count.
+        """
+        # 0) Log resolved config first so output artifacts can always be traced.
+        print_config(self.config)
+
+        model: BasePredictionModel = create_forecasting_model(
+            self.config.model,
+            seed=self.config.seed,
+            forecasting_config=self.config.forecasting,
+            features_config=self.config.features,
+        )
+
+        # 1) Build a unified evaluation context (splits + cache + row groups).
+        data_context = self._load_evaluation_data(model)
+
+        # 2) Initialize run-level writer for shared metadata/config persistence.
+        public_writer = PublicWriter(
+            self.config,
+            experiment_name=self.config.experiment_name,
+        )
+
+        # 3) Execute one model sequentially over all prepared test trajectories.
+        self._run_sequential(model, data_context, public_writer)
+
+        # 4) Flush run-level metadata and return a compact run summary.
+        run_dir = public_writer.finalize()
+        return {
+            "run_dir": str(run_dir),
+            "prediction_samples": public_writer.total_written,
+            "skipped_users": public_writer.skipped_users,
+        }
+
+    def _load_evaluation_data(self, model: BasePredictionModel) -> EvaluationDataContext:
+        """Load all data needed by the current model during the unified load step."""
+        data_loader = ForecastingDataLoader(self.config.data)
+        train_ds, val_ds, test_ds = data_loader.load_splits()
+
+        context = EvaluationDataContext(
+            train_ds=train_ds,
+            val_ds=val_ds,
+            test_ds=test_ds,
+        )
+        # Resolve cache layout once so all model types use one loader path.
+        model_config, h5_output_dir = self._resolve_eval_cache_config(model, test_ds)
+        split_datasets = {
+            "train": train_ds,
+            "val": val_ds,
+            "test": test_ds,
+        }
+        # Cache bundle generation is split-aware: train/val/test are prepared together
+        # even though prediction is only emitted for test trajectories.
+        _cache_dir, cache_paths, row_groups_by_split, _scaler_stats = prepare_history_cf_cache_bundle(
+            split_datasets=split_datasets,
+            data_config=self.config.data,
+            model_config=model_config,
+            features_config=self.config.features,
+            h5_output_dir=h5_output_dir,
+            overwrite=False,
+            scaler_stats_override=(
+                model.scaler_stats if isinstance(model, BasePyPOTSForecastingModel) else None
+            ),
+        )
+        context.test_cache_path = (
+            cache_paths["test_standard"]
+            if isinstance(model, BasePyPOTSForecastingModel) and model.uses_standard_scaler
+            else cache_paths["test"]
+        )
+        context.test_row_groups = row_groups_by_split["test"]
+        logger.info(
+            "Prepared eval dataset using %s cache at %s",
+            (
+                "standardized"
+                if isinstance(model, BasePyPOTSForecastingModel) and model.uses_standard_scaler
+                else "raw"
+            ),
+            context.test_cache_path,
+        )
+        return context
+
+    def _resolve_eval_cache_config(self, model: BasePredictionModel, test_ds) -> tuple[SimpleNamespace, str]:
+        """Resolve one cache-bundle config so every model can share the same loader path."""
+        if isinstance(model, BasePyPOTSForecastingModel):
+            h5_output_dir = model._get_training_config_value("h5_export", "output_dir")
+            if not h5_output_dir:
+                h5_output_dir = "data/processed/forecasting_pypots_h5"
+            if model.uses_standard_scaler and model.scaler_stats is None:
+                raise FileNotFoundError(
+                    "PyPOTS checkpoint was trained with standard scaling, but "
+                    "standard_scaler_stats.json could not be resolved from the saved training config."
+                )
+            return (
+                SimpleNamespace(
+                    n_steps=int(model.n_steps),
+                    n_pred_steps=int(model.n_pred_steps),
+                    n_features=int(model.n_features),
+                ),
+                h5_output_dir,
+            )
+
+        if len(test_ds) > 0:
+            n_features = int(np.asarray(test_ds[0]["values"]).shape[1])
+        else:
+            # Keep a stable fallback for empty test splits.
+            n_features = 19
+        return (
+            SimpleNamespace(
+                n_steps=1,
+                n_pred_steps=int(self.config.forecasting.forecasting_length),
+                n_features=n_features,
+            ),
+            "data/processed/forecasting_eval_h5",
+        )
+
+    def _run_sequential(
+        self,
+        model: BasePredictionModel,
+        data_context: EvaluationDataContext,
+        public_writer: PublicWriter,
+    ) -> None:
+        """Run current sequential evaluation path with one shared cached sample loader."""
+        model_name = getattr(model, "model_name", model.__class__.__name__)
+        model_dir = public_writer.prepare_model_dir(model_name)
+        test_ds = data_context.test_ds
+        if data_context.test_cache_path is None or data_context.test_row_groups is None:
+            raise RuntimeError("Evaluation data context is incomplete")
+
+        logger.info(
+            "Running model %s on %d trajectories with shared cached sample loader",
+            model_name,
+            len(test_ds),
+        )
+        daily_start_hour_offset = self._resolve_runtime_daily_start_hour_offset(model)
+        prediction_hours = (
+            int(model.n_pred_steps)
+            if isinstance(model, BasePyPOTSForecastingModel)
+            else int(self.config.forecasting.forecasting_length)
+        )
+
+        with h5py.File(data_context.test_cache_path, "r") as history_handle:
+            for row_group in data_context.test_row_groups:
+                user_id = str(row_group.user_id)
+                if public_writer.should_skip_user(user_id):
+                    logger.info(
+                        "[%s] Skip user_id=%s because parquet exists and overwrite is disabled",
+                        model_name,
+                        user_id,
+                    )
+                    public_writer.increment_skipped_users()
+                    continue
+
+                row = test_ds[int(row_group.dataset_row_idx)]
+                logger.info(
+                    "[%s] Processing cached trajectory row %d/%d (user_id: %s), length: %d",
+                    model_name,
+                    int(row_group.dataset_row_idx) + 1,
+                    len(test_ds),
+                    user_id,
+                    len(row["values"]),
+                )
+                history_cf = np.asarray(
+                    history_handle["history_cf_rows"][str(row_group.dataset_row_idx)][...],
+                    dtype=np.float32,
+                )
+                predict_writer = PredictResultWriter(
+                    model_dir=model_dir,
+                    user_id=user_id,
+                    overwrite_existing=self.config.output.overwrite_existing_parquet,
+                )
+
+                try:
+                    for window in row_group.windows:
+                        # Runtime hour boundaries are derived from day index + offset.
+                        history_end_hour, pred_end_hour = _resolve_window_hours(
+                            current_day=int(window.current_day),
+                            horizon_length=prediction_hours,
+                            daily_start_hour_offset=daily_start_hour_offset,
+                        )
+
+                        if history_end_hour <= 0:
+                            continue
+
+                        if (
+                            isinstance(model, BasePyPOTSForecastingModel)
+                            and history_end_hour < int(model.n_steps)
+                        ):
+                            continue
+
+                        if pred_end_hour > history_cf.shape[1]:
+                            continue
+
+                        # History slicing depends on model family:
+                        # - PyPOTS: fixed-length trailing context.
+                        # - Others: full-prefix context up to forecast origin.
+                        history_window = self._build_history_window(
+                            model=model,
+                            history_cf=history_cf,
+                            history_end_hour=history_end_hour,
+                        )
+
+                        if history_window.shape[1] <= 0:
+                            continue
+
+                        # Target window is always the absolute horizon slice from origin.
+                        target_window = history_cf[
+                            :,
+                            history_end_hour:pred_end_hour,
+                        ]
+
+                        sub_trajectory = SubTrajectoryInput(
+                            history=history_window,
+                            variable_names=list(row["channel_names"]),
+                            past_covariates={},
+                            future_covariates={},
+                            static_covariates=None,
+                            ground_truth=target_window,
+                            index_days=int(window.current_day),
+                            prediction_hours=prediction_hours,
+                        )
+
+                        point_result, quantiles_result, base_result = model.predict_wrapper(
+                            sub_trajectory
+                        )
+
+                        prediction_record = {
+                            "user_id": user_id,
+                            "model": model_name,
+                            "history_length": int(history_end_hour),
+                            "point_predictions": point_result,
+                            "quantile_predictions": quantiles_result,
+                            "performance": base_result,
+                        }
+                        quantile_levels = getattr(model, "quantile_levels", None)
+                        if quantiles_result is not None and quantile_levels is not None:
+                            prediction_record["quantile_levels"] = quantile_levels
+
+                        predict_writer.append(prediction_record)
+                finally:
+                    predict_writer.close()
+                    # Reset model state between users to avoid cross-user leakage.
+                    model.reset()
+
+                public_writer.increment_written(predict_writer.records_written)
+
+    def _resolve_runtime_daily_start_hour_offset(self, model: BasePredictionModel) -> int:
+        """Resolve the effective runtime offset for one evaluation run."""
+        eval_offset = int(self.config.forecasting.daily_start_hour_offset)
+        eval_offset_explicit = bool(
+            getattr(self.config.forecasting, "_daily_start_hour_offset_explicit", False)
+        )
+
+        if not isinstance(model, BasePyPOTSForecastingModel):
+            return eval_offset
+
+        training_offset = int(model.training_daily_start_hour_offset)
+        # For fixed-window deep models, day-boundary mismatch changes samples.
+        # Enforce exact match when eval config explicitly sets an offset.
+        if eval_offset_explicit and eval_offset != training_offset:
+            raise ValueError(
+                "Eval config forecasting.daily_start_hour_offset="
+                f"{eval_offset} does not match checkpoint training offset "
+                f"{training_offset}."
+            )
+        return training_offset
+
+    def _build_history_window(
+        self,
+        *,
+        model: BasePredictionModel,
+        history_cf: np.ndarray,
+        history_end_hour: int,
+    ) -> np.ndarray:
+        """Slice one model-ready history window from the shared cached row tensor."""
+        if isinstance(model, BasePyPOTSForecastingModel):
+            return history_cf[:, history_end_hour - model.n_steps : history_end_hour]
+        return history_cf[:, :history_end_hour]

--- a/src/forecasting_evaluation/evaluation/point_metrics.py
+++ b/src/forecasting_evaluation/evaluation/point_metrics.py
@@ -1,0 +1,510 @@
+"""Point forecasting metrics for forecasting evaluation."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def compute_mae(predictions: np.ndarray, ground_truth: np.ndarray) -> list[float]:
+    r"""Compute per-horizon Mean Absolute Error.
+
+    Formula (per horizon $t$):
+        $\mathrm{MAE}_t = |y_t - \hat{y}_t|$
+
+    Args:
+        predictions: Predicted values with shape ``(1, prediction_length)``.
+        ground_truth: Ground-truth values with shape ``(1, prediction_length)``.
+
+    Returns:
+        A flat list of length ``prediction_length`` containing the absolute error at
+        each forecast horizon.
+    """
+    return np.abs(predictions - ground_truth).reshape(-1).tolist()
+
+
+def compute_mse(predictions: np.ndarray, ground_truth: np.ndarray) -> list[float]:
+    r"""Compute per-horizon Mean Squared Error.
+
+    Formula (per horizon $t$):
+        $\mathrm{MSE}_t = (y_t - \hat{y}_t)^2$
+
+    Args:
+        predictions: Predicted values with shape ``(1, prediction_length)``.
+        ground_truth: Ground-truth values with shape ``(1, prediction_length)``.
+
+    Returns:
+        A flat list of length ``prediction_length`` containing the squared error at
+        each forecast horizon.
+    """
+    return ((predictions - ground_truth) ** 2).reshape(-1).tolist()
+
+
+def compute_f1(
+    predictions: np.ndarray,
+    ground_truth: np.ndarray,
+    mask: np.ndarray | None = None,
+    threshold: float = 0.5,
+) -> float:
+    r"""Compute F1 score over all valid positions.
+
+    Args:
+        predictions: Predicted probabilities or scores. The array can have any shape
+            as long as it is broadcast-compatible with ``ground_truth`` after
+            flattening.
+        ground_truth: Binary ground-truth values. Entries equal to ``1.0`` are treated
+            as positive, and all other finite values are treated as negative.
+        mask: Optional boolean mask with the same flattened shape as
+            ``ground_truth``. Positions where the mask is ``False`` are excluded from
+            the TP/FP/FN counts.
+        threshold: Threshold used to convert prediction scores into binary labels.
+
+    Returns:
+        Scalar F1 score computed from the aggregated TP/FP/FN counts over all valid
+        positions. Returns ``NaN`` when ``2 * TP + FP + FN == 0``.
+    """
+    pred = np.asarray(predictions, dtype=float).reshape(-1)
+    truth = np.asarray(ground_truth, dtype=float).reshape(-1)
+    if pred.shape != truth.shape:
+        raise ValueError(
+            f"Predictions and ground truth must have the same flattened shape, got {pred.shape} and {truth.shape}"
+        )
+
+    if mask is None:
+        valid = np.ones(pred.shape, dtype=bool)
+    else:
+        valid = np.asarray(mask, dtype=bool).reshape(-1)
+        if valid.shape != truth.shape:
+            raise ValueError(
+                f"Mask must have the same flattened shape as ground truth, got {valid.shape} and {truth.shape}"
+            )
+
+    pred_binary = pred >= float(threshold)
+    truth_binary = truth == 1.0
+
+    tp = int(np.sum(valid & truth_binary & pred_binary))
+    fp = int(np.sum(valid & (~truth_binary) & pred_binary))
+    fn = int(np.sum(valid & truth_binary & (~pred_binary)))
+
+    denominator = (2 * tp) + fp + fn
+    if denominator <= 0:
+        return float("nan")
+    return float((2.0 * tp) / denominator)
+
+
+def finalize_hour_of_day_scales(
+    scale_sum: np.ndarray,
+    scale_count: np.ndarray,
+) -> np.ndarray:
+    """Convert accumulated scale sums/counts into mean hour-of-day scales.
+
+    This helper is the final reduction step for the benchmark-global scaling term
+    used by ``MASE`` and ``sQL``. It divides the accumulated absolute-difference sum
+    by the number of valid seasonal pairs for each ``(feature, hour-of-day)`` cell.
+
+    Args:
+        scale_sum: Sum of absolute seasonal differences. Shape is typically
+            ``(n_features, season_length)``.
+        scale_count: Count of valid seasonal pairs contributing to each cell. Must
+            have the same shape as ``scale_sum``.
+
+    Returns:
+        An array with the same shape as the inputs. Cells with zero valid pairs, or
+        cells whose resulting mean is ``0.0``, are returned as ``NaN`` so downstream
+        normalized metrics remain undefined in those cases.
+    """
+    sum_arr = np.asarray(scale_sum, dtype=float)
+    count_arr = np.asarray(scale_count, dtype=float)
+    if sum_arr.shape != count_arr.shape:
+        raise ValueError(
+            f"scale_sum and scale_count must have the same shape, got {sum_arr.shape} and {count_arr.shape}"
+        )
+
+    scales = np.full(sum_arr.shape, np.nan, dtype=float)
+    valid = count_arr > 0
+    scales[valid] = sum_arr[valid] / count_arr[valid]
+    return np.where(np.isfinite(scales) & (scales != 0.0), scales, np.nan)
+
+
+def finalize_global_scales(
+    scale_sum: np.ndarray,
+    scale_count: np.ndarray,
+) -> np.ndarray:
+    """Convert accumulated scale sums/counts into one global scale per feature.
+
+    This helper is used for ``mase_all``, whose denominator is a single
+    benchmark-global seasonal-naive scale per feature instead of one scale per
+    hour-of-day bucket.
+
+    Args:
+        scale_sum: Sum of absolute seasonal differences with shape ``(n_features,)``.
+        scale_count: Count of valid seasonal pairs with the same shape.
+
+    Returns:
+        One-dimensional array of length ``n_features``. Entries are ``NaN`` when a
+        feature has no valid seasonal pairs or when the resulting scale is ``0.0``.
+    """
+    sum_arr = np.asarray(scale_sum, dtype=float).reshape(-1)
+    count_arr = np.asarray(scale_count, dtype=float).reshape(-1)
+    if sum_arr.shape != count_arr.shape:
+        raise ValueError(
+            f"scale_sum and scale_count must have the same shape, got {sum_arr.shape} and {count_arr.shape}"
+        )
+
+    scales = np.full(sum_arr.shape, np.nan, dtype=float)
+    valid = count_arr > 0
+    scales[valid] = sum_arr[valid] / count_arr[valid]
+    return np.where(np.isfinite(scales) & (scales != 0.0), scales, np.nan)
+
+
+def accumulate_hour_of_day_scale_statistics(
+    values: np.ndarray,
+    target_start_idx: int,
+    prediction_length: int,
+    season_length: int,
+    scale_sum: np.ndarray | None = None,
+    scale_count: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    r"""Accumulate benchmark-level scale statistics for one forecasting window.
+
+    This follows the manuscript definition
+
+    .. math::
+        S_h^{(c)} \propto
+        \sum_{t \in \mathcal{T}_i}
+        M_{i,t+h}^{(c)} M_{i,t+h-24}^{(c)}
+        \lvert Y_{i,t+h}^{(c)} - Y_{i,t+h-24}^{(c)} \rvert.
+
+    Args:
+        values: Full transformed trajectory for one user with shape
+            ``(n_features, trajectory_length)``. Missing target values should already
+            be encoded as ``NaN`` so they can be excluded via the implicit mask.
+        target_start_idx: Absolute 0-based start index of the forecasting window
+            inside ``values``.
+        prediction_length: Forecast horizon ``H``. The function examines target
+            indices ``target_start_idx`` through ``target_start_idx + H - 1``.
+        season_length: Seasonal lag in hours. For the benchmark this is ``24``.
+        scale_sum: Optional running sum array used to accumulate statistics across
+            many forecasting windows. When omitted, a zero-initialized array is
+            created.
+        scale_count: Optional running count array with the same shape as
+            ``scale_sum``. When omitted, a zero-initialized array is created.
+
+    Returns:
+        A tuple ``(scale_sum, scale_count)`` after incorporating this forecasting
+        window's valid seasonal pairs. Only pairs where both ``t+h`` and
+        ``t+h-24`` are finite contribute to the accumulation.
+    """
+    value_arr = np.asarray(values, dtype=float)
+    if value_arr.ndim != 2:
+        raise ValueError(f"Expected values with shape (n_features, trajectory_length), got {value_arr.shape}")
+    if season_length <= 0:
+        raise ValueError(f"season_length must be positive, got {season_length}")
+
+    n_features, trajectory_length = value_arr.shape
+    if scale_sum is None:
+        scale_sum_arr = np.zeros((n_features, season_length), dtype=float)
+    else:
+        scale_sum_arr = np.asarray(scale_sum, dtype=float)
+        if scale_sum_arr.shape != (n_features, season_length):
+            raise ValueError(
+                f"scale_sum must have shape {(n_features, season_length)}, got {scale_sum_arr.shape}"
+            )
+
+    if scale_count is None:
+        scale_count_arr = np.zeros((n_features, season_length), dtype=np.int64)
+    else:
+        scale_count_arr = np.asarray(scale_count, dtype=np.int64)
+        if scale_count_arr.shape != (n_features, season_length):
+            raise ValueError(
+                f"scale_count must have shape {(n_features, season_length)}, got {scale_count_arr.shape}"
+            )
+
+    if prediction_length <= 0:
+        return scale_sum_arr, scale_count_arr
+
+    target_indices = np.arange(target_start_idx, target_start_idx + prediction_length, dtype=int)
+    valid_target_mask = (target_indices >= 0) & (target_indices < trajectory_length)
+    if not np.any(valid_target_mask):
+        return scale_sum_arr, scale_count_arr
+
+    target_indices = target_indices[valid_target_mask]
+    previous_indices = target_indices - season_length
+    valid_pair_mask = previous_indices >= 0
+    if not np.any(valid_pair_mask):
+        return scale_sum_arr, scale_count_arr
+
+    target_indices = target_indices[valid_pair_mask]
+    previous_indices = previous_indices[valid_pair_mask]
+    hour_buckets = target_indices % season_length
+
+    current_values = value_arr[:, target_indices]
+    previous_values = value_arr[:, previous_indices]
+    valid_observed = np.isfinite(current_values) & np.isfinite(previous_values)
+    absolute_diff = np.abs(current_values - previous_values)
+
+    for col_idx, hour_bucket in enumerate(hour_buckets):
+        feature_mask = valid_observed[:, col_idx]
+        if not np.any(feature_mask):
+            continue
+        scale_sum_arr[feature_mask, hour_bucket] += absolute_diff[feature_mask, col_idx]
+        scale_count_arr[feature_mask, hour_bucket] += 1
+
+    return scale_sum_arr, scale_count_arr
+
+
+def accumulate_global_scale_statistics(
+    values: np.ndarray,
+    target_start_idx: int,
+    prediction_length: int,
+    season_length: int,
+    scale_sum: np.ndarray | None = None,
+    scale_count: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    r"""Accumulate one benchmark-global seasonal scale per feature.
+
+    Unlike ``accumulate_hour_of_day_scale_statistics()``, this helper ignores the
+    hour-of-day bucket and aggregates every valid seasonal pair for a feature into a
+    single global denominator. This matches the ``mase_all`` definition requested by
+    the benchmark.
+
+    Args:
+        values: Full transformed trajectory for one user with shape
+            ``(n_features, trajectory_length)``.
+        target_start_idx: Absolute 0-based start index of the forecasting window.
+        prediction_length: Forecast horizon ``H``.
+        season_length: Seasonal lag in hours. For the benchmark this is ``24``.
+        scale_sum: Optional running per-feature sum of absolute seasonal
+            differences.
+        scale_count: Optional running per-feature count of valid seasonal pairs.
+
+    Returns:
+        A tuple ``(scale_sum, scale_count)`` after incorporating this forecasting
+        window's valid seasonal pairs into one global scale per feature.
+    """
+    value_arr = np.asarray(values, dtype=float)
+    if value_arr.ndim != 2:
+        raise ValueError(f"Expected values with shape (n_features, trajectory_length), got {value_arr.shape}")
+    if season_length <= 0:
+        raise ValueError(f"season_length must be positive, got {season_length}")
+
+    n_features, trajectory_length = value_arr.shape
+    if scale_sum is None:
+        scale_sum_arr = np.zeros(n_features, dtype=float)
+    else:
+        scale_sum_arr = np.asarray(scale_sum, dtype=float).reshape(-1)
+        if scale_sum_arr.shape != (n_features,):
+            raise ValueError(
+                f"scale_sum must have shape {(n_features,)}, got {scale_sum_arr.shape}"
+            )
+
+    if scale_count is None:
+        scale_count_arr = np.zeros(n_features, dtype=np.int64)
+    else:
+        scale_count_arr = np.asarray(scale_count, dtype=np.int64).reshape(-1)
+        if scale_count_arr.shape != (n_features,):
+            raise ValueError(
+                f"scale_count must have shape {(n_features,)}, got {scale_count_arr.shape}"
+            )
+
+    if prediction_length <= 0:
+        return scale_sum_arr, scale_count_arr
+
+    target_indices = np.arange(target_start_idx, target_start_idx + prediction_length, dtype=int)
+    valid_target_mask = (target_indices >= 0) & (target_indices < trajectory_length)
+    if not np.any(valid_target_mask):
+        return scale_sum_arr, scale_count_arr
+
+    target_indices = target_indices[valid_target_mask]
+    previous_indices = target_indices - season_length
+    valid_pair_mask = previous_indices >= 0
+    if not np.any(valid_pair_mask):
+        return scale_sum_arr, scale_count_arr
+
+    target_indices = target_indices[valid_pair_mask]
+    previous_indices = previous_indices[valid_pair_mask]
+
+    current_values = value_arr[:, target_indices]
+    previous_values = value_arr[:, previous_indices]
+    valid_observed = np.isfinite(current_values) & np.isfinite(previous_values)
+    absolute_diff = np.abs(current_values - previous_values)
+
+    feature_sums = np.where(valid_observed, absolute_diff, 0.0).sum(axis=1)
+    feature_counts = valid_observed.sum(axis=1)
+    scale_sum_arr += feature_sums
+    scale_count_arr += feature_counts
+    return scale_sum_arr, scale_count_arr
+
+
+def select_hour_of_day_scale(
+    scales_by_hour: np.ndarray,
+    season_length: int,
+    target_idx: int,
+) -> float:
+    """Select the relevant hour-of-day scale for one absolute target time.
+
+    Args:
+        scales_by_hour: One-dimensional scale vector of length ``season_length``.
+        season_length: Seasonal lag in hours.
+        target_idx: Absolute 0-based target time index.
+
+    Returns:
+        The scale associated with the hour-of-day bucket of ``target_idx``. Returns
+        ``NaN`` when ``target_idx`` is negative.
+    """
+    if target_idx < 0:
+        return float("nan")
+
+    scales = np.asarray(scales_by_hour, dtype=float).reshape(-1)
+    if scales.shape[0] != season_length:
+        raise ValueError(
+            f"scales_by_hour must have length {season_length}, got {scales.shape[0]}"
+        )
+    return float(scales[int(target_idx % season_length)])
+
+
+def compute_mase(
+    predictions: np.ndarray,
+    ground_truth: np.ndarray,
+    scales_by_hour: np.ndarray,
+    season_length: int,
+    target_start_idx: int,
+) -> list[float]:
+    r"""Compute per-horizon Mean Absolute Scaled Error using benchmark-global scales.
+
+    Formula (per horizon $t+h$):
+        $\mathrm{MASE}_{t+h} = \frac{|y_{t+h} - \hat{y}_{t+h}|}{S^{(H_{t+h})}}$
+
+    Here ``S^(r)`` is the benchmark-global scaling term for hour-of-day bucket
+    ``r``, precomputed from all valid evaluation-window seasonal pairs.
+
+    Args:
+        predictions: Predicted values with shape ``(1, prediction_length)``.
+        ground_truth: Ground-truth values with shape ``(1, prediction_length)``.
+        scales_by_hour: One-dimensional scale vector of length ``season_length`` for
+            the current feature.
+        season_length: Seasonal lag in hours. For the benchmark this is ``24``.
+        target_start_idx: Absolute 0-based start index of the forecast window inside
+            the full trajectory. This is used only to map each horizon to the correct
+            hour-of-day bucket.
+
+    Returns:
+        A flat list of length ``prediction_length``. Each entry is the absolute error
+        divided by the corresponding hour-of-day scale. If the required scale is
+        missing or zero, the returned value is ``NaN``.
+    """
+    pred_errors = np.abs(predictions - ground_truth).reshape(-1)
+    scales = np.asarray(scales_by_hour, dtype=float).reshape(-1)
+    if scales.shape[0] != season_length:
+        raise ValueError(
+            f"scales_by_hour must have length {season_length}, got {scales.shape[0]}"
+        )
+
+    target_indices = np.arange(target_start_idx, target_start_idx + pred_errors.shape[0], dtype=int)
+    scale_by_horizon = np.full(pred_errors.shape, np.nan, dtype=float)
+    valid_index_mask = target_indices >= 0
+    scale_by_horizon[valid_index_mask] = scales[target_indices[valid_index_mask] % season_length]
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        mase = pred_errors / scale_by_horizon
+    mase = np.where(np.isfinite(scale_by_horizon) & (scale_by_horizon != 0.0), mase, np.nan)
+    return mase.tolist()
+
+
+def compute_mase_all(
+    predictions: np.ndarray,
+    ground_truth: np.ndarray,
+    global_scale: float,
+) -> list[float]:
+    r"""Compute per-horizon Mean Absolute Scaled Error with one global feature scale.
+
+    Formula (per horizon $t+h$):
+        $\mathrm{MASE\_all}_{t+h} = \frac{|y_{t+h} - \hat{y}_{t+h}|}{S_{\mathrm{all}}}$
+
+    Args:
+        predictions: Predicted values with shape ``(1, prediction_length)``.
+        ground_truth: Ground-truth values with shape ``(1, prediction_length)``.
+        global_scale: Single benchmark-global seasonal scale for the current feature.
+
+    Returns:
+        A flat list of length ``prediction_length``. Each entry is the absolute error
+        divided by ``global_scale``. Returns ``NaN`` for all horizons when the scale
+        is missing or zero.
+    """
+    pred_errors = np.abs(predictions - ground_truth).reshape(-1)
+    if not np.isfinite(global_scale) or float(global_scale) == 0.0:
+        return np.full(pred_errors.shape, np.nan, dtype=float).tolist()
+    return (pred_errors / float(global_scale)).tolist()
+
+
+def compute_point_metrics(
+    predictions: np.ndarray | None,
+    ground_truth: np.ndarray,
+    variable_names: list[str] | None = None,
+    scales_by_feature: np.ndarray | None = None,
+    season_length: int = 24,
+    target_start_idx: int | None = None,
+) -> dict[str, dict[str, list[float]] | None]:
+    """Compute point forecasting metrics for all features in one sample.
+
+    Args:
+        predictions: Point predictions with shape ``(n_features, prediction_length)``.
+            When ``None``, all metric groups are returned as ``None``.
+        ground_truth: Ground-truth matrix with the same shape as ``predictions``.
+        variable_names: Optional feature names aligned with the first dimension. If
+            omitted, default names ``var_0``, ``var_1``, ... are generated.
+        scales_by_feature: Optional benchmark-global scale matrix with shape
+            ``(n_features, season_length)``. When provided together with
+            ``target_start_idx``, ``MASE`` is computed per feature.
+        season_length: Seasonal lag in hours used by ``MASE``.
+        target_start_idx: Absolute 0-based forecast start index used to map each
+            horizon to its hour-of-day bucket.
+
+    Returns:
+        A dictionary with the following keys:
+        - ``mae``: maps each variable name to its per-horizon MAE list.
+        - ``mse``: maps each variable name to its per-horizon MSE list.
+        - ``f1``: maps each variable name to a scalar F1 value computed over the full
+          horizon.
+        - ``mase``: maps each variable name to its per-horizon MASE list when scales
+          are provided; otherwise ``None``.
+    """
+    if predictions is None:
+        return {
+            "mae": None,
+            "mse": None,
+            "f1": None,
+            "mase": None,
+        }
+
+    n_features = predictions.shape[0]
+    if variable_names is None:
+        variable_names = [f"var_{i}" for i in range(n_features)]
+
+    mae_per_feature: dict[str, list[float]] = {}
+    mse_per_feature: dict[str, list[float]] = {}
+    f1_per_feature: dict[str, float] = {}
+    mase_per_feature: dict[str, list[float]] = {}
+
+    for i, var_name in enumerate(variable_names):
+        feature_pred = predictions[i:i + 1, :]
+        feature_truth = ground_truth[i:i + 1, :]
+
+        mae_per_feature[var_name] = compute_mae(feature_pred, feature_truth)
+        mse_per_feature[var_name] = compute_mse(feature_pred, feature_truth)
+        f1_per_feature[var_name] = compute_f1(feature_pred, feature_truth)
+
+        if scales_by_feature is not None and target_start_idx is not None:
+            mase_per_feature[var_name] = compute_mase(
+                predictions=feature_pred,
+                ground_truth=feature_truth,
+                scales_by_hour=scales_by_feature[i],
+                season_length=season_length,
+                target_start_idx=target_start_idx,
+            )
+
+    return {
+        "mae": mae_per_feature,
+        "mse": mse_per_feature,
+        "f1": f1_per_feature,
+        "mase": mase_per_feature if mase_per_feature else None,
+    }

--- a/src/forecasting_evaluation/evaluation/quantiles_metrics.py
+++ b/src/forecasting_evaluation/evaluation/quantiles_metrics.py
@@ -1,0 +1,191 @@
+"""Quantile forecasting metrics for forecasting evaluation."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _default_quantile_levels(n_quantiles: int) -> np.ndarray:
+    """Generate default quantile levels when none are provided.
+
+    The levels are evenly spaced in the open interval ``(0, 1)`` so that endpoints
+    ``0`` and ``1`` are never used.
+
+    Args:
+        n_quantiles: Number of quantile levels required.
+
+    Returns:
+        One-dimensional array of length ``n_quantiles``. When ``n_quantiles <= 0``,
+        returns an empty array.
+    """
+    if n_quantiles <= 0:
+        return np.asarray([])
+    return np.linspace(1.0 / (n_quantiles + 1), n_quantiles / (n_quantiles + 1), n_quantiles)
+
+
+def compute_ql(
+    predictions: np.ndarray,
+    ground_truth: np.ndarray,
+    quantile_levels: np.ndarray,
+    mask: np.ndarray | None = None,
+) -> np.ndarray:
+    r"""Compute per-horizon Quantile Loss.
+
+    Formula (per horizon $t$):
+        $\mathrm{QL}_t = \frac{1}{|Q|}\sum_{q \in Q}
+        (q - \mathbb{1}\{y_t \le \hat{y}_t^{(q)}\})(y_t - \hat{y}_t^{(q)})$
+
+    Args:
+        predictions: Quantile prediction matrix with shape
+            ``(prediction_length, n_quantiles)``.
+        ground_truth: Ground-truth vector with shape ``(prediction_length,)``.
+        quantile_levels: Quantile levels aligned with the second dimension of
+            ``predictions``.
+        mask: Optional boolean vector of length ``prediction_length``. Horizons where
+            the mask is ``False`` are excluded from the loss and returned as ``NaN``.
+
+    Returns:
+        One-dimensional array of length ``prediction_length``. Each entry is the mean
+        pinball loss across all quantile levels for that horizon.
+    """
+    y = ground_truth.reshape(-1, 1)
+    q_hat = predictions
+    q = quantile_levels.reshape(1, -1)
+    indicator = (y <= q_hat).astype(float)
+    loss = (q - indicator) * (y - q_hat)
+    if mask is not None:
+        valid = mask.reshape(-1, 1).astype(bool)
+        loss = np.where(valid, loss, np.nan)
+
+    valid_counts = np.sum(np.isfinite(loss), axis=1)
+    loss_sum = np.nansum(loss, axis=1)
+    result = np.full(loss.shape[0], np.nan, dtype=float)
+    valid_rows = valid_counts > 0
+    result[valid_rows] = loss_sum[valid_rows] / valid_counts[valid_rows]
+    return result
+
+
+def compute_sql(
+    ql: np.ndarray,
+    scales_by_hour: np.ndarray,
+    season_length: int = 24,
+    target_start_idx: int | None = None,
+) -> np.ndarray:
+    r"""Compute per-horizon Scaled Quantile Loss.
+
+    Formula (per horizon $t+h$):
+        $\mathrm{sQL}_{t+h} = \frac{\mathrm{QL}_{t+h}}{S^{(H_{t+h})}}$
+
+    Args:
+        ql: Per-horizon quantile loss vector with shape ``(prediction_length,)``.
+        scales_by_hour: One-dimensional benchmark-global scale vector for the current
+            feature. Its length must equal ``season_length``.
+        season_length: Seasonal lag in hours. For the benchmark this is ``24``.
+        target_start_idx: Absolute 0-based start index of the forecast window inside
+            the full trajectory. Used to map each horizon to the proper hour-of-day
+            bucket. When omitted, ``sQL`` is returned as all ``NaN``.
+
+    Returns:
+        One-dimensional array of length ``prediction_length``. Each entry is the
+        corresponding ``QL`` value divided by the benchmark-global scale for that
+        hour-of-day. Missing or zero scales yield ``NaN``.
+    """
+    if target_start_idx is None:
+        return np.full_like(ql, np.nan, dtype=float)
+
+    scales = np.asarray(scales_by_hour, dtype=float).reshape(-1)
+    if scales.shape[0] != season_length:
+        raise ValueError(
+            f"scales_by_hour must have length {season_length}, got {scales.shape[0]}"
+        )
+
+    target_indices = np.arange(target_start_idx, target_start_idx + ql.shape[0], dtype=int)
+    scale_by_horizon = np.full(ql.shape, np.nan, dtype=float)
+    valid_index_mask = target_indices >= 0
+    scale_by_horizon[valid_index_mask] = scales[target_indices[valid_index_mask] % season_length]
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        sql = ql / scale_by_horizon
+    return np.where(np.isfinite(scale_by_horizon) & (scale_by_horizon != 0.0), sql, np.nan)
+
+
+def compute_quantiles_metrics(
+    predictions: np.ndarray | None,
+    ground_truth: np.ndarray,
+    variable_names: list[str] | None = None,
+    quantile_levels: np.ndarray | None = None,
+    scales_by_feature: np.ndarray | None = None,
+    mask: np.ndarray | None = None,
+    target_start_idx: int | None = None,
+) -> dict[str, dict[str, list[float]] | None]:
+    """Compute quantile-based forecasting metrics for all features in one sample.
+
+    Args:
+        predictions: Quantile prediction tensor with shape
+            ``(n_features, prediction_length, n_quantiles)``. When ``None``, all
+            metric groups are returned as ``None``.
+        ground_truth: Ground-truth matrix with shape ``(n_features, prediction_length)``.
+        variable_names: Optional feature names aligned with the first dimension. If
+            omitted, default names ``var_0``, ``var_1``, ... are generated.
+        quantile_levels: Quantile levels aligned with the last dimension of
+            ``predictions``.
+        scales_by_feature: Optional benchmark-global scale matrix with shape
+            ``(n_features, 24)``. When provided, ``sQL`` is computed using the same
+            benchmark-global scales as ``MASE``.
+        mask: Optional observed-value mask with shape ``(n_features, prediction_length)``.
+            Missing horizons are excluded from ``QL`` and ``sQL``.
+        target_start_idx: Absolute 0-based forecast start index used to map horizons
+            to hour-of-day buckets.
+
+    Returns:
+        A dictionary with the following keys:
+        - ``ql``: maps each variable name to its per-horizon QL list.
+        - ``sQL``: maps each variable name to its per-horizon scaled quantile loss.
+        - ``ql_by_feature``: maps each variable name to the mean QL over its valid
+          horizons.
+        - ``ql_mean``: scalar mean of ``ql_by_feature`` across all features.
+    """
+    if predictions is None or quantile_levels is None:
+        return {
+            "ql": None,
+            "sQL": None,
+            "ql_by_feature": None,
+            "ql_mean": None,
+        }
+
+    n_features = predictions.shape[0]
+    if variable_names is None:
+        variable_names = [f"var_{i}" for i in range(n_features)]
+
+    ql_per_feature: dict[str, list[float]] = {}
+    sql_per_feature: dict[str, list[float]] = {}
+    ql_by_feature: dict[str, float] = {}
+
+    for i, var_name in enumerate(variable_names):
+        feature_pred = predictions[i]
+        feature_truth = ground_truth[i]
+        feature_mask = mask[i] if mask is not None else None
+
+        ql = compute_ql(feature_pred, feature_truth, quantile_levels, mask=feature_mask)
+        if scales_by_feature is None:
+            sql = np.full_like(ql, np.nan, dtype=float)
+        else:
+            sql = compute_sql(
+                ql=ql,
+                scales_by_hour=scales_by_feature[i],
+                season_length=24,
+                target_start_idx=target_start_idx,
+            )
+
+        ql_per_feature[var_name] = ql.tolist()
+        sql_per_feature[var_name] = sql.tolist()
+        ql_by_feature[var_name] = float(np.nanmean(ql))
+
+    overall_ql = float(np.nanmean(np.asarray(list(ql_by_feature.values()), dtype=float)))
+
+    return {
+        "ql": ql_per_feature,
+        "sQL": sql_per_feature,
+        "ql_by_feature": ql_by_feature,
+        "ql_mean": overall_ql,
+    }

--- a/src/forecasting_evaluation/feature_extractors/__init__.py
+++ b/src/forecasting_evaluation/feature_extractors/__init__.py
@@ -1,0 +1,24 @@
+"""Feature extractors for downstream evaluation."""
+
+__all__ = ["FeatureExtractor", "BaselineFeatureExtractor", "EncoderFeatureExtractor"]
+
+
+def __getattr__(name: str):
+    """Lazy import to avoid heavy dependencies at module load."""
+    if name == "FeatureExtractor":
+        from downstream_evaluation.feature_extractors.base import FeatureExtractor
+
+        return FeatureExtractor
+    elif name == "BaselineFeatureExtractor":
+        from downstream_evaluation.feature_extractors.baseline_extractor import (
+            BaselineFeatureExtractor,
+        )
+
+        return BaselineFeatureExtractor
+    elif name == "EncoderFeatureExtractor":
+        from downstream_evaluation.feature_extractors.encoder_extractor import (
+            EncoderFeatureExtractor,
+        )
+
+        return EncoderFeatureExtractor
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/forecasting_evaluation/feature_extractors/base.py
+++ b/src/forecasting_evaluation/feature_extractors/base.py
@@ -1,0 +1,29 @@
+"""Base protocol for feature extractors."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import datasets as hf_ds
+
+
+class FeatureExtractor(Protocol):
+    """Protocol for feature extraction from HuggingFace datasets."""
+
+    def extract(self, hf_dataset: hf_ds.Dataset) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Extract features from dataset.
+
+        Args:
+            hf_dataset: HuggingFace dataset with 'x', 'user_id', and task_name columns.
+            task_name: Name of the label column.
+
+        Returns:
+            Tuple of (features, labels, user_ids) where:
+            - features: (N, D) float32 array
+            - labels: (N,) int64 array
+            - user_ids: (N,) object array of user ID strings
+        """
+        ...

--- a/src/forecasting_evaluation/feature_extractors/multivariate_extractor.py
+++ b/src/forecasting_evaluation/feature_extractors/multivariate_extractor.py
@@ -1,0 +1,105 @@
+"""Multivariate feature extractor for time series forecasting.
+
+Extracts multivariate time series data from trajectory samples for forecasting tasks.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from forecasting_evaluation.config import FeaturesConfig
+
+logger = logging.getLogger(__name__)
+
+
+class MultivariateFeatureExtractor:
+    """Extract multivariate forecasting features from one trajectory row.
+
+    Output schema is consumed by ``SubTrajectoryGenerator.generate`` and includes
+    both values and observed-value masks in channel-first format.
+    """
+
+    def __init__(self, config: FeaturesConfig, forecasting_length: int = 24):
+        """Initialize multivariate feature extractor.
+
+        Args:
+            config: Required forecasting feature configuration.
+            forecasting_length: Number of hours to forecast (for future covariates).
+        """
+        self.config = config
+        self.prediction_length = forecasting_length
+
+    def extract(self, trajectory: dict) -> dict:
+        """Extract multivariate features from a single trajectory.
+
+        Args:
+            trajectory: Single trajectory sample with the following fields:
+                - user_id: str
+                - values: (T, C) float32 array - T timesteps, C channels
+                - timestamps: list of length T
+                - channel_names: list of length C
+                - channel_units: list of length C
+                - start_time: str (ISO 8601)
+                - end_time: str (ISO 8601)
+
+        Returns:
+            Dictionary containing:
+                {
+                    "history": np.ndarray of shape (n_features, trajectory_length),
+                    "variable_names": list[str],
+                    "past_covariates": dict[str, np.ndarray] | None,
+                    "future_covariates": dict[str, np.ndarray] | None,
+                    "static_covariates": dict[str, object] | None,
+                }
+
+        Note:
+                Covariates are placeholder interfaces in the current benchmark release.
+                We intentionally do not implement feature engineering here; model-specific
+                encoding is deferred to model implementations in later iterations.
+        """
+        # Extract data from trajectory
+        values = np.asarray(trajectory["values"], dtype=np.float32)  # (T, C)
+        # mask = np.asarray(trajectory["mask"], dtype=bool)  # (T, C)
+        channel_names = trajectory["channel_names"]
+        # timestamps = trajectory["timestamps"]
+
+        channel = self.config.channel
+
+        if channel != "all":
+            raise ValueError(f"Unknown channel type: {channel}")
+
+        # Select target channels for both values and masks.
+        selected_values = values  # (T, 19)
+        # selected_mask = mask[:, channel_indices]  # (T, n_features)
+        selected_channel_names = list(channel_names)
+
+        # Convert from (T, n_features) to (n_features, T) for forecasting pipeline.
+        history = selected_values.T  # (n_features, T)
+        # history_mask = selected_mask.T  # (n_features, T)
+        # trajectory_length = history.shape[1]
+        
+        # Placeholder-only covariate interfaces:
+        # - dynamic covariates (past/future) are kept as empty dicts by default.
+        # - static covariates are set to None.
+        # This preserves a stable contract without forcing a single encoding scheme.
+        covariate_types = self.config.covariate_types if self.config is not None else None
+        if covariate_types:
+            logger.info(
+                "covariate_types=%s requested, but covariate engineering is intentionally deferred; "
+                "returning placeholder empty covariate dicts.",
+                covariate_types,
+            )
+
+        past_covariates: dict[str, np.ndarray] = {}
+        future_covariates: dict[str, np.ndarray] = {}
+        static_covariates: dict[str, object] | None = None
+        
+        return {
+            "history": history,
+            "variable_names": selected_channel_names,
+            "past_covariates": past_covariates,
+            "future_covariates": future_covariates,
+            "static_covariates": static_covariates,
+        }

--- a/src/forecasting_evaluation/forecasting_training/__init__.py
+++ b/src/forecasting_evaluation/forecasting_training/__init__.py
@@ -1,0 +1,1 @@
+"""Forecasting-specific PyPOTS training utilities."""

--- a/src/forecasting_evaluation/forecasting_training/cache_bundle.py
+++ b/src/forecasting_evaluation/forecasting_training/cache_bundle.py
@@ -1,0 +1,168 @@
+"""Shared history_cf cache bundle orchestration for training and evaluation."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from pathlib import Path
+
+import yaml
+
+from forecasting_evaluation.forecasting_training.online_dataset import (
+    build_history_cf_rows,
+    history_cf_cache_subdir,
+    history_cf_manifest_path,
+    load_or_build_row_group_manifest,
+    write_history_cf_cache,
+)
+from forecasting_evaluation.forecasting_training.standard_scaler import (
+    ChannelStandardScalerStats,
+    fit_from_history_cf_rows,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def save_data_config_yaml(cache_dir: Path, data_config) -> Path:
+    """Persist the effective data-layer config beside the generated caches."""
+    output_path = cache_dir / "config.yaml"
+    payload = asdict(data_config)
+    with output_path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(payload, handle, sort_keys=False, allow_unicode=True)
+    return output_path
+
+
+def cache_bundle_paths(cache_dir: Path) -> dict[str, Path]:
+    """Return the fixed set of cache bundle paths under one cache directory."""
+    return {
+        "train": cache_dir / "train.h5",
+        "train_standard": cache_dir / "train_standard.h5",
+        "val": cache_dir / "val.h5",
+        "val_standard": cache_dir / "val_standard.h5",
+        "test": cache_dir / "test.h5",
+        "test_standard": cache_dir / "test_standard.h5",
+        "data_config": cache_dir / "config.yaml",
+        "scaler_stats": cache_dir / "standard_scaler_stats.json",
+        "train_manifest": cache_dir / "train_manifest.json",
+        "val_manifest": cache_dir / "val_manifest.json",
+        "test_manifest": cache_dir / "test_manifest.json",
+    }
+
+
+def prepare_history_cf_cache_bundle(
+    *,
+    split_datasets: dict[str, object],
+    data_config,
+    model_config,
+    features_config,
+    h5_output_dir: str | Path,
+    overwrite: bool = False,
+    scaler_stats_override: ChannelStandardScalerStats | None = None,
+) -> tuple[Path, dict[str, Path], dict[str, list], ChannelStandardScalerStats]:
+    """Ensure the raw+standard history_cf cache bundle exists for all three splits."""
+    cache_dir = history_cf_cache_subdir(
+        base_dir=Path(h5_output_dir) / "history_cf_cache",
+        data_config=data_config,
+        model_config=model_config,
+        features_config=features_config,
+    )
+    cache_paths = cache_bundle_paths(cache_dir)
+    cache_bundle_ready = not overwrite and all(path.exists() for path in cache_paths.values())
+
+    row_groups_by_split: dict[str, list] = {}
+    scaler_stats: ChannelStandardScalerStats | None = scaler_stats_override
+
+    if cache_bundle_ready:
+        logger.info("history_cf cache bundle already exists under %s, reusing it", cache_dir)
+        for split_name, split_ds in split_datasets.items():
+            row_groups_by_split[split_name] = load_or_build_row_group_manifest(
+                split_ds=split_ds,
+                sample_index_file=data_config.sample_index_file,
+                model_config=model_config,
+                manifest_path=history_cf_manifest_path(cache_dir, split_name),
+                split_name=split_name,
+                overwrite=False,
+            )
+        if scaler_stats is None:
+            from forecasting_evaluation.forecasting_training.standard_scaler import load_stats_json
+
+            scaler_stats = load_stats_json(cache_paths["scaler_stats"])
+    else:
+        logger.info("Building history_cf cache bundle under %s", cache_dir)
+        rows_by_split: dict[str, list] = {}
+        for split_name, split_ds in split_datasets.items():
+            logger.info("Building history_cf rows for %s split", split_name)
+            rows_by_split[split_name] = build_history_cf_rows(
+                split_ds=split_ds,
+                features_config=features_config,
+                model_config=model_config,
+            )
+
+        if scaler_stats is None:
+            logger.info("Fitting StandardScaler stats from train split history_cf rows")
+            scaler_stats = fit_from_history_cf_rows(
+                rows_by_split["train"],
+                n_channels=model_config.n_features,
+            )
+        else:
+            logger.info("Using provided StandardScaler stats to materialize standard caches")
+
+        scaler_stats_path = scaler_stats.save_stats_json(cache_paths["scaler_stats"])
+        data_config_path = save_data_config_yaml(cache_dir, data_config)
+
+        for split_name, history_rows in rows_by_split.items():
+            write_history_cf_cache(
+                history_rows,
+                cache_paths[split_name],
+                overwrite=True,
+            )
+            write_history_cf_cache(
+                [scaler_stats.transform_history_cf(row) for row in history_rows],
+                cache_paths[f"{split_name}_standard"],
+                overwrite=True,
+            )
+
+        for split_name, split_ds in split_datasets.items():
+            row_groups_by_split[split_name] = load_or_build_row_group_manifest(
+                split_ds=split_ds,
+                sample_index_file=data_config.sample_index_file,
+                model_config=model_config,
+                manifest_path=history_cf_manifest_path(cache_dir, split_name),
+                split_name=split_name,
+                overwrite=True,
+            )
+
+        logger.info("Saved scaler stats to %s", scaler_stats_path)
+        logger.info("Saved cache data config to %s", data_config_path)
+
+    logger.info(
+        "Prepared history_cf cache bundle under %s", cache_dir
+    )
+    logger.info(
+        "Cache files ready: train=%s, train_standard=%s, val=%s, val_standard=%s, test=%s, test_standard=%s, train_manifest=%s, val_manifest=%s, test_manifest=%s, data_config=%s, scaler_stats=%s",
+        cache_paths["train"],
+        cache_paths["train_standard"],
+        cache_paths["val"],
+        cache_paths["val_standard"],
+        cache_paths["test"],
+        cache_paths["test_standard"],
+        cache_paths["train_manifest"],
+        cache_paths["val_manifest"],
+        cache_paths["test_manifest"],
+        cache_paths["data_config"],
+        cache_paths["scaler_stats"],
+    )
+    logger.info(
+        "Manifest row-groups ready: train=%d rows/%d samples, val=%d rows/%d samples, test=%d rows/%d samples",
+        len(row_groups_by_split["train"]),
+        sum(len(group.windows) for group in row_groups_by_split["train"]),
+        len(row_groups_by_split["val"]),
+        sum(len(group.windows) for group in row_groups_by_split["val"]),
+        len(row_groups_by_split["test"]),
+        sum(len(group.windows) for group in row_groups_by_split["test"]),
+    )
+
+    if scaler_stats is None:
+        raise RuntimeError("Scaler stats should be available after preparing the cache bundle")
+
+    return cache_dir, cache_paths, row_groups_by_split, scaler_stats

--- a/src/forecasting_evaluation/forecasting_training/config.py
+++ b/src/forecasting_evaluation/forecasting_training/config.py
@@ -1,0 +1,150 @@
+"""Configuration dataclasses for forecasting PyPOTS training."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from forecasting_evaluation.config import DataConfig, FeaturesConfig, ForecastingConfig
+
+
+@dataclass
+class H5ExportConfig:
+    """Deprecated HDF5 export configuration for forecasting samples."""
+
+    output_dir: str = "data/processed/forecasting_pypots_h5"
+    overwrite: bool = False
+    chunk_size: int = 512
+
+
+@dataclass
+class ModelConfig:
+    """PyPOTS forecasting model configuration.
+
+    Reference:
+    - PyPOTS DLinear forecasting API
+    - PyPOTS MixLinear forecasting API
+    - PyPOTS TEFN forecasting API
+    - PyPOTS SegRNN forecasting API
+
+    Shared parameters:
+    - ``n_steps``: input history length
+    - ``n_features``: number of channels/features
+    - ``n_pred_steps``: forecast horizon
+    - ``loss``: PyPOTS training loss name, resolved from ``pypots.nn.modules.loss``
+    - ``validation_metric``: PyPOTS validation metric name
+
+    DLinear-specific parameters:
+    - ``moving_avg_window_size``
+    - ``individual``
+    - ``d_model`` (used in non-individual mode)
+
+    MixLinear-specific parameters:
+    - ``period_len``
+    - ``lpf``
+    - ``alpha``
+    - ``rank``
+
+    TEFN-specific parameters:
+    - ``n_fod``
+    - ``apply_nonstationary_norm``
+
+    SegRNN-specific parameters:
+    - ``seg_len``
+    - ``d_model``
+    - ``dropout``
+
+    ``base_model_name`` is only used by the Chronos-2 fine-tuning path.
+    """
+
+    model_name: str = "chronos2"
+    base_model_name: str = "amazon/chronos-2"
+    n_steps: int = 168  # Shared: input history length in hours.
+    n_pred_steps: int = 24  # Shared: forecast horizon in hours.
+    n_features: int = 19  # Shared: number of input/output channels.
+    loss: str = "mae"
+    validation_metric: str = "mae"
+
+    # DLinear-specific parameters.
+    d_model: int = 64
+    moving_avg_window_size: int = 25
+    individual: bool = False
+
+    # MixLinear-specific parameters.
+    period_len: int = 24
+    lpf: int = 2
+    alpha: float = 0.5
+    rank: int = 2
+
+    # TEFN-specific parameters.
+    n_fod: int = 2
+    apply_nonstationary_norm: bool = False
+
+    # SegRNN-specific parameters.
+    seg_len: int = 24
+
+    # Shared deep-learning hyperparameters used by several forecasting architectures.
+    n_layers: int = 2
+    n_heads: int = 4
+    d_ffn: int = 128
+    dropout: float = 0.1
+
+    # Frequency / decomposition style params.
+    top_k: int = 5
+    n_kernels: int = 6
+
+
+@dataclass
+class TrainingConfig:
+    """Training hyperparameters."""
+
+    finetune_mode: Literal["full", "lora"] = "full"
+    whether_standardscaler: bool = False
+    epochs: int = 50
+    batch_size: int = 64
+    patience: int = 10
+    optimizer_lr: float = 1.0e-3
+    device: str = "cuda"
+    disable_data_parallel: bool = True
+    # LoRA-specific (Chronos-2)
+    lora_r: int = 8
+    lora_alpha: int = 16
+    lora_dropout: float = 0.0
+
+
+@dataclass
+class OutputConfig:
+    """Model saving and tracking configuration."""
+
+    saving_path: str = "models/forecasting_pypots"
+    finetuned_ckpt_name: str = "finetuned-ckpt"
+    model_saving_strategy: Literal["best", "better", "all"] = "best"
+    upload_wandb_artifact: bool = True
+    wandb_project: str = "mhc-forecasting"
+    wandb_entity: str = "MHC_Dataset"
+
+
+@dataclass
+class ForecastingPyPOTSTrainingConfig:
+    """Root configuration for forecasting PyPOTS training."""
+
+    seed: int = 42
+    data: DataConfig = field(default_factory=DataConfig)
+    forecasting: ForecastingConfig = field(default_factory=ForecastingConfig)
+    features: FeaturesConfig = field(default_factory=FeaturesConfig)
+    h5_export: H5ExportConfig = field(default_factory=H5ExportConfig)
+    model: ModelConfig = field(default_factory=ModelConfig)
+    training: TrainingConfig = field(default_factory=TrainingConfig)
+    output: OutputConfig = field(default_factory=OutputConfig)
+
+    def __post_init__(self) -> None:
+        """Normalize output paths derived from runtime-only forecasting settings."""
+        offset = int(self.forecasting.daily_start_hour_offset)
+        if offset == 0:
+            return
+
+        output_path = Path(self.output.saving_path)
+        suffix = f"_{offset}"
+        if not output_path.name.endswith(suffix):
+            self.output.saving_path = str(output_path.with_name(f"{output_path.name}{suffix}"))

--- a/src/forecasting_evaluation/forecasting_training/online_dataset.py
+++ b/src/forecasting_evaluation/forecasting_training/online_dataset.py
@@ -1,0 +1,654 @@
+"""Online PyPOTS datasets for forecasting training.
+
+This module replaces the previous "export everything to H5 first" flow with a
+manifest-driven Dataset that slices samples directly from the original
+trajectory HuggingFace dataset on demand.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import datasets as hf_ds
+import h5py
+import numpy as np
+import torch
+from pygrinder import fill_and_get_mask_torch
+from pypots.data.dataset.base import BaseDataset
+from torch.utils.data import BatchSampler, Sampler
+
+from data.transforms.nan_transforms import ZeroToNaNTransform
+from forecasting_evaluation.feature_extractors.multivariate_extractor import (
+    MultivariateFeatureExtractor,
+)
+from forecasting_evaluation.forecasting_training.config import FeaturesConfig, ModelConfig
+from forecasting_evaluation.forecasting_training.standard_scaler import (
+    ChannelStandardScalerStats,
+)
+
+logger = logging.getLogger(__name__)
+SCALER_VARIANT = "train_only_standard_scaler_v1"
+MANIFEST_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ForecastingSampleDescriptor:
+    """Manifest entry describing one forecasting sample."""
+
+    dataset_row_idx: int
+    user_id: str
+    current_day: int
+    history_end_hour: int
+    pred_end_hour: int
+
+
+@dataclass(frozen=True)
+class ForecastingWindowDescriptor:
+    """Window metadata for one sample within a row group."""
+
+    current_day: int
+    history_end_hour: int
+    pred_end_hour: int
+
+
+@dataclass(frozen=True)
+class ForecastingRowGroup:
+    """All valid forecasting windows derived from one trajectory row."""
+
+    dataset_row_idx: int
+    user_id: str
+    windows: tuple[ForecastingWindowDescriptor, ...]
+
+
+class ForecastingSampleIndexBuilder:
+    """Build row-grouped manifests from split trajectories and sample indices."""
+
+    HOURS_PER_DAY = 24
+
+    def __init__(
+        self,
+        split_ds: hf_ds.Dataset,
+        sample_index_file: str | Path,
+        n_steps: int,
+        n_pred_steps: int,
+    ) -> None:
+        """Initialize the manifest builder from a split and sample index."""
+        self._split_ds = split_ds
+        self._sample_index_file = Path(sample_index_file)
+        self._n_steps = int(n_steps)
+        self._n_pred_steps = int(n_pred_steps)
+        self._sample_index = self._load_sample_index()
+
+    def _load_sample_index(self) -> dict[str, list[int]]:
+        if not self._sample_index_file.exists():
+            raise FileNotFoundError(f"sample_index_file not found: {self._sample_index_file}")
+
+        loaded = json.loads(self._sample_index_file.read_text(encoding="utf-8"))
+        if not isinstance(loaded, dict):
+            raise ValueError(
+                f"sample_index_file must contain a user->days mapping: {self._sample_index_file}"
+            )
+
+        normalized: dict[str, list[int]] = {}
+        for user_id, day_list in loaded.items():
+            if not isinstance(day_list, list):
+                continue
+            normalized[str(user_id)] = sorted({int(day) for day in day_list if int(day) >= 1})
+        return normalized
+
+    def build_row_groups(self) -> list[ForecastingRowGroup]:
+        """Create row-grouped slice descriptors matching the previous H5 export logic."""
+        row_groups: list[ForecastingRowGroup] = []
+
+        for row_idx, row in enumerate(self._split_ds):
+            user_id = str(row["user_id"])
+            candidate_days = self._sample_index.get(user_id, [])
+            if not candidate_days:
+                continue
+
+            trajectory_length = len(row["values"])
+            windows: list[ForecastingWindowDescriptor] = []
+            for current_day in candidate_days:
+                history_end = current_day * self.HOURS_PER_DAY
+                pred_end = history_end + self._n_pred_steps
+                latest_possible_history_end = history_end + (self.HOURS_PER_DAY - 1)
+
+                if history_end <= 0:
+                    continue
+                if pred_end > trajectory_length:
+                    continue
+                # Keep a day-level manifest independent of the runtime offset.
+                # The actual offset-specific validity is resolved later when
+                # slicing windows from loaded row tensors.
+                if latest_possible_history_end < self._n_steps:
+                    continue
+
+                windows.append(
+                    ForecastingWindowDescriptor(
+                        current_day=current_day,
+                        history_end_hour=history_end,
+                        pred_end_hour=pred_end,
+                    )
+                )
+
+            if windows:
+                row_groups.append(
+                    ForecastingRowGroup(
+                        dataset_row_idx=row_idx,
+                        user_id=user_id,
+                        windows=tuple(windows),
+                    )
+                )
+
+        logger.info(
+            "Built online forecasting row-group manifest with %d rows and %d samples",
+            len(row_groups),
+            sum(len(group.windows) for group in row_groups),
+        )
+        return row_groups
+
+    def build(self) -> list[ForecastingSampleDescriptor]:
+        """Backward-compatible flat manifest view."""
+        manifest: list[ForecastingSampleDescriptor] = []
+        for row_group in self.build_row_groups():
+            for window in row_group.windows:
+                manifest.append(
+                    ForecastingSampleDescriptor(
+                        dataset_row_idx=row_group.dataset_row_idx,
+                        user_id=row_group.user_id,
+                        current_day=window.current_day,
+                        history_end_hour=window.history_end_hour,
+                        pred_end_hour=window.pred_end_hour,
+                    )
+                )
+        return manifest
+
+
+def history_cf_cache_subdir(
+    base_dir: str | Path,
+    data_config,
+    model_config: ModelConfig,
+    features_config: FeaturesConfig,
+) -> Path:
+    """Return content-addressed cache path for per-row history_cf storage."""
+    key = {
+        "trajectory_hf_dir": str(data_config.trajectory_hf_dir),
+        "split_file": str(data_config.split_file),
+        "sample_index_file": str(data_config.sample_index_file),
+        "train_ratio": data_config.train_ratio,
+        "val_ratio": data_config.val_ratio,
+        "split_seed": data_config.split_seed,
+        "max_samples": data_config.max_samples,
+        "feature_channel": features_config.channel,
+        "n_steps": model_config.n_steps,
+        "n_pred_steps": model_config.n_pred_steps,
+        "n_features": model_config.n_features,
+        "scaler_variant": SCALER_VARIANT,
+    }
+    digest = hashlib.sha256(json.dumps(key, sort_keys=True, default=str).encode()).hexdigest()[:8]
+    return Path(base_dir) / digest
+
+
+def history_cf_manifest_path(cache_dir: str | Path, split_name: str) -> Path:
+    """Return the JSON manifest cache path for one split."""
+    normalized_split = str(split_name).strip().lower()
+    return Path(cache_dir) / f"{normalized_split}_manifest.json"
+
+
+def build_history_cf_rows(
+    split_ds: hf_ds.Dataset,
+    features_config: FeaturesConfig,
+    model_config: ModelConfig,
+) -> list[torch.Tensor]:
+    """Extract raw channel-first history tensors for one split."""
+    extractor = MultivariateFeatureExtractor(
+        config=features_config,
+        forecasting_length=model_config.n_pred_steps,
+    )
+    zero_to_nan_transform = ZeroToNaNTransform()
+
+    rows: list[torch.Tensor] = []
+    for row in split_ds:
+        features = extractor.extract(row)
+        history_cf = torch.as_tensor(features["history"], dtype=torch.float32)
+        history_cf = zero_to_nan_transform(history_cf)
+        rows.append(history_cf)
+    return rows
+
+
+def write_row_group_manifest(
+    row_groups: list[ForecastingRowGroup],
+    manifest_path: str | Path,
+) -> Path:
+    """Persist row-group manifest as JSON."""
+    manifest_path = Path(manifest_path)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "manifest_version": MANIFEST_VERSION,
+        "row_groups": [
+            {
+                "dataset_row_idx": row_group.dataset_row_idx,
+                "user_id": row_group.user_id,
+                "windows": [
+                    {
+                        "current_day": window.current_day,
+                        "history_end_hour": window.history_end_hour,
+                        "pred_end_hour": window.pred_end_hour,
+                    }
+                    for window in row_group.windows
+                ],
+            }
+            for row_group in row_groups
+        ],
+    }
+    manifest_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    return manifest_path
+
+
+def load_row_group_manifest(manifest_path: str | Path) -> list[ForecastingRowGroup]:
+    """Load row-group manifest from JSON."""
+    manifest_path = Path(manifest_path)
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    row_groups_payload = payload.get("row_groups", [])
+    row_groups: list[ForecastingRowGroup] = []
+    for row_group_payload in row_groups_payload:
+        windows = tuple(
+            ForecastingWindowDescriptor(
+                current_day=int(window_payload["current_day"]),
+                history_end_hour=int(window_payload["history_end_hour"]),
+                pred_end_hour=int(window_payload["pred_end_hour"]),
+            )
+            for window_payload in row_group_payload.get("windows", [])
+        )
+        row_groups.append(
+            ForecastingRowGroup(
+                dataset_row_idx=int(row_group_payload["dataset_row_idx"]),
+                user_id=str(row_group_payload["user_id"]),
+                windows=windows,
+            )
+        )
+    return row_groups
+
+
+def load_or_build_row_group_manifest(
+    *,
+    split_ds: hf_ds.Dataset,
+    sample_index_file: str | Path,
+    model_config: ModelConfig,
+    manifest_path: str | Path,
+    split_name: str,
+    overwrite: bool = False,
+) -> list[ForecastingRowGroup]:
+    """Reuse manifest JSON when present, otherwise rebuild and persist it."""
+    manifest_path = Path(manifest_path)
+    if manifest_path.exists() and not overwrite:
+        row_groups = load_row_group_manifest(manifest_path)
+        logger.info(
+            "Manifest cache already exists at %s, reusing it (%d rows, %d samples)",
+            manifest_path,
+            len(row_groups),
+            sum(len(group.windows) for group in row_groups),
+        )
+        return row_groups
+
+    logger.info("Building %s manifest cache at %s", split_name, manifest_path)
+    row_groups = ForecastingSampleIndexBuilder(
+        split_ds=split_ds,
+        sample_index_file=sample_index_file,
+        n_steps=model_config.n_steps,
+        n_pred_steps=model_config.n_pred_steps,
+    ).build_row_groups()
+    write_row_group_manifest(row_groups, manifest_path)
+    logger.info(
+        "Saved %s manifest cache to %s (%d rows, %d samples)",
+        split_name,
+        manifest_path,
+        len(row_groups),
+        sum(len(group.windows) for group in row_groups),
+    )
+    return row_groups
+
+
+def write_history_cf_cache(
+    history_cf_rows: list[torch.Tensor],
+    cache_path: str | Path,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Persist per-row history_cf tensors to HDF5."""
+    cache_path = Path(cache_path)
+    if cache_path.exists() and not overwrite:
+        logger.info("history_cf cache already exists at %s, reusing it", cache_path)
+        return cache_path
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    n_features = int(history_cf_rows[0].shape[0]) if history_cf_rows else 0
+
+    with h5py.File(cache_path, "w") as handle:
+        rows_group = handle.create_group("history_cf_rows")
+        for row_idx, history_cf in enumerate(history_cf_rows):
+            rows_group.create_dataset(
+                str(row_idx),
+                data=history_cf.cpu().numpy().astype(np.float32),
+                compression="gzip",
+            )
+
+        handle.attrs["n_features"] = n_features
+        handle.attrs["n_rows"] = len(history_cf_rows)
+
+    logger.info("Saved history_cf H5 cache for %d rows to %s", len(history_cf_rows), cache_path)
+    return cache_path
+
+
+def precompute_history_cf_cache(
+    split_ds: hf_ds.Dataset,
+    cache_path: str | Path,
+    features_config: FeaturesConfig,
+    model_config: ModelConfig,
+    scaler_stats: ChannelStandardScalerStats | None = None,
+    overwrite: bool = False,
+) -> Path:
+    """Materialize one history_cf tensor per split row and store it in HDF5."""
+    history_cf_rows = build_history_cf_rows(split_ds, features_config, model_config)
+    if scaler_stats is not None:
+        history_cf_rows = [scaler_stats.transform_history_cf(row) for row in history_cf_rows]
+    return write_history_cf_cache(history_cf_rows, cache_path, overwrite=overwrite)
+
+
+def _resolve_window_hours(
+    *,
+    current_day: int,
+    horizon_length: int,
+    daily_start_hour_offset: int,
+) -> tuple[int, int]:
+    history_end_hour = current_day * 24 + daily_start_hour_offset
+    pred_end_hour = history_end_hour + horizon_length
+    return history_end_hour, pred_end_hour
+
+
+def resolve_runtime_row_groups(
+    *,
+    row_groups: list[ForecastingRowGroup],
+    row_lengths_by_idx: dict[int, int],
+    history_length: int,
+    horizon_length: int,
+    daily_start_hour_offset: int,
+) -> list[ForecastingRowGroup]:
+    """Resolve offset-adjusted windows without changing persisted manifest data."""
+    resolved_row_groups: list[ForecastingRowGroup] = []
+
+    for row_group in row_groups:
+        trajectory_length = int(row_lengths_by_idx.get(int(row_group.dataset_row_idx), 0))
+        resolved_windows: list[ForecastingWindowDescriptor] = []
+        for window in row_group.windows:
+            history_end_hour, pred_end_hour = _resolve_window_hours(
+                current_day=int(window.current_day),
+                horizon_length=horizon_length,
+                daily_start_hour_offset=daily_start_hour_offset,
+            )
+            if history_end_hour <= 0:
+                continue
+            if history_end_hour < history_length:
+                continue
+            if pred_end_hour > trajectory_length:
+                continue
+            resolved_windows.append(
+                ForecastingWindowDescriptor(
+                    current_day=int(window.current_day),
+                    history_end_hour=history_end_hour,
+                    pred_end_hour=pred_end_hour,
+                )
+            )
+
+        if resolved_windows:
+            resolved_row_groups.append(
+                ForecastingRowGroup(
+                    dataset_row_idx=int(row_group.dataset_row_idx),
+                    user_id=str(row_group.user_id),
+                    windows=tuple(resolved_windows),
+                )
+            )
+
+    return resolved_row_groups
+
+
+class PyPOTSForecastingDataset(BaseDataset):
+    """Manifest-backed forecasting Dataset aligned with PyPOTS BaseDataset semantics."""
+
+    def __init__(
+        self,
+        history_cf_source: str | Path | list[torch.Tensor],
+        row_groups: list[ForecastingRowGroup],
+        model_config: ModelConfig,
+        daily_start_hour_offset: int = 0,
+    ) -> None:
+        """Initialize a dataset that slices forecasting windows on demand."""
+        # We intentionally don't call BaseDataset.__init__ because our data source is
+        # a manifest over a precomputed per-row cache rather than an in-memory dict / H5 file.
+        self._history_length = int(model_config.n_steps)
+        self._horizon_length = int(model_config.n_pred_steps)
+        self._daily_start_hour_offset = int(daily_start_hour_offset)
+        if not 0 <= self._daily_start_hour_offset < 24:
+            raise ValueError(
+                "daily_start_hour_offset must be within [0, 24), "
+                f"but received {self._daily_start_hour_offset}"
+            )
+        self._history_cf_source = history_cf_source
+        self._history_cf_rows = self._load_history_cf_rows(history_cf_source)
+        self._history_cf_file_handle = None
+        self._cached_row_idx: int | None = None
+        self._cached_row_tensor: torch.Tensor | None = None
+        self._row_groups = resolve_runtime_row_groups(
+            row_groups=row_groups,
+            row_lengths_by_idx=self._build_row_lengths_by_idx(history_cf_source),
+            history_length=self._history_length,
+            horizon_length=self._horizon_length,
+            daily_start_hour_offset=self._daily_start_hour_offset,
+        )
+        self._sample_lookup = self._build_sample_lookup(self._row_groups)
+        self.data = None
+        self.return_X_ori = False
+        self.return_X_pred = True
+        self.return_y = False
+        self.file_type = "online"
+        self.fetch_data = self._fetch_data_from_manifest
+        self.n_samples = len(self._sample_lookup)
+        self.n_steps = self._history_length
+        self.n_features = int(model_config.n_features)
+        self.n_pred_steps = self._horizon_length
+        self.n_pred_features = int(model_config.n_features)
+
+    @staticmethod
+    def _load_history_cf_rows(history_cf_source: str | Path | list[torch.Tensor]) -> list[torch.Tensor] | None:
+        if isinstance(history_cf_source, list):
+            return history_cf_source
+
+        history_cf_source = Path(history_cf_source)
+        if history_cf_source.suffix.lower() != ".h5":
+            raise ValueError(f"Unsupported history_cf cache format: {history_cf_source}")
+        return None
+
+    @staticmethod
+    def _build_row_lengths_by_idx(
+        history_cf_source: str | Path | list[torch.Tensor],
+    ) -> dict[int, int]:
+        if isinstance(history_cf_source, list):
+            return {idx: int(row.shape[1]) for idx, row in enumerate(history_cf_source)}
+
+        history_cf_path = Path(history_cf_source)
+        with h5py.File(history_cf_path, "r") as handle:
+            rows_group = handle["history_cf_rows"]
+            return {
+                int(row_idx): int(rows_group[row_idx].shape[1])
+                for row_idx in rows_group.keys()
+            }
+
+    @staticmethod
+    def _build_sample_lookup(
+        row_groups: list[ForecastingRowGroup],
+    ) -> list[tuple[int, int]]:
+        sample_lookup: list[tuple[int, int]] = []
+        for group_idx, row_group in enumerate(row_groups):
+            for window_idx, _window in enumerate(row_group.windows):
+                sample_lookup.append((group_idx, window_idx))
+        return sample_lookup
+
+    def build_batch_sampler(self, batch_size: int, shuffle: bool) -> BatchSampler:
+        """Create a sampler that keeps windows from the same row adjacent."""
+        return ForecastingRowGroupedBatchSampler(
+            row_groups=self._row_groups,
+            batch_size=batch_size,
+            shuffle=shuffle,
+        )
+
+    def _open_history_cf_file_handle(self):
+        if self._history_cf_file_handle is None:
+            if isinstance(self._history_cf_source, list):
+                return None
+            self._history_cf_file_handle = h5py.File(self._history_cf_source, "r")
+        return self._history_cf_file_handle
+
+    def _get_history_cf_row(self, dataset_row_idx: int) -> torch.Tensor:
+        if self._cached_row_idx == dataset_row_idx and self._cached_row_tensor is not None:
+            return self._cached_row_tensor
+
+        if self._history_cf_rows is not None:
+            history_cf = self._history_cf_rows[dataset_row_idx]
+        else:
+            handle = self._open_history_cf_file_handle()
+            if handle is None or "history_cf_rows" not in handle:
+                raise ValueError(f"Invalid history_cf cache format: {self._history_cf_source}")
+            history_cf = torch.from_numpy(handle["history_cf_rows"][str(dataset_row_idx)][...]).to(
+                torch.float32
+            )
+
+        self._cached_row_idx = dataset_row_idx
+        self._cached_row_tensor = history_cf
+        return history_cf
+
+    def __len__(self) -> int:
+        """Return the number of available forecasting samples."""
+        return len(self._sample_lookup)
+
+    def _fetch_data_from_manifest(self, idx: int) -> tuple[torch.Tensor, ...]:
+        group_idx, window_idx = self._sample_lookup[idx]
+        row_group = self._row_groups[group_idx]
+        window = row_group.windows[window_idx]
+        history_cf = self._get_history_cf_row(row_group.dataset_row_idx)
+
+        history_window = history_cf[
+            :,
+            window.history_end_hour - self._history_length : window.history_end_hour,
+        ]
+        target_window = history_cf[:, window.history_end_hour : window.pred_end_hour]
+
+        x = history_window.transpose(0, 1).contiguous()
+        x_pred = target_window.transpose(0, 1).contiguous()
+        x, missing_mask = fill_and_get_mask_torch(x)
+        x_pred, x_pred_missing_mask = fill_and_get_mask_torch(x_pred)
+
+        return (
+            torch.tensor(idx, dtype=torch.int64),
+            x,
+            missing_mask,
+            x_pred,
+            x_pred_missing_mask,
+        )
+
+
+class ForecastingRowGroupedBatchSampler(Sampler[list[int]]):
+    """Yield sample-index batches while keeping samples from the same row adjacent."""
+
+    def __init__(
+        self,
+        row_groups: list[ForecastingRowGroup],
+        batch_size: int,
+        shuffle: bool,
+    ) -> None:
+        """Initialize a row-group-aware batch sampler."""
+        self._row_groups = row_groups
+        self._batch_size = int(batch_size)
+        self._shuffle = shuffle
+
+    def __iter__(self):
+        """Yield batches of sample indices with row-local adjacency."""
+        row_indices = list(range(len(self._row_groups)))
+        if self._shuffle:
+            permutation = torch.randperm(len(row_indices)).tolist()
+            row_indices = [row_indices[i] for i in permutation]
+
+        batch: list[int] = []
+        running_sample_idx = 0
+        group_start_indices: list[int] = []
+        for row_group in self._row_groups:
+            group_start_indices.append(running_sample_idx)
+            running_sample_idx += len(row_group.windows)
+
+        for row_group_idx in row_indices:
+            row_group = self._row_groups[row_group_idx]
+            sample_indices = list(
+                range(
+                    group_start_indices[row_group_idx],
+                    group_start_indices[row_group_idx] + len(row_group.windows),
+                )
+            )
+            if self._shuffle and len(sample_indices) > 1:
+                sample_indices = [sample_indices[i] for i in torch.randperm(len(sample_indices)).tolist()]
+
+            for sample_idx in sample_indices:
+                batch.append(sample_idx)
+                if len(batch) == self._batch_size:
+                    yield batch
+                    batch = []
+
+        if batch:
+            yield batch
+
+    def __len__(self) -> int:
+        """Return the number of batches produced by this sampler."""
+        total_samples = sum(len(group.windows) for group in self._row_groups)
+        return (total_samples + self._batch_size - 1) // self._batch_size
+
+
+def build_pypots_forecasting_dataset(
+    split_ds: hf_ds.Dataset,
+    sample_index_file: str | Path | None,
+    model_config: ModelConfig,
+    features_config: FeaturesConfig,
+    daily_start_hour_offset: int = 0,
+    history_cf_source: str | Path | list[torch.Tensor] | None = None,
+    row_groups: list[ForecastingRowGroup] | None = None,
+) -> PyPOTSForecastingDataset:
+    """Construct an online forecasting Dataset for one split."""
+    if row_groups is None:
+        if sample_index_file is None:
+            raise ValueError("sample_index_file is required when row_groups is not provided")
+        row_groups = ForecastingSampleIndexBuilder(
+            split_ds=split_ds,
+            sample_index_file=sample_index_file,
+            n_steps=model_config.n_steps,
+            n_pred_steps=model_config.n_pred_steps,
+        ).build_row_groups()
+    if history_cf_source is None:
+        history_cf_source = [
+            ZeroToNaNTransform()(
+                torch.as_tensor(
+                    MultivariateFeatureExtractor(
+                        config=features_config,
+                        forecasting_length=model_config.n_pred_steps,
+                    ).extract(row)["history"],
+                    dtype=torch.float32,
+                )
+            )
+            for row in split_ds
+        ]
+    return PyPOTSForecastingDataset(
+        history_cf_source=history_cf_source,
+        row_groups=row_groups,
+        model_config=model_config,
+        daily_start_hour_offset=daily_start_hour_offset,
+    )

--- a/src/forecasting_evaluation/forecasting_training/standard_scaler.py
+++ b/src/forecasting_evaluation/forecasting_training/standard_scaler.py
@@ -1,0 +1,146 @@
+"""Channel-wise StandardScaler utilities for forecasting training caches."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+@dataclass(frozen=True)
+class ChannelStandardScalerStats:
+    """Train-fit per-channel StandardScaler statistics."""
+
+    means: np.ndarray
+    stds: np.ndarray
+    valid_counts: np.ndarray
+    fit_scope: str = "train"
+
+    def __post_init__(self) -> None:
+        """Normalize scaler statistics to stable NumPy dtypes."""
+        object.__setattr__(self, "means", np.asarray(self.means, dtype=np.float64))
+        object.__setattr__(self, "stds", np.asarray(self.stds, dtype=np.float64))
+        object.__setattr__(self, "valid_counts", np.asarray(self.valid_counts, dtype=np.int64))
+
+    @property
+    def n_channels(self) -> int:
+        """Return the number of channel statistics stored."""
+        return int(self.means.shape[0])
+
+    def transform_history_cf(self, history_cf: torch.Tensor) -> torch.Tensor:
+        """Standardize a channel-first history tensor."""
+        return transform_history_cf(history_cf, self)
+
+    def inverse_transform_history_cf(self, history_cf: torch.Tensor) -> torch.Tensor:
+        """Restore a standardized channel-first history tensor."""
+        return inverse_transform_history_cf(history_cf, self)
+
+    def save_stats_json(self, output_path: str | Path) -> Path:
+        """Persist these scaler statistics to JSON."""
+        return save_stats_json(self, output_path)
+
+
+def fit_from_history_cf_rows(
+    history_cf_rows: list[torch.Tensor],
+    *,
+    n_channels: int | None = None,
+) -> ChannelStandardScalerStats:
+    """Fit per-channel mean/std from train-split history_cf rows only."""
+    if not history_cf_rows:
+        if n_channels is None:
+            raise ValueError("n_channels is required when fitting scaler on an empty row list.")
+        means = np.zeros(n_channels, dtype=np.float64)
+        stds = np.ones(n_channels, dtype=np.float64)
+        valid_counts = np.zeros(n_channels, dtype=np.int64)
+        return ChannelStandardScalerStats(means=means, stds=stds, valid_counts=valid_counts)
+
+    if n_channels is None:
+        n_channels = int(history_cf_rows[0].shape[0])
+
+    value_sum = np.zeros(n_channels, dtype=np.float64)
+    value_sq_sum = np.zeros(n_channels, dtype=np.float64)
+    valid_counts = np.zeros(n_channels, dtype=np.int64)
+
+    for row in history_cf_rows:
+        row_np = row.detach().cpu().numpy().astype(np.float64, copy=False)
+        valid_mask = ~np.isnan(row_np)
+        valid_counts += valid_mask.sum(axis=1).astype(np.int64)
+        value_sum += np.where(valid_mask, row_np, 0.0).sum(axis=1)
+        value_sq_sum += np.where(valid_mask, row_np * row_np, 0.0).sum(axis=1)
+
+    means = np.zeros(n_channels, dtype=np.float64)
+    non_empty_mask = valid_counts > 0
+    means[non_empty_mask] = value_sum[non_empty_mask] / valid_counts[non_empty_mask]
+
+    variances = np.zeros(n_channels, dtype=np.float64)
+    variances[non_empty_mask] = (
+        value_sq_sum[non_empty_mask] / valid_counts[non_empty_mask] - means[non_empty_mask] ** 2
+    )
+    variances = np.maximum(variances, 0.0)
+    stds = np.ones(n_channels, dtype=np.float64)
+    stds[non_empty_mask] = np.sqrt(variances[non_empty_mask])
+    stds[stds == 0.0] = 1.0
+
+    return ChannelStandardScalerStats(
+        means=means,
+        stds=stds,
+        valid_counts=valid_counts,
+    )
+
+
+def transform_history_cf(
+    history_cf: torch.Tensor,
+    stats: ChannelStandardScalerStats,
+) -> torch.Tensor:
+    """Apply channel-wise StandardScaler to a channel-first tensor, preserving NaN."""
+    output = history_cf.clone()
+    means = torch.as_tensor(stats.means, dtype=output.dtype, device=output.device).unsqueeze(1)
+    stds = torch.as_tensor(stats.stds, dtype=output.dtype, device=output.device).unsqueeze(1)
+    valid_mask = ~torch.isnan(output)
+    output[valid_mask] = ((output - means) / stds)[valid_mask]
+    return output
+
+
+def inverse_transform_history_cf(
+    history_cf: torch.Tensor,
+    stats: ChannelStandardScalerStats,
+) -> torch.Tensor:
+    """Invert channel-wise StandardScaler on a channel-first tensor, preserving NaN."""
+    output = history_cf.clone()
+    means = torch.as_tensor(stats.means, dtype=output.dtype, device=output.device).unsqueeze(1)
+    stds = torch.as_tensor(stats.stds, dtype=output.dtype, device=output.device).unsqueeze(1)
+    valid_mask = ~torch.isnan(output)
+    output[valid_mask] = (output * stds + means)[valid_mask]
+    return output
+
+
+def save_stats_json(
+    stats: ChannelStandardScalerStats,
+    output_path: str | Path,
+) -> Path:
+    """Persist scaler statistics as JSON."""
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "fit_scope": stats.fit_scope,
+        "n_channels": stats.n_channels,
+        "means": stats.means.tolist(),
+        "stds": stats.stds.tolist(),
+        "valid_counts": stats.valid_counts.tolist(),
+    }
+    output_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    return output_path
+
+
+def load_stats_json(input_path: str | Path) -> ChannelStandardScalerStats:
+    """Load scaler statistics from JSON."""
+    payload = json.loads(Path(input_path).read_text(encoding="utf-8"))
+    return ChannelStandardScalerStats(
+        means=np.asarray(payload["means"], dtype=np.float64),
+        stds=np.asarray(payload["stds"], dtype=np.float64),
+        valid_counts=np.asarray(payload["valid_counts"], dtype=np.int64),
+        fit_scope=str(payload.get("fit_scope", "train")),
+    )

--- a/src/forecasting_evaluation/io/__init__.py
+++ b/src/forecasting_evaluation/io/__init__.py
@@ -1,0 +1,6 @@
+"""IO utilities for forecasting evaluation."""
+
+from forecasting_evaluation.io.predict_result_writer import PredictResultWriter, PublicWriter
+from forecasting_evaluation.io.writer import ResultsWriter
+
+__all__ = ["PredictResultWriter", "PublicWriter", "ResultsWriter"]

--- a/src/forecasting_evaluation/io/predict_result_writer.py
+++ b/src/forecasting_evaluation/io/predict_result_writer.py
@@ -1,0 +1,277 @@
+"""Parquet writers for forecasting prediction results."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, is_dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from forecasting_evaluation.config import ForecastingEvalConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _make_type_nullable(data_type: Any, pa_module: Any) -> Any:
+    """Recursively rebuild pyarrow data types with nullable nested fields."""
+    if pa_module.types.is_struct(data_type):
+        return pa_module.struct(
+            [
+                pa_module.field(
+                    field.name,
+                    _make_type_nullable(field.type, pa_module),
+                    nullable=True,
+                    metadata=field.metadata,
+                )
+                for field in data_type
+            ]
+        )
+
+    if pa_module.types.is_list(data_type):
+        value_field = data_type.value_field
+        return pa_module.list_(
+            pa_module.field(
+                value_field.name,
+                _make_type_nullable(value_field.type, pa_module),
+                nullable=True,
+                metadata=value_field.metadata,
+            )
+        )
+
+    if pa_module.types.is_large_list(data_type):
+        value_field = data_type.value_field
+        return pa_module.large_list(
+            pa_module.field(
+                value_field.name,
+                _make_type_nullable(value_field.type, pa_module),
+                nullable=True,
+                metadata=value_field.metadata,
+            )
+        )
+
+    if pa_module.types.is_fixed_size_list(data_type):
+        value_field = data_type.value_field
+        return pa_module.list_(
+            pa_module.field(
+                value_field.name,
+                _make_type_nullable(value_field.type, pa_module),
+                nullable=True,
+                metadata=value_field.metadata,
+            )
+        )
+
+    return data_type
+
+
+def _make_schema_nullable(schema: Any, pa_module: Any) -> Any:
+    """Ensure all schema fields (including nested list/struct fields) are nullable."""
+    return pa_module.schema(
+        [
+            pa_module.field(
+                field.name,
+                _make_type_nullable(field.type, pa_module),
+                nullable=True,
+                metadata=field.metadata,
+            )
+            for field in schema
+        ],
+        metadata=schema.metadata,
+    )
+
+
+def to_serializable(value: Any) -> Any:
+    """Convert nested numpy objects to native Python types for parquet compatibility.
+
+    Handles non-finite floating values by normalizing them to NaN so nested
+    numeric arrays remain valid float arrays when written through PyArrow.
+    """
+    if isinstance(value, dict):
+        return {k: to_serializable(v) for k, v in value.items()}
+    if isinstance(value, list | tuple):
+        return [to_serializable(v) for v in value]
+    if isinstance(value, np.ndarray):
+        # Recursively process the list result to convert NaN/inf to None
+        list_value = value.tolist()
+        return to_serializable(list_value)
+    if isinstance(value, np.generic):
+        result = value.item()
+        # Keep nested numeric arrays float-typed for stable pyarrow conversion.
+        if isinstance(result, float) and not np.isfinite(result):
+            return float("nan")
+        return result
+    # Handle native Python floats
+    if isinstance(value, float):
+        if not np.isfinite(value):
+            return float("nan")
+    return value
+
+
+def sanitize_name(name: str) -> str:
+    """Convert name into filesystem-safe string."""
+    sanitized = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in name)
+    return sanitized or "unknown"
+
+
+class PublicWriter:
+    """Handle run-level metadata and shared output context."""
+
+    def __init__(
+        self,
+        config: ForecastingEvalConfig,
+        experiment_name: str | None = None,
+    ) -> None:
+        """Initialize run-level output context and metadata writer.
+
+        Args:
+            config: Forecasting evaluation config containing output settings.
+            experiment_name: Optional run namespace used under results_dir.
+        """
+        self.config = config
+
+        self.experiment_name = experiment_name or config.experiment_name or "Default"
+        self.experiment_dir = Path(config.output.results_dir) / self.experiment_name
+        self.experiment_dir.mkdir(parents=True, exist_ok=True)
+
+        self.model_dir: Path | None = None
+        self.model_name: str | None = None
+
+        self.total_written = 0
+        self.skipped_users = 0
+
+    def prepare_model_dir(self, model_name: str) -> Path:
+        """Create and return current model output directory under the experiment directory."""
+        model_dir_name = sanitize_name(model_name)
+        if self.experiment_name.startswith("Test"):
+            model_dir_name = f"{model_dir_name}_{datetime.now().strftime('%Y%m%d%H%M')}"
+
+        self.model_name = model_name
+        self.model_dir = self.experiment_dir / model_dir_name
+        self.model_dir.mkdir(parents=True, exist_ok=True)
+
+        if self.config.output.save_config:
+            self._save_run_config()
+        return self.model_dir
+
+    def get_user_file_path(self, user_id: str) -> Path:
+        """Get deterministic parquet file path for one user under current model directory."""
+        if self.model_dir is None:
+            raise RuntimeError("Model output directory is not initialized")
+        return self.model_dir / f"{sanitize_name(user_id)}.parquet"
+
+    def should_skip_user(self, user_id: str) -> bool:
+        """Return whether existing user parquet should be skipped under overwrite policy."""
+        if self.config.output.overwrite_existing_parquet:
+            return False
+        return self.get_user_file_path(user_id).exists()
+
+    def increment_written(self, count: int = 1) -> None:
+        """Increase global prediction row count."""
+        self.total_written += count
+
+    def increment_skipped_users(self, count: int = 1) -> None:
+        """Increase skipped user count when existing outputs are preserved."""
+        self.skipped_users += count
+
+    def finalize(self) -> Path:
+        """Finalize run-level output and return run directory."""
+        logger.info("Prediction write complete. Total samples: %d", self.total_written)
+        logger.info("Skipped users (existing parquet): %d", self.skipped_users)
+        if self.model_dir is None:
+            raise RuntimeError("Model output directory is not initialized")
+        logger.info("Run directory: %s", self.model_dir)
+        return self.model_dir
+
+    def _save_run_config(self) -> None:
+        """Persist run config for reproducibility."""
+        try:
+            if is_dataclass(self.config):
+                config_data = asdict(self.config)
+            else:
+                config_data = dict(self.config)
+        except Exception as exc:  # pragma: no cover
+            logger.warning("Failed to serialize run config: %s", exc)
+            return
+
+        if self.model_dir is None:
+            raise RuntimeError("Model output directory is not initialized")
+
+        yaml_path = self.model_dir / "config.yaml"
+        json_path = self.model_dir / "config.json"
+
+        try:
+            import yaml
+
+            with yaml_path.open("w", encoding="utf-8") as handle:
+                yaml.safe_dump(config_data, handle, sort_keys=False, allow_unicode=True)
+            return
+        except ImportError:
+            logger.warning("PyYAML not available, saving JSON config instead")
+        except Exception as exc:  # pragma: no cover
+            logger.warning("Failed writing YAML config, saving JSON config instead: %s", exc)
+
+        with json_path.open("w", encoding="utf-8") as handle:
+            json.dump(config_data, handle, indent=2, ensure_ascii=False)
+
+class PredictResultWriter:
+    """Write prediction rows for a single model/user pair."""
+
+    def __init__(self, model_dir: Path, user_id: str, overwrite_existing: bool = False) -> None:
+        """Initialize a parquet writer for one model-user output shard.
+
+        Args:
+            model_dir: Directory for one model output.
+            user_id: User identifier used in parquet filename.
+            overwrite_existing: Whether to overwrite existing user parquet.
+        """
+        try:
+            import pyarrow as pa
+            import pyarrow.parquet as pq
+        except ImportError as exc:
+            raise RuntimeError("pyarrow is required to write parquet prediction files") from exc
+
+        self._pa = pa
+        self._pq = pq
+        self.model_name = model_dir.name
+        self.user_id = user_id
+        self.records_written = 0
+
+        user_key = sanitize_name(user_id)
+        model_dir.mkdir(parents=True, exist_ok=True)
+        self.file_path = model_dir / f"{user_key}.parquet"
+
+        if self.file_path.exists() and not overwrite_existing:
+            raise FileExistsError(f"Prediction output already exists: {self.file_path}")
+
+        if self.file_path.exists() and overwrite_existing:
+            self.file_path.unlink()
+
+        self._writer: Any | None = None
+        self._schema: Any | None = None
+
+    def append(self, record: dict[str, Any]) -> None:
+        """Append one prediction row into the current parquet file."""
+        serializable_record = to_serializable(record)
+
+        if self._writer is None:
+            sample_table = self._pa.Table.from_pylist([serializable_record])
+            self._schema = _make_schema_nullable(sample_table.schema, self._pa)
+            self._writer = self._pq.ParquetWriter(self.file_path, self._schema)
+
+        table = self._pa.Table.from_pylist([serializable_record], schema=self._schema)
+        self._writer.write_table(table)
+        self.records_written += 1
+
+    def close(self) -> None:
+        """Close parquet writer for current model/user pair."""
+        if self._writer is None:
+            return
+
+        self._writer.close()
+        self._writer = None
+        self._schema = None
+        logger.debug("Finalized prediction file: %s (rows=%d)", self.file_path, self.records_written)

--- a/src/forecasting_evaluation/io/writer.py
+++ b/src/forecasting_evaluation/io/writer.py
@@ -1,0 +1,94 @@
+"""Results writing utilities for downstream evaluation."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:
+    from downstream_evaluation.config import DownstreamEvalConfig, OutputConfig
+
+logger = logging.getLogger(__name__)
+
+
+class ResultsWriter:
+    """Write evaluation results to JSON/CSV files."""
+
+    def __init__(self, config: OutputConfig, full_config: DownstreamEvalConfig):
+        """Initialize results writer.
+
+        Args:
+            config: Output configuration.
+            full_config: Full downstream evaluation config for saving.
+        """
+        self.config = config
+        self.full_config = full_config
+
+        # Generate experiment name if not provided
+        if config.experiment_name:
+            self.experiment_name = config.experiment_name
+        else:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            self.experiment_name = (
+                f"{full_config.data.task_name}_"
+                f"{full_config.features.type}_"
+                f"{full_config.classifier.type}_"
+                f"{timestamp}"
+            )
+
+        self.output_dir = Path(config.results_dir) / self.experiment_name
+
+    def write(self, results: dict) -> Path:
+        """Write results to output directory.
+
+        Creates:
+        - results.json: Full results with metrics
+        - config.yaml: Copy of config used
+        - predictions_val.csv: Per-user val predictions (if save_predictions=True)
+        - predictions_test.csv: Per-user test predictions (if save_predictions=True)
+
+        Args:
+            results: Results dictionary from evaluator.
+
+        Returns:
+            Path to output directory.
+        """
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Separate predictions for CSV output
+        predictions = results.pop("predictions", None)
+
+        # Write main results JSON
+        results_file = self.output_dir / "results.json"
+        with results_file.open("w") as f:
+            json.dump(results, f, indent=2)
+        logger.info(f"Saved results to {results_file}")
+
+        # Write config
+        if self.config.save_config:
+            config_file = self.output_dir / "config.yaml"
+            config_dict = asdict(self.full_config)
+            with config_file.open("w") as f:
+                yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
+            logger.info(f"Saved config to {config_file}")
+
+        # Write per-user predictions as CSV
+        if predictions and self.config.save_predictions:
+            try:
+                import pandas as pd
+
+                for split_name, pred_list in predictions.items():
+                    csv_file = self.output_dir / f"predictions_{split_name}.csv"
+                    pd.DataFrame(pred_list).to_csv(csv_file, index=False)
+                    logger.info(f"Saved predictions to {csv_file}")
+            except ImportError:
+                logger.warning("pandas not available, skipping CSV prediction output")
+
+        logger.info(f"Results saved to: {self.output_dir}")
+        return self.output_dir

--- a/src/forecasting_evaluation/metrics/binary_group_summary_metrics_result.py
+++ b/src/forecasting_evaluation/metrics/binary_group_summary_metrics_result.py
@@ -1,0 +1,563 @@
+"""Aggregate binary forecasting metrics into grouped sample-based summaries."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+_METRIC_NAMES = ("auprc", "auroc", "f1")
+_DEFAULT_GROUPS: tuple[tuple[str, tuple[int, ...]], ...] = (
+    ("sleep", (7, 8)),
+    ("workout", (9, 10, 11, 12, 13, 14, 15, 16, 17, 18)),
+)
+
+
+def _metric_display_name(metric_name: str) -> str:
+    normalized = metric_name.strip().lower()
+    if normalized == "auprc":
+        return "AUPRC"
+    if normalized == "auroc":
+        return "AUROC"
+    if normalized == "f1":
+        return "F1"
+    return metric_name
+
+
+def _safe_read_parquet(file_path: str | Path, **kwargs: Any) -> pd.DataFrame | None:
+    path = Path(file_path)
+    try:
+        if not path.exists() or path.stat().st_size == 0:
+            return None
+        return pd.read_parquet(path, **kwargs)
+    except Exception:
+        return None
+
+
+def _list_parquet_files(model_dir: str | Path) -> list[Path]:
+    path = Path(model_dir)
+    if not path.exists():
+        return []
+    return sorted(path.rglob("*.parquet"))
+
+
+def _safe_to_1d_float_array(value: Any) -> np.ndarray | None:
+    if value is None:
+        return None
+    try:
+        arr = np.asarray(value, dtype=float).reshape(-1)
+    except Exception:
+        return None
+    return arr if arr.ndim == 1 else None
+
+
+def _safe_to_1d_int_array(value: Any) -> np.ndarray | None:
+    if value is None:
+        return None
+    try:
+        arr = np.asarray(value, dtype=float).reshape(-1)
+    except Exception:
+        return None
+    return arr.astype(int) if arr.ndim == 1 else None
+
+
+def _parse_model_arg(model_arg: str) -> tuple[str, str]:
+    if "=" not in model_arg:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --model value: {model_arg}. Expected format: MODEL_NAME=/path/to/model_root"
+        )
+    model_name, model_dir = model_arg.split("=", 1)
+    model_name = model_name.strip()
+    model_dir = model_dir.strip()
+    if not model_name or not model_dir:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --model value: {model_arg}. Model name and path must be non-empty."
+        )
+    return model_name, model_dir
+
+
+def _parse_group_arg(group_arg: str) -> tuple[str, tuple[int, ...]]:
+    if "=" not in group_arg:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --group value: {group_arg}. Expected format: GROUP_NAME=7,8,9"
+        )
+    group_name, raw_indices = group_arg.split("=", 1)
+    group_name = group_name.strip()
+    if not group_name:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --group value: {group_arg}. Group name must be non-empty."
+        )
+
+    indices: list[int] = []
+    for part in raw_indices.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        indices.append(int(token))
+    if not indices:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --group value: {group_arg}. At least one channel index is required."
+        )
+    return group_name, tuple(indices)
+
+
+def _resolve_groups(group_args: list[str] | None) -> list[tuple[str, tuple[int, ...]]]:
+    if not group_args:
+        return [(name, tuple(indices)) for name, indices in _DEFAULT_GROUPS]
+
+    groups: list[tuple[str, tuple[int, ...]]] = []
+    seen_names: set[str] = set()
+    for item in group_args:
+        group_name, indices = _parse_group_arg(item)
+        if group_name in seen_names:
+            raise ValueError(f"Duplicate group name: {group_name}")
+        seen_names.add(group_name)
+        groups.append((group_name, indices))
+    return groups
+
+
+def _sample_occurrences(df: pd.DataFrame) -> pd.Series:
+    return df.groupby(["user_id", "history_length"]).cumcount()
+
+
+def _load_sample_metric_rows(
+    *,
+    model_name: str,
+    model_root: str | Path,
+    groups: list[tuple[str, tuple[int, ...]]],
+) -> pd.DataFrame:
+    root = Path(model_root)
+    f1_dir = root / "f1"
+    if not _list_parquet_files(f1_dir):
+        return pd.DataFrame()
+
+    sample_values: dict[tuple[str, int, int, str, str], list[float]] = {}
+    coverage: dict[tuple[str, int, int, str], dict[str, int]] = {}
+
+    for metric_name in _METRIC_NAMES:
+        metric_dir = root / metric_name
+        for parquet_file in _list_parquet_files(metric_dir):
+            df = _safe_read_parquet(
+                parquet_file,
+                columns=[
+                    "user_id",
+                    "history_length",
+                    metric_name,
+                    "binary_valid_count",
+                    "binary_positive_count",
+                    "binary_negative_count",
+                ],
+            )
+            if (
+                df is None
+                or "user_id" not in df.columns
+                or "history_length" not in df.columns
+                or metric_name not in df.columns
+            ):
+                continue
+
+            df = df.copy()
+            df["sample_occurrence"] = _sample_occurrences(df)
+            for row in df.itertuples(index=False):
+                user_id = str(getattr(row, "user_id"))
+                history_length = int(getattr(row, "history_length"))
+                sample_index = int(getattr(row, "sample_occurrence"))
+                metric_arr = _safe_to_1d_float_array(getattr(row, metric_name))
+                valid_arr = _safe_to_1d_int_array(getattr(row, "binary_valid_count"))
+                positive_arr = _safe_to_1d_int_array(getattr(row, "binary_positive_count"))
+                negative_arr = _safe_to_1d_int_array(getattr(row, "binary_negative_count"))
+                if (
+                    metric_arr is None
+                    or valid_arr is None
+                    or positive_arr is None
+                    or negative_arr is None
+                ):
+                    continue
+
+                n_features = min(
+                    metric_arr.shape[0],
+                    valid_arr.shape[0],
+                    positive_arr.shape[0],
+                    negative_arr.shape[0],
+                )
+                for group_name, channel_indices in groups:
+                    group_metric_values: list[float] = []
+                    group_valid_count = 0
+                    group_positive_count = 0
+                    group_negative_count = 0
+                    for channel_idx in channel_indices:
+                        if channel_idx < 0 or channel_idx >= n_features:
+                            continue
+                        group_valid_count += int(valid_arr[channel_idx])
+                        group_positive_count += int(positive_arr[channel_idx])
+                        group_negative_count += int(negative_arr[channel_idx])
+                        metric_value = float(metric_arr[channel_idx])
+                        if np.isfinite(metric_value):
+                            group_metric_values.append(metric_value)
+
+                    cov_key = (user_id, history_length, sample_index, group_name)
+                    if metric_name == "f1":
+                        coverage[cov_key] = {
+                            "valid_count": int(group_valid_count),
+                            "positive_count": int(group_positive_count),
+                            "negative_count": int(group_negative_count),
+                        }
+
+                    if group_metric_values:
+                        sample_values[(user_id, history_length, sample_index, group_name, metric_name)] = (
+                            group_metric_values
+                        )
+
+    rows: list[dict[str, Any]] = []
+    for (user_id, history_length, sample_index, group_name), cov in coverage.items():
+        if int(cov["positive_count"]) <= 0:
+            continue
+        for metric_name in _METRIC_NAMES:
+            values = sample_values.get((user_id, history_length, sample_index, group_name, metric_name), [])
+            metric_value = float(np.mean(values)) if values else float("nan")
+            rows.append(
+                {
+                    "model": model_name,
+                    "group_name": group_name,
+                    "user_id": user_id,
+                    "history_length": int(history_length),
+                    "sample_index": int(sample_index),
+                    "metric": metric_name,
+                    "metric_display": _metric_display_name(metric_name),
+                    "metric_value": metric_value,
+                    "valid_count": int(cov["valid_count"]),
+                    "positive_count": int(cov["positive_count"]),
+                    "negative_count": int(cov["negative_count"]),
+                }
+            )
+
+    return pd.DataFrame(rows)
+
+
+def _build_user_metric_rows(sample_metric_df: pd.DataFrame) -> pd.DataFrame:
+    if sample_metric_df.empty:
+        return pd.DataFrame(
+            columns=[
+                "model",
+                "group_name",
+                "user_id",
+                "metric",
+                "metric_display",
+                "metric_value",
+                "valid_count",
+                "positive_count",
+                "negative_count",
+            ]
+        )
+
+    key_columns = ["model", "group_name", "user_id", "metric", "metric_display"]
+    coverage_df = (
+        sample_metric_df.groupby(key_columns, as_index=False)
+        .agg(
+            valid_count=("valid_count", "sum"),
+            positive_count=("positive_count", "sum"),
+            negative_count=("negative_count", "sum"),
+        )
+    )
+
+    finite_df = sample_metric_df.loc[np.isfinite(sample_metric_df["metric_value"])].copy()
+    if finite_df.empty:
+        user_metric_df = coverage_df.copy()
+        user_metric_df["metric_value"] = np.nan
+        return user_metric_df[
+            [
+                "model",
+                "group_name",
+                "user_id",
+                "metric",
+                "metric_display",
+                "metric_value",
+                "valid_count",
+                "positive_count",
+                "negative_count",
+            ]
+        ]
+
+    metric_df = (
+        finite_df.groupby(key_columns, as_index=False)
+        .agg(metric_value=("metric_value", "mean"))
+    )
+    user_metric_df = coverage_df.merge(metric_df, on=key_columns, how="left")
+    return user_metric_df[
+        [
+            "model",
+            "group_name",
+            "user_id",
+            "metric",
+            "metric_display",
+            "metric_value",
+            "valid_count",
+            "positive_count",
+            "negative_count",
+        ]
+    ]
+
+
+def _compute_model_mean_ranks(sample_metric_df: pd.DataFrame) -> pd.DataFrame:
+    if sample_metric_df.empty:
+        return pd.DataFrame(
+            columns=["metric", "group_name", "model", "rank", "rank_n_samples"]
+        )
+
+    finite_df = sample_metric_df.loc[np.isfinite(sample_metric_df["metric_value"])].copy()
+    if finite_df.empty:
+        return pd.DataFrame(
+            columns=["metric", "group_name", "model", "rank", "rank_n_samples"]
+        )
+
+    rank_rows: list[pd.DataFrame] = []
+    for (metric_name, group_name), group_slice in finite_df.groupby(
+        ["metric", "group_name"],
+        sort=True,
+    ):
+        pivot = group_slice.pivot(
+            index=["user_id", "history_length", "sample_index"],
+            columns="model",
+            values="metric_value",
+        )
+        if pivot.empty:
+            continue
+
+        rank_df = pivot.rank(axis=1, method="average", ascending=False)
+        long_rank = rank_df.stack(future_stack=True).reset_index()
+        long_rank.columns = ["user_id", "history_length", "sample_index", "model", "rank"]
+        long_rank["metric"] = metric_name
+        long_rank["group_name"] = group_name
+        long_rank["sample_key"] = (
+            long_rank["user_id"].astype(str)
+            + "::"
+            + long_rank["history_length"].astype(str)
+            + "::"
+            + long_rank["sample_index"].astype(str)
+        )
+        rank_rows.append(long_rank)
+
+    if not rank_rows:
+        return pd.DataFrame(
+            columns=["metric", "group_name", "model", "rank", "rank_n_samples"]
+        )
+
+    rank_all = pd.concat(rank_rows, ignore_index=True)
+    return (
+        rank_all.groupby(["metric", "group_name", "model"], as_index=False)
+        .agg(rank=("rank", "mean"), rank_n_samples=("sample_key", "nunique"))
+    )
+
+
+def _build_summary(
+    user_metric_df: pd.DataFrame,
+    sample_metric_df: pd.DataFrame,
+    model_order: list[str],
+    group_order: list[str],
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    if user_metric_df.empty:
+        empty_long = pd.DataFrame(
+            columns=[
+                "metric",
+                "metric_display",
+                "group_name",
+                "model",
+                "metric_mean",
+                "rank",
+                "n_users",
+                "rank_n_samples",
+                "total_valid_count",
+                "total_positive_count",
+                "total_negative_count",
+            ]
+        )
+        return empty_long, pd.DataFrame(columns=["group_name", "metric", "metric_display"])
+
+    finite_df = user_metric_df.loc[np.isfinite(user_metric_df["metric_value"])].copy()
+    metric_means_df = (
+        finite_df.groupby(
+            ["metric", "metric_display", "group_name", "model"],
+            as_index=False,
+        )
+        .agg(
+            metric_mean=("metric_value", "mean"),
+            n_users=("user_id", "nunique"),
+            total_valid_count=("valid_count", "sum"),
+            total_positive_count=("positive_count", "sum"),
+            total_negative_count=("negative_count", "sum"),
+        )
+    )
+    rank_df = _compute_model_mean_ranks(sample_metric_df)
+    long_df = metric_means_df.merge(
+        rank_df,
+        on=["metric", "group_name", "model"],
+        how="left",
+    )
+    long_df["model"] = pd.Categorical(long_df["model"], categories=model_order, ordered=True)
+    long_df["group_name"] = pd.Categorical(
+        long_df["group_name"], categories=group_order, ordered=True
+    )
+    long_df = long_df.sort_values(["group_name", "metric", "model"]).reset_index(drop=True)
+
+    base_df = (
+        long_df[["group_name", "metric", "metric_display"]]
+        .drop_duplicates()
+        .sort_values(["group_name", "metric"])
+        .reset_index(drop=True)
+    )
+    wide_df = base_df.copy()
+    for model_name in model_order:
+        model_slice = long_df.loc[long_df["model"] == model_name].copy()
+        if model_slice.empty:
+            continue
+        model_slice = model_slice[
+            [
+                "group_name",
+                "metric",
+                "metric_mean",
+                "rank",
+                "n_users",
+                "rank_n_samples",
+            ]
+        ].rename(
+            columns={
+                "metric_mean": f"{model_name}_metric",
+                "rank": f"{model_name}_rank",
+                "n_users": f"{model_name}_n_users",
+                "rank_n_samples": f"{model_name}_rank_n_samples",
+            }
+        )
+        wide_df = wide_df.merge(model_slice, on=["group_name", "metric"], how="left")
+
+    return long_df, wide_df
+
+
+def _render_preview_table(wide_df: pd.DataFrame, model_order: list[str]) -> str:
+    if wide_df.empty:
+        return "(empty)"
+
+    preview_columns = ["group_name", "metric_display"]
+    for model_name in model_order:
+        if f"{model_name}_metric" not in wide_df.columns:
+            wide_df[f"{model_name}_metric"] = np.nan
+        if f"{model_name}_rank" not in wide_df.columns:
+            wide_df[f"{model_name}_rank"] = np.nan
+        preview_columns.extend([f"{model_name}_metric", f"{model_name}_rank"])
+
+    preview_df = wide_df[preview_columns].copy().rename(columns={"metric_display": "metric"})
+    for column in preview_df.columns:
+        if column.endswith("_metric") or column.endswith("_rank"):
+            preview_df[column] = preview_df[column].map(
+                lambda value: "/"
+                if pd.isna(value) or not np.isfinite(float(value))
+                else f"{float(value):.3f}"
+            )
+
+    widths = {
+        column: max(len(str(column)), preview_df[column].astype(str).map(len).max())
+        for column in preview_df.columns
+    }
+    header = " | ".join(str(column).ljust(widths[column]) for column in preview_df.columns)
+    divider = "-+-".join("-" * widths[column] for column in preview_df.columns)
+    body = [
+        " | ".join(str(row[column]).ljust(widths[column]) for column in preview_df.columns)
+        for _, row in preview_df.iterrows()
+    ]
+    return "\n".join([header, divider, *body])
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser for grouped binary metric summaries."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Aggregate binary forecasting metrics from local per-user parquet files "
+            "into grouped sample-based model summaries."
+        )
+    )
+    parser.add_argument(
+        "--model",
+        action="append",
+        required=True,
+        help="MODEL_NAME=/path/to/results/metrics/<model_root>",
+    )
+    parser.add_argument(
+        "--group",
+        action="append",
+        default=None,
+        help="GROUP_NAME=7,8,9. May be passed multiple times. Defaults to sleep/workout groups.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="results/metrics_summary",
+        help="Directory for generated summary CSV files.",
+    )
+    parser.add_argument(
+        "--output-prefix",
+        default="binary_group_metric_rank_summary",
+        help="Filename prefix for generated CSV files.",
+    )
+    return parser
+
+
+def main() -> None:
+    """Generate grouped binary metric summary outputs."""
+    args = build_parser().parse_args()
+    models = dict(_parse_model_arg(item) for item in args.model)
+    model_order = list(models.keys())
+    groups = _resolve_groups(args.group)
+    group_order = [group_name for group_name, _ in groups]
+
+    sample_frames: list[pd.DataFrame] = []
+    for model_name, model_root in models.items():
+        df = _load_sample_metric_rows(
+            model_name=model_name,
+            model_root=model_root,
+            groups=groups,
+        )
+        if not df.empty:
+            sample_frames.append(df)
+
+    if sample_frames:
+        sample_metric_df = pd.concat(sample_frames, ignore_index=True)
+    else:
+        sample_metric_df = pd.DataFrame()
+
+    user_metric_df = _build_user_metric_rows(sample_metric_df)
+    long_df, wide_df = _build_summary(
+        user_metric_df,
+        sample_metric_df,
+        model_order=model_order,
+        group_order=group_order,
+    )
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    user_output_path = output_dir / f"{args.output_prefix}_user_level_long.csv"
+    long_output_path = output_dir / f"{args.output_prefix}_long.csv"
+    wide_output_path = output_dir / f"{args.output_prefix}_wide.csv"
+
+    user_metric_df.to_csv(user_output_path, index=False)
+    long_df.to_csv(long_output_path, index=False)
+    wide_df.to_csv(wide_output_path, index=False)
+
+    print("=== Binary grouped metric/rank summary preview ===")
+    print(_render_preview_table(wide_df, model_order=model_order))
+    print(f"\nSaved user-level table: {user_output_path}")
+    print(f"Saved long table: {long_output_path}")
+    print(f"Saved wide table: {wide_output_path}")
+    print("Group rule: per-sample group metric is the mean of finite channel metrics within the group.")
+    print("Skip rule: if total positive_count for one sample/group is zero, skip that sample/group.")
+    print("Rank rule: rank models per (group, metric, sample), then average ranks over samples.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/forecasting_evaluation/metrics/binary_offline_calculate.py
+++ b/src/forecasting_evaluation/metrics/binary_offline_calculate.py
@@ -1,0 +1,468 @@
+"""CLI entry point for binary forecasting metrics calculation.
+
+This companion to ``offline_calculate.py`` computes per-sample binary-channel
+metrics from saved forecasting prediction parquets and stores them under the
+same metric-partitioned output tree:
+
+``results/metrics/<model_name>/{f1,auroc,auprc}/*.parquet``
+"""
+
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import average_precision_score, roc_auc_score
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from forecasting_evaluation.metrics.offline.channel_merge import (
+    merge_channel_first_array,
+    resolve_channel_merges,
+)
+from forecasting_evaluation.metrics.offline.common import (
+    coerce_2d_float_array,
+    coerce_non_negative_int,
+    get_model_name,
+    sanitize_name,
+)
+from forecasting_evaluation.metrics.offline.config_io import copy_run_config, load_run_config
+from forecasting_evaluation.metrics.offline.data_context import (
+    load_offline_user_contexts_from_eval_flow,
+)
+from forecasting_evaluation.metrics.offline.metric_core import slice_ground_truth
+from forecasting_evaluation.metrics.offline.parquet_io import (
+    index_prediction_files,
+    read_parquet_rows,
+)
+
+logger = logging.getLogger(__name__)
+
+_METRIC_NAMES = ("f1", "auroc", "auprc")
+
+
+def _parse_named_paths(items: list[str]) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for item in items:
+        if "=" not in item:
+            raise argparse.ArgumentTypeError(
+                f"Invalid run mapping '{item}', expected format: name=/abs/or/rel/path"
+            )
+        key, path = item.split("=", 1)
+        key = key.strip()
+        path = path.strip()
+        if not key or not path:
+            raise argparse.ArgumentTypeError(
+                f"Invalid run mapping '{item}', expected non-empty name and path"
+            )
+        parsed[key] = path
+    return parsed
+
+
+def _append_records_to_parquet(output_dir: Path, user_id: str, records: list[dict[str, Any]]) -> None:
+    if not records:
+        return
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_file = output_dir / f"{sanitize_name(user_id)}.parquet"
+    df_new = pd.DataFrame(records)
+    if output_file.exists():
+        df_existing = pd.read_parquet(output_file)
+        df = pd.concat([df_existing, df_new], ignore_index=True)
+    else:
+        df = df_new
+    df.to_parquet(output_file, engine="pyarrow", compression="snappy")
+
+
+def _save_binary_metrics_by_metric(
+    *,
+    output_root: Path,
+    model_key: str,
+    records_by_user: dict[str, list[dict[str, Any]]],
+) -> dict[str, dict[str, str]]:
+    saved: dict[str, dict[str, str]] = {}
+    for metric_name in _METRIC_NAMES:
+        metric_dir = output_root / metric_name
+        metric_saved: dict[str, str] = {}
+        for user_id, records in records_by_user.items():
+            metric_rows: list[dict[str, Any]] = []
+            for record in records:
+                metric_rows.append(
+                    {
+                        "user_id": record.get("user_id"),
+                        "model": record.get("model"),
+                        "history_length": record.get("history_length"),
+                        "forecasting_length": record.get("forecasting_length"),
+                        metric_name: record.get(metric_name),
+                        "binary_valid_count": record.get("binary_valid_count"),
+                        "binary_positive_count": record.get("binary_positive_count"),
+                        "binary_negative_count": record.get("binary_negative_count"),
+                    }
+                )
+            if metric_rows:
+                _append_records_to_parquet(metric_dir, user_id, metric_rows)
+                metric_saved[user_id] = str(metric_dir / f"{sanitize_name(user_id)}.parquet")
+        if metric_saved:
+            saved[metric_name] = metric_saved
+            logger.info(
+                "Saved binary metrics for model=%s metric=%s users=%d dir=%s",
+                model_key,
+                metric_name,
+                len(metric_saved),
+                metric_dir,
+            )
+    return saved
+
+
+def _compute_f1_from_scores(truth: np.ndarray, score: np.ndarray, threshold: float) -> float:
+    pred_binary = score >= float(threshold)
+    truth_binary = truth == 1.0
+    tp = int(np.sum(truth_binary & pred_binary))
+    fp = int(np.sum((~truth_binary) & pred_binary))
+    fn = int(np.sum(truth_binary & (~pred_binary)))
+    denominator = (2 * tp) + fp + fn
+    if denominator <= 0:
+        return float("nan")
+    return float((2.0 * tp) / denominator)
+
+
+def _compute_binary_metrics_for_sample(
+    *,
+    point_predictions: np.ndarray | None,
+    ground_truth: np.ndarray,
+    threshold: float,
+) -> dict[str, list[float]]:
+    n_features, _ = ground_truth.shape
+    f1 = np.full(n_features, np.nan, dtype=float)
+    auroc = np.full(n_features, np.nan, dtype=float)
+    auprc = np.full(n_features, np.nan, dtype=float)
+    valid_count = np.zeros(n_features, dtype=int)
+    positive_count = np.zeros(n_features, dtype=int)
+    negative_count = np.zeros(n_features, dtype=int)
+
+    if point_predictions is None or point_predictions.shape != ground_truth.shape:
+        return {
+            "f1": f1.tolist(),
+            "auroc": auroc.tolist(),
+            "auprc": auprc.tolist(),
+            "binary_valid_count": valid_count.tolist(),
+            "binary_positive_count": positive_count.tolist(),
+            "binary_negative_count": negative_count.tolist(),
+        }
+
+    for feature_idx in range(n_features):
+        truth_row = np.asarray(ground_truth[feature_idx], dtype=float).reshape(-1)
+        score_row = np.asarray(point_predictions[feature_idx], dtype=float).reshape(-1)
+        finite_mask = np.isfinite(truth_row) & np.isfinite(score_row)
+        if not np.any(finite_mask):
+            continue
+
+        truth_values = truth_row[finite_mask]
+        score_values = score_row[finite_mask]
+        positive_mask = truth_values == 1.0
+        negative_mask = truth_values == 0.0
+        binary_mask = positive_mask | negative_mask
+        if not np.any(binary_mask):
+            continue
+
+        truth_binary = truth_values[binary_mask]
+        score_binary = score_values[binary_mask]
+        n_positive = int(np.sum(truth_binary == 1.0))
+        n_negative = int(np.sum(truth_binary == 0.0))
+        positive_count[feature_idx] = n_positive
+        negative_count[feature_idx] = n_negative
+        valid_count[feature_idx] = int(truth_binary.shape[0])
+
+        if n_positive <= 0:
+            continue
+
+        f1[feature_idx] = _compute_f1_from_scores(
+            truth=truth_binary,
+            score=score_binary,
+            threshold=threshold,
+        )
+        auprc[feature_idx] = float(average_precision_score(truth_binary, score_binary))
+        if n_negative > 0:
+            auroc[feature_idx] = float(roc_auc_score(truth_binary, score_binary))
+
+    return {
+        "f1": f1.tolist(),
+        "auroc": auroc.tolist(),
+        "auprc": auprc.tolist(),
+        "binary_valid_count": valid_count.tolist(),
+        "binary_positive_count": positive_count.tolist(),
+        "binary_negative_count": negative_count.tolist(),
+    }
+
+
+class BinaryOfflineMetricsPipeline:
+    """Compute and persist per-sample binary metrics for one forecasting run."""
+
+    def __init__(
+        self,
+        *,
+        run_key: str,
+        run_path: Path,
+        metrics_output_path: Path,
+        threshold: float,
+        max_user: int | None = None,
+    ):
+        """Initialize binary metric generation for one forecasting run."""
+        self.run_key = str(run_key)
+        self.run_path = Path(run_path)
+        self.metrics_output_path = Path(metrics_output_path)
+        self.threshold = float(threshold)
+        self.max_user = int(max_user) if max_user is not None else None
+
+    def run(self) -> dict[str, Any]:
+        """Compute and save binary metrics for one forecasting run."""
+        config = load_run_config(self.run_path)
+        forecast_length = int(config.forecasting.forecasting_length)
+        model_name = get_model_name(config.model)
+        prediction_files = index_prediction_files(self.run_path, model_name)
+
+        output_run_dir = self.metrics_output_path / sanitize_name(self.run_key)
+        copy_run_config(self.run_path, output_run_dir)
+
+        user_contexts = load_offline_user_contexts_from_eval_flow(
+            config=config,
+            prediction_files=prediction_files,
+        )
+        for user_context in user_contexts.values():
+            history = np.asarray(user_context["history"], dtype=float)
+            variable_names = list(user_context["variable_names"])
+            merge_plan = resolve_channel_merges(variable_names)
+            user_context["history"] = merge_channel_first_array(history, merge_plan)
+            user_context["merge_plan"] = merge_plan
+
+        prediction_rows_by_user: dict[str, list[dict[str, Any]]] = {}
+        for user_id, parquet_paths in prediction_files.items():
+            rows: list[dict[str, Any]] = []
+            for parquet_path in parquet_paths:
+                rows.extend(read_parquet_rows(parquet_path))
+            if rows:
+                prediction_rows_by_user[user_id] = rows
+
+        records_by_user: dict[str, list[dict[str, Any]]] = {}
+        saved_rows = 0
+        skipped_rows = 0
+        computed_user_count = 0
+
+        for user_id, user_context in user_contexts.items():
+            if self.max_user is not None and computed_user_count >= self.max_user:
+                logger.info(
+                    "Reached max_user limit for binary metrics run=%s max_user=%s",
+                    self.run_key,
+                    self.max_user,
+                )
+                break
+
+            user_metrics_file = output_run_dir / "f1" / f"{sanitize_name(user_id)}.parquet"
+            if user_metrics_file.exists():
+                logger.info(
+                    "Binary metrics parquet for user exists, skipping. run=%s user=%s file=%s",
+                    self.run_key,
+                    user_id,
+                    user_metrics_file,
+                )
+                continue
+
+            history = np.asarray(user_context["history"], dtype=float)
+            merge_plan = user_context["merge_plan"]
+            user_records: list[dict[str, Any]] = []
+            for row in prediction_rows_by_user.get(user_id, []):
+                history_length = coerce_non_negative_int(row.get("history_length"))
+                if history_length is None:
+                    skipped_rows += 1
+                    continue
+
+                gt_pack = slice_ground_truth(
+                    history=history,
+                    history_length=history_length,
+                    forecast_length=forecast_length,
+                )
+                if gt_pack is None:
+                    skipped_rows += 1
+                    continue
+
+                ground_truth, _ = gt_pack
+                point_predictions = merge_channel_first_array(
+                    coerce_2d_float_array(row.get("point_predictions")),
+                    merge_plan,
+                )
+                metrics_output = _compute_binary_metrics_for_sample(
+                    point_predictions=point_predictions,
+                    ground_truth=ground_truth,
+                    threshold=self.threshold,
+                )
+                record = {
+                    "user_id": user_id,
+                    "model": model_name,
+                    "history_length": history_length,
+                    "forecasting_length": forecast_length,
+                    "f1": metrics_output["f1"],
+                    "auroc": metrics_output["auroc"],
+                    "auprc": metrics_output["auprc"],
+                    "binary_valid_count": metrics_output["binary_valid_count"],
+                    "binary_positive_count": metrics_output["binary_positive_count"],
+                    "binary_negative_count": metrics_output["binary_negative_count"],
+                }
+                user_records.append(record)
+                saved_rows += 1
+
+            if user_records:
+                records_by_user[user_id] = user_records
+                computed_user_count += 1
+
+        saved_files_by_metric = _save_binary_metrics_by_metric(
+            output_root=output_run_dir,
+            model_key=sanitize_name(model_name),
+            records_by_user=records_by_user,
+        )
+        return {
+            "run_key": self.run_key,
+            "run_path": str(self.run_path),
+            "model_name": model_name,
+            "saved_rows": saved_rows,
+            "skipped_rows": skipped_rows,
+            "computed_user_count": computed_user_count,
+            "threshold": self.threshold,
+            "output_run_dir": str(output_run_dir),
+            "saved_files_by_metric": saved_files_by_metric,
+        }
+
+
+class BinaryOfflineMetricsCalculator:
+    """Orchestrate binary offline metric generation across forecasting runs."""
+
+    def __init__(
+        self,
+        *,
+        evaluation_result_paths: dict[str, str],
+        metrics_output_path: str,
+        threshold: float,
+        max_user: int | None = None,
+    ):
+        """Initialize binary metric generation across forecasting runs."""
+        self.evaluation_result_paths = {
+            str(name): Path(path) for name, path in evaluation_result_paths.items()
+        }
+        self.metrics_output_path = Path(metrics_output_path)
+        self.metrics_output_path.mkdir(parents=True, exist_ok=True)
+        self.threshold = float(threshold)
+        self.max_user = int(max_user) if max_user is not None else None
+
+    def run(self) -> dict[str, Any]:
+        """Run binary metric generation for all configured runs."""
+        run_summaries: list[dict[str, Any]] = []
+        for run_key, run_path in self.evaluation_result_paths.items():
+            if not run_path.exists():
+                logger.warning("Run path does not exist for key=%s, skipped: %s", run_key, run_path)
+                continue
+
+            logger.info("Processing binary metrics for key=%s run path=%s", run_key, run_path)
+            pipeline = BinaryOfflineMetricsPipeline(
+                run_key=run_key,
+                run_path=run_path,
+                metrics_output_path=self.metrics_output_path,
+                threshold=self.threshold,
+                max_user=self.max_user,
+            )
+            run_summaries.append(pipeline.run())
+
+        return {
+            "runs": run_summaries,
+            "total_runs": len(run_summaries),
+            "total_saved_rows": int(sum(summary["saved_rows"] for summary in run_summaries)),
+            "total_skipped_rows": int(sum(summary["skipped_rows"] for summary in run_summaries)),
+        }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser for binary offline metric calculation."""
+    parser = argparse.ArgumentParser(
+        description="Compute per-sample binary forecasting metrics from saved forecasting outputs.",
+    )
+    parser.add_argument(
+        "--evaluation-result-paths",
+        "--run-dirs",
+        nargs="+",
+        default=[],
+        help=(
+            "One or more named forecasting run mappings in key=path format. "
+            "Each path should point to one model output directory containing "
+            "config.yaml and user parquet files."
+        ),
+    )
+    parser.add_argument(
+        "--metrics-output-path",
+        "--output-dir",
+        default="/home/lp925/code/MHC-benchmark/results/metrics",
+        help="Root output directory to store offline metrics results.",
+    )
+    parser.add_argument(
+        "--f1-threshold",
+        type=float,
+        default=0.5,
+        help="Threshold used to binarize continuous scores for F1.",
+    )
+    parser.add_argument(
+        "--max-user",
+        type=int,
+        default=None,
+        help="Optional sequential cap on how many user parquet files to compute per run.",
+    )
+    return parser
+
+
+def main() -> None:
+    """Run binary offline metric calculation from CLI arguments."""
+    args = build_parser().parse_args()
+    if not args.evaluation_result_paths:
+        raise ValueError("Please provide --evaluation-result-paths in key=path format")
+    evaluation_result_paths = _parse_named_paths(args.evaluation_result_paths)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    calculator = BinaryOfflineMetricsCalculator(
+        evaluation_result_paths=evaluation_result_paths,
+        metrics_output_path=args.metrics_output_path,
+        threshold=float(args.f1_threshold),
+        max_user=args.max_user,
+    )
+    summary = calculator.run()
+    compact_summary = {
+        "total_runs": summary.get("total_runs"),
+        "total_saved_rows": summary.get("total_saved_rows"),
+        "total_skipped_rows": summary.get("total_skipped_rows"),
+        "runs": [
+            {
+                "run_key": run_summary.get("run_key"),
+                "model_name": run_summary.get("model_name"),
+                "saved_rows": run_summary.get("saved_rows"),
+                "skipped_rows": run_summary.get("skipped_rows"),
+                "computed_user_count": run_summary.get("computed_user_count"),
+                "threshold": run_summary.get("threshold"),
+                "output_run_dir": run_summary.get("output_run_dir"),
+            }
+            for run_summary in summary.get("runs", [])
+        ],
+    }
+    logging.getLogger(__name__).info("Binary offline metrics finished: %s", compact_summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/forecasting_evaluation/metrics/binary_summary_metrics_result.py
+++ b/src/forecasting_evaluation/metrics/binary_summary_metrics_result.py
@@ -1,0 +1,437 @@
+"""Aggregate binary forecasting metrics from local per-user parquet files."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from visualizations.constants import CHANNEL_INFO  # noqa: E402
+
+_METRIC_NAMES = ("auprc", "auroc", "f1")
+
+
+def _metric_display_name(metric_name: str) -> str:
+    normalized = metric_name.strip().lower()
+    if normalized == "auprc":
+        return "AUPRC"
+    if normalized == "auroc":
+        return "AUROC"
+    if normalized == "f1":
+        return "F1"
+    return metric_name
+
+
+def _channel_label(channel_idx: int) -> str:
+    metadata = CHANNEL_INFO.get(channel_idx)
+    if metadata is None:
+        return f"Channel {channel_idx}"
+    return str(metadata["name"])
+
+
+def _safe_read_parquet(file_path: str | Path, **kwargs: Any) -> pd.DataFrame | None:
+    path = Path(file_path)
+    try:
+        if not path.exists() or path.stat().st_size == 0:
+            return None
+        return pd.read_parquet(path, **kwargs)
+    except Exception:
+        return None
+
+
+def _list_parquet_files(model_dir: str | Path) -> list[Path]:
+    path = Path(model_dir)
+    if not path.exists():
+        return []
+    return sorted(path.rglob("*.parquet"))
+
+
+def _safe_to_1d_float_array(value: Any) -> np.ndarray | None:
+    if value is None:
+        return None
+    try:
+        arr = np.asarray(value, dtype=float).reshape(-1)
+    except Exception:
+        return None
+    return arr if arr.ndim == 1 else None
+
+
+def _safe_to_1d_int_array(value: Any) -> np.ndarray | None:
+    if value is None:
+        return None
+    try:
+        arr = np.asarray(value, dtype=float).reshape(-1)
+    except Exception:
+        return None
+    return arr.astype(int) if arr.ndim == 1 else None
+
+
+def _parse_model_arg(model_arg: str) -> tuple[str, str]:
+    if "=" not in model_arg:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --model value: {model_arg}. Expected format: MODEL_NAME=/path/to/model_root"
+        )
+    model_name, model_dir = model_arg.split("=", 1)
+    model_name = model_name.strip()
+    model_dir = model_dir.strip()
+    if not model_name or not model_dir:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --model value: {model_arg}. Model name and path must be non-empty."
+        )
+    return model_name, model_dir
+
+
+def _parse_channel_indices(raw_value: str | None) -> tuple[int, ...]:
+    if raw_value is None or not raw_value.strip():
+        return tuple(range(7, 19))
+
+    indices: list[int] = []
+    for part in raw_value.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        indices.append(int(token))
+
+    if not indices:
+        raise ValueError("At least one channel index must be provided.")
+    return tuple(indices)
+
+
+def _load_user_metric_rows(
+    *,
+    model_name: str,
+    model_root: str | Path,
+    channel_indices: tuple[int, ...],
+) -> pd.DataFrame:
+    root = Path(model_root)
+    f1_dir = root / "f1"
+    files = _list_parquet_files(f1_dir)
+    if not files:
+        return pd.DataFrame()
+
+    sample_values: dict[tuple[str, int, str], list[float]] = {}
+    coverage: dict[tuple[str, int], dict[str, int]] = {}
+
+    for metric_name in _METRIC_NAMES:
+        metric_dir = root / metric_name
+        for parquet_file in _list_parquet_files(metric_dir):
+            df = _safe_read_parquet(
+                parquet_file,
+                columns=[
+                    "user_id",
+                    metric_name,
+                    "binary_valid_count",
+                    "binary_positive_count",
+                    "binary_negative_count",
+                ],
+            )
+            if (
+                df is None
+                or "user_id" not in df.columns
+                or metric_name not in df.columns
+            ):
+                continue
+
+            for _, row in df.iterrows():
+                user_id = str(row.get("user_id"))
+                metric_arr = _safe_to_1d_float_array(row.get(metric_name))
+                valid_arr = _safe_to_1d_int_array(row.get("binary_valid_count"))
+                positive_arr = _safe_to_1d_int_array(row.get("binary_positive_count"))
+                negative_arr = _safe_to_1d_int_array(row.get("binary_negative_count"))
+                if (
+                    metric_arr is None
+                    or valid_arr is None
+                    or positive_arr is None
+                    or negative_arr is None
+                ):
+                    continue
+
+                n_features = min(
+                    metric_arr.shape[0],
+                    valid_arr.shape[0],
+                    positive_arr.shape[0],
+                    negative_arr.shape[0],
+                )
+                for channel_idx in channel_indices:
+                    if channel_idx < 0 or channel_idx >= n_features:
+                        continue
+
+                    cov_key = (user_id, int(channel_idx))
+                    coverage_entry = coverage.setdefault(
+                        cov_key,
+                        {"valid_count": 0, "positive_count": 0, "negative_count": 0},
+                    )
+                    if metric_name == "f1":
+                        coverage_entry["valid_count"] += int(valid_arr[channel_idx])
+                        coverage_entry["positive_count"] += int(positive_arr[channel_idx])
+                        coverage_entry["negative_count"] += int(negative_arr[channel_idx])
+
+                    metric_value = float(metric_arr[channel_idx])
+                    if np.isfinite(metric_value):
+                        sample_values.setdefault(
+                            (user_id, int(channel_idx), metric_name),
+                            [],
+                        ).append(metric_value)
+
+    rows: list[dict[str, Any]] = []
+    for (user_id, channel_idx), cov in coverage.items():
+        if int(cov["positive_count"]) <= 0:
+            continue
+        for metric_name in _METRIC_NAMES:
+            values = sample_values.get((user_id, channel_idx, metric_name), [])
+            metric_value = float(np.mean(values)) if values else float("nan")
+            rows.append(
+                {
+                    "model": model_name,
+                    "channel_idx": int(channel_idx),
+                    "channel_name": _channel_label(channel_idx),
+                    "user_id": user_id,
+                    "metric": metric_name,
+                    "metric_display": _metric_display_name(metric_name),
+                    "metric_value": metric_value,
+                    "valid_count": int(cov["valid_count"]),
+                    "positive_count": int(cov["positive_count"]),
+                    "negative_count": int(cov["negative_count"]),
+                }
+            )
+
+    return pd.DataFrame(rows)
+
+
+def _compute_model_mean_ranks(user_metric_df: pd.DataFrame) -> pd.DataFrame:
+    if user_metric_df.empty:
+        return pd.DataFrame(
+            columns=["metric", "channel_idx", "model", "rank", "rank_n_users"]
+        )
+
+    finite_df = user_metric_df.loc[np.isfinite(user_metric_df["metric_value"])].copy()
+    if finite_df.empty:
+        return pd.DataFrame(
+            columns=["metric", "channel_idx", "model", "rank", "rank_n_users"]
+        )
+
+    rank_rows: list[pd.DataFrame] = []
+    for (metric_name, channel_idx), group_slice in finite_df.groupby(
+        ["metric", "channel_idx"],
+        sort=True,
+    ):
+        pivot = group_slice.pivot(index="user_id", columns="model", values="metric_value")
+        if pivot.empty:
+            continue
+
+        rank_df = pivot.rank(axis=1, method="average", ascending=False)
+        long_rank = rank_df.stack(future_stack=True).reset_index()
+        long_rank.columns = ["user_id", "model", "rank"]
+        long_rank["metric"] = metric_name
+        long_rank["channel_idx"] = int(channel_idx)
+        rank_rows.append(long_rank)
+
+    if not rank_rows:
+        return pd.DataFrame(
+            columns=["metric", "channel_idx", "model", "rank", "rank_n_users"]
+        )
+
+    rank_all = pd.concat(rank_rows, ignore_index=True)
+    return (
+        rank_all.groupby(["metric", "channel_idx", "model"], as_index=False)
+        .agg(rank=("rank", "mean"), rank_n_users=("user_id", "nunique"))
+    )
+
+
+def _build_summary(user_metric_df: pd.DataFrame, model_order: list[str]) -> tuple[pd.DataFrame, pd.DataFrame]:
+    if user_metric_df.empty:
+        empty_long = pd.DataFrame(
+            columns=[
+                "metric",
+                "metric_display",
+                "channel_idx",
+                "channel_name",
+                "model",
+                "metric_mean",
+                "rank",
+                "n_users",
+                "rank_n_users",
+                "total_valid_count",
+                "total_positive_count",
+                "total_negative_count",
+            ]
+        )
+        return empty_long, pd.DataFrame(columns=["channel_idx", "channel_name", "metric"])
+
+    finite_df = user_metric_df.loc[np.isfinite(user_metric_df["metric_value"])].copy()
+    metric_means_df = (
+        finite_df.groupby(
+            ["metric", "metric_display", "channel_idx", "channel_name", "model"],
+            as_index=False,
+        )
+        .agg(
+            metric_mean=("metric_value", "mean"),
+            n_users=("user_id", "nunique"),
+            total_valid_count=("valid_count", "sum"),
+            total_positive_count=("positive_count", "sum"),
+            total_negative_count=("negative_count", "sum"),
+        )
+    )
+    rank_df = _compute_model_mean_ranks(user_metric_df)
+    long_df = metric_means_df.merge(
+        rank_df,
+        on=["metric", "channel_idx", "model"],
+        how="left",
+    )
+    long_df["model"] = pd.Categorical(long_df["model"], categories=model_order, ordered=True)
+    long_df = long_df.sort_values(["channel_idx", "metric", "model"]).reset_index(drop=True)
+
+    base_df = (
+        long_df[["channel_idx", "channel_name", "metric", "metric_display"]]
+        .drop_duplicates()
+        .sort_values(["channel_idx", "metric"])
+        .reset_index(drop=True)
+    )
+    wide_df = base_df.copy()
+    for model_name in model_order:
+        model_slice = long_df.loc[long_df["model"] == model_name].copy()
+        if model_slice.empty:
+            continue
+        model_slice = model_slice[
+            [
+                "channel_idx",
+                "metric",
+                "metric_mean",
+                "rank",
+                "n_users",
+                "rank_n_users",
+            ]
+        ].rename(
+            columns={
+                "metric_mean": f"{model_name}_metric",
+                "rank": f"{model_name}_rank",
+                "n_users": f"{model_name}_n_users",
+                "rank_n_users": f"{model_name}_rank_n_users",
+            }
+        )
+        wide_df = wide_df.merge(model_slice, on=["channel_idx", "metric"], how="left")
+
+    return long_df, wide_df
+
+
+def _render_preview_table(wide_df: pd.DataFrame, model_order: list[str]) -> str:
+    if wide_df.empty:
+        return "(empty)"
+
+    preview_columns = ["channel_idx", "channel_name", "metric_display"]
+    for model_name in model_order:
+        if f"{model_name}_metric" not in wide_df.columns:
+            wide_df[f"{model_name}_metric"] = np.nan
+        if f"{model_name}_rank" not in wide_df.columns:
+            wide_df[f"{model_name}_rank"] = np.nan
+        preview_columns.extend([f"{model_name}_metric", f"{model_name}_rank"])
+
+    preview_df = wide_df[preview_columns].copy().rename(columns={"metric_display": "metric"})
+    for column in preview_df.columns:
+        if column.endswith("_metric") or column.endswith("_rank"):
+            preview_df[column] = preview_df[column].map(
+                lambda value: "/"
+                if pd.isna(value) or not np.isfinite(float(value))
+                else f"{float(value):.3f}"
+            )
+
+    widths = {
+        column: max(len(str(column)), preview_df[column].astype(str).map(len).max())
+        for column in preview_df.columns
+    }
+    header = " | ".join(str(column).ljust(widths[column]) for column in preview_df.columns)
+    divider = "-+-".join("-" * widths[column] for column in preview_df.columns)
+    body = [
+        " | ".join(str(row[column]).ljust(widths[column]) for column in preview_df.columns)
+        for _, row in preview_df.iterrows()
+    ]
+    return "\n".join([header, divider, *body])
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser for binary channel metric summaries."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Aggregate binary forecasting metrics from local per-user parquet files "
+            "into channel-level model summaries."
+        )
+    )
+    parser.add_argument(
+        "--model",
+        action="append",
+        required=True,
+        help="MODEL_NAME=/path/to/results/metrics/<model_root>",
+    )
+    parser.add_argument(
+        "--channel-indices",
+        default="7,8,9,10,11,12,13,14,15,16,17,18",
+        help="Comma-separated binary channel indices. Defaults to 7-18.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="results/metrics_summary",
+        help="Directory for generated summary CSV files.",
+    )
+    parser.add_argument(
+        "--output-prefix",
+        default="binary_metric_rank_summary_channels_7_18",
+        help="Filename prefix for generated CSV files.",
+    )
+    return parser
+
+
+def main() -> None:
+    """Generate binary channel metric summary outputs."""
+    args = build_parser().parse_args()
+    models = dict(_parse_model_arg(item) for item in args.model)
+    model_order = list(models.keys())
+    channel_indices = _parse_channel_indices(args.channel_indices)
+
+    frames: list[pd.DataFrame] = []
+    for model_name, model_root in models.items():
+        df = _load_user_metric_rows(
+            model_name=model_name,
+            model_root=model_root,
+            channel_indices=channel_indices,
+        )
+        if not df.empty:
+            frames.append(df)
+
+    if frames:
+        user_metric_df = pd.concat(frames, ignore_index=True)
+    else:
+        user_metric_df = pd.DataFrame()
+
+    long_df, wide_df = _build_summary(user_metric_df, model_order=model_order)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    user_output_path = output_dir / f"{args.output_prefix}_user_level_long.csv"
+    long_output_path = output_dir / f"{args.output_prefix}_long.csv"
+    wide_output_path = output_dir / f"{args.output_prefix}_wide.csv"
+
+    user_metric_df.to_csv(user_output_path, index=False)
+    long_df.to_csv(long_output_path, index=False)
+    wide_df.to_csv(wide_output_path, index=False)
+
+    print("=== Binary metric/rank summary preview ===")
+    print(_render_preview_table(wide_df, model_order=model_order))
+    print(f"\nSaved user-level table: {user_output_path}")
+    print(f"Saved long table: {long_output_path}")
+    print(f"Saved wide table: {wide_output_path}")
+    print("User-level rule: mean over finite sample-level metrics within one (model, user, channel).")
+    print("Skip rule: if total positive_count for a user/channel is zero, skip that user/channel.")
+    print("Model-level rule: mean over finite user-level metric values only.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/forecasting_evaluation/metrics/fairness_skill_score_summary.py
+++ b/src/forecasting_evaluation/metrics/fairness_skill_score_summary.py
@@ -1,0 +1,765 @@
+"""Compute forecasting fairness-adjusted skill scores.
+
+This paper-result helper follows the unified scoring definition used for the
+benchmark: task errors are converted to ratios against a fixed baseline,
+clipped, then aggregated with a geometric mean. For subgroup scores, model
+errors are subgroup-specific while baseline errors remain global full-test
+errors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from forecasting_evaluation.metrics.skill_score_summary import (  # noqa: E402
+    _channel_label,
+    _list_parquet_files,
+    _load_models_dict,
+    _metric_channel_value,
+    _metric_to_error,
+    _parse_channel_indices,
+    _safe_read_parquet,
+    _safe_to_metric_array,
+)
+
+DEFAULT_AGE_BINS = (18, 30, 40, 50, 60)
+DEFAULT_DEMOGRAPHIC_ATTRS = ("age_group", "sex")
+
+
+def _load_compute_static_age():
+    """Load ``compute_static_age`` from the repository script."""
+    script_path = REPO_ROOT / "scripts" / "build_static_age.py"
+    spec = importlib.util.spec_from_file_location("_forecasting_static_age", script_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.compute_static_age
+
+
+def _last_value(entries: dict[str, Any], user_id: str) -> Any | None:
+    item = entries.get(user_id)
+    if not isinstance(item, dict):
+        return None
+    values = item.get("values") or []
+    if not values:
+        return None
+    return values[-1]
+
+
+def bin_age(age: float | int | None, age_bins: tuple[int, ...] = DEFAULT_AGE_BINS) -> str:
+    """Bin an age into the benchmark demographic buckets."""
+    if age is None or not np.isfinite(float(age)):
+        return "unknown"
+    age_value = float(age)
+    for idx in range(len(age_bins) - 1):
+        if age_bins[idx] <= age_value < age_bins[idx + 1]:
+            return f"{age_bins[idx]}-{age_bins[idx + 1] - 1}"
+    if age_value >= age_bins[-1]:
+        return f"{age_bins[-1]}+"
+    return "unknown"
+
+
+def normalize_sex(value: Any) -> str:
+    """Normalize BiologicalSex values to male/female/unknown."""
+    if isinstance(value, bool):
+        return "male" if value else "female"
+    if isinstance(value, (int, float)) and np.isfinite(float(value)):
+        if int(value) == 1:
+            return "male"
+        if int(value) == 0:
+            return "female"
+    if isinstance(value, str):
+        token = value.strip().lower()
+        if token in {"male", "m", "man", "true", "1"}:
+            return "male"
+        if token in {"female", "f", "woman", "false", "0"}:
+            return "female"
+    return "unknown"
+
+
+def load_user_demographics(
+    *,
+    user_ids: set[str],
+    labels_path: str | Path,
+    enrollment_path: str | Path,
+) -> dict[str, dict[str, str]]:
+    """Load age-group and sex labels for the requested users."""
+    labels_file = Path(labels_path)
+    enrollment_file = Path(enrollment_path)
+    with labels_file.open("r", encoding="utf-8") as file:
+        labels_data = json.load(file)
+    with enrollment_file.open("r", encoding="utf-8") as file:
+        enrollment = json.load(file)
+
+    compute_static_age = _load_compute_static_age()
+    age_entries = compute_static_age(labels_data, enrollment)
+    sex_entries = labels_data.get("BiologicalSex", {})
+
+    demographics: dict[str, dict[str, str]] = {}
+    for user_id in sorted(user_ids):
+        age_value = _last_value(age_entries, user_id)
+        sex_value = _last_value(sex_entries, user_id)
+        demographics[user_id] = {
+            "age_group": bin_age(float(age_value) if age_value is not None else None),
+            "sex": normalize_sex(sex_value),
+        }
+    return demographics
+
+
+def _load_metric_values(
+    *,
+    model_name: str,
+    model_root: str | Path,
+    metric_name: str,
+    channel_indices: tuple[int, ...],
+    group_name: str,
+) -> pd.DataFrame:
+    metric_dir = Path(model_root) / metric_name
+    per_user_values: dict[tuple[str, int, str], list[float]] = {}
+
+    for parquet_file in _list_parquet_files(metric_dir):
+        df = _safe_read_parquet(
+            parquet_file,
+            columns=["user_id", "history_length", "forecasting_length", metric_name],
+        )
+        if df is None or "user_id" not in df.columns or metric_name not in df.columns:
+            continue
+
+        for _, row in df.iterrows():
+            user_id = str(row.get("user_id"))
+            metric = _safe_to_metric_array(row.get(metric_name))
+            if metric is None:
+                continue
+            for channel_idx in channel_indices:
+                value = _metric_channel_value(metric=metric, channel_idx=channel_idx)
+                if not np.isfinite(value):
+                    continue
+                error = _metric_to_error(metric_name=metric_name, metric_value=value)
+                if not np.isfinite(error):
+                    continue
+                key = (user_id, int(channel_idx), metric_name)
+                per_user_values.setdefault(key, []).append(error)
+
+    rows: list[dict[str, Any]] = []
+    for (user_id, channel_idx, metric), values in per_user_values.items():
+        finite = np.asarray(values, dtype=float)
+        finite = finite[np.isfinite(finite)]
+        if finite.size == 0:
+            continue
+        rows.append(
+            {
+                "model": model_name,
+                "group": group_name,
+                "metric": metric,
+                "channel_idx": int(channel_idx),
+                "channel_name": _channel_label(channel_idx),
+                "user_id": user_id,
+                "error": float(np.mean(finite)),
+                "n_values": int(finite.size),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _build_error_table(
+    *,
+    models: dict[str, dict[str, str]],
+    continuous_metrics: list[str],
+    binary_metrics: list[str],
+    continuous_channel_indices: tuple[int, ...],
+    binary_channel_indices: tuple[int, ...],
+) -> pd.DataFrame:
+    frames: list[pd.DataFrame] = []
+    metric_groups = {
+        "continuous": (
+            [metric.strip().lower() for metric in continuous_metrics if metric.strip()],
+            continuous_channel_indices,
+        ),
+        "binary": (
+            [metric.strip().lower() for metric in binary_metrics if metric.strip()],
+            binary_channel_indices,
+        ),
+    }
+    for group_name, (metric_names, channel_indices) in metric_groups.items():
+        for model_name, model_spec in models.items():
+            for metric_name in metric_names:
+                frame = _load_metric_values(
+                    model_name=model_name,
+                    model_root=model_spec["path"],
+                    metric_name=metric_name,
+                    channel_indices=channel_indices,
+                    group_name=group_name,
+                )
+                if not frame.empty:
+                    frames.append(frame)
+
+    columns = [
+        "model",
+        "group",
+        "metric",
+        "channel_idx",
+        "channel_name",
+        "user_id",
+        "error",
+        "n_values",
+    ]
+    if not frames:
+        return pd.DataFrame(columns=columns)
+    return pd.concat(frames, ignore_index=True)
+
+
+def _task_cols() -> list[str]:
+    return ["group", "metric", "channel_idx", "channel_name"]
+
+
+def _score_from_ratios(ratios: np.ndarray, clip_lower: float, clip_upper: float) -> float:
+    valid = np.asarray(ratios, dtype=float)
+    valid = valid[np.isfinite(valid) & (valid > 0.0)]
+    if valid.size == 0:
+        return float("nan")
+    clipped = np.clip(valid, float(clip_lower), float(clip_upper))
+    return float(1.0 - np.exp(np.mean(np.log(clipped))))
+
+
+def _build_task_errors(error_df: pd.DataFrame) -> pd.DataFrame:
+    if error_df.empty:
+        return pd.DataFrame(columns=["model", *_task_cols(), "error", "n_users"])
+    grouped = error_df.groupby(["model", *_task_cols()], sort=True)
+    return grouped.agg(
+        error=("error", "mean"),
+        n_users=("user_id", "nunique"),
+    ).reset_index()
+
+
+def _compute_global_scores(
+    *,
+    task_errors: pd.DataFrame,
+    models: dict[str, dict[str, str]],
+    baseline_model: str,
+    clip_lower: float,
+    clip_upper: float,
+) -> pd.DataFrame:
+    columns = [
+        "model",
+        "skill_score",
+        "geometric_mean_ratio",
+        "n_tasks",
+        "mean_error",
+        "baseline_error_mean",
+    ]
+    if task_errors.empty:
+        return pd.DataFrame(columns=columns)
+
+    baseline = task_errors.loc[task_errors["model"] == baseline_model].copy()
+    if baseline.empty:
+        raise ValueError(f"Baseline model '{baseline_model}' has no readable metric rows.")
+    baseline_lookup = baseline.set_index(_task_cols())["error"]
+
+    rows: list[dict[str, Any]] = []
+    for model_name in models:
+        model_tasks = task_errors.loc[task_errors["model"] == model_name]
+        ratios: list[float] = []
+        model_errors: list[float] = []
+        baseline_errors: list[float] = []
+        for _, row in model_tasks.iterrows():
+            key = tuple(row[col] for col in _task_cols())
+            if key not in baseline_lookup.index:
+                continue
+            baseline_error = float(baseline_lookup.loc[key])
+            model_error = float(row["error"])
+            if baseline_error <= 0 or not np.isfinite(baseline_error):
+                continue
+            if not np.isfinite(model_error):
+                continue
+            ratios.append(model_error / baseline_error)
+            model_errors.append(model_error)
+            baseline_errors.append(baseline_error)
+
+        ratios_arr = np.asarray(ratios, dtype=float)
+        skill = _score_from_ratios(ratios_arr, clip_lower, clip_upper)
+        gm_ratio = (
+            float(np.exp(np.mean(np.log(np.clip(ratios_arr, clip_lower, clip_upper)))))
+            if ratios_arr.size
+            else float("nan")
+        )
+        rows.append(
+            {
+                "model": model_name,
+                "skill_score": skill,
+                "geometric_mean_ratio": gm_ratio,
+                "n_tasks": int(ratios_arr.size),
+                "mean_error": float(np.mean(model_errors)) if model_errors else float("nan"),
+                "baseline_error_mean": (
+                    float(np.mean(baseline_errors)) if baseline_errors else float("nan")
+                ),
+            }
+        )
+    return pd.DataFrame(rows, columns=columns)
+
+
+def _compute_average_ranks(task_errors: pd.DataFrame) -> pd.DataFrame:
+    if task_errors.empty:
+        return pd.DataFrame(columns=["model", "avg_rank", "n_ranked_tasks"])
+    ranked = task_errors.copy()
+    ranked["rank"] = ranked.groupby(_task_cols())["error"].rank(
+        method="average",
+        ascending=True,
+    )
+    return ranked.groupby("model", sort=True).agg(
+        avg_rank=("rank", "mean"),
+        n_ranked_tasks=("rank", "count"),
+    ).reset_index()
+
+
+def _compute_subgroup_scores(
+    *,
+    error_df: pd.DataFrame,
+    demographics: dict[str, dict[str, str]],
+    models: dict[str, dict[str, str]],
+    baseline_model: str,
+    clip_lower: float,
+    clip_upper: float,
+    demographic_attrs: tuple[str, ...] = DEFAULT_DEMOGRAPHIC_ATTRS,
+) -> pd.DataFrame:
+    columns = [
+        "model",
+        "demographic_attr",
+        "subgroup",
+        "skill_score",
+        "geometric_mean_ratio",
+        "n_tasks",
+        "n_units",
+    ]
+    if error_df.empty:
+        return pd.DataFrame(columns=columns)
+
+    baseline_task_errors = _build_task_errors(error_df.loc[error_df["model"] == baseline_model])
+    baseline_lookup = baseline_task_errors.set_index(_task_cols())["error"]
+
+    with_demo = error_df.copy()
+    for attr in demographic_attrs:
+        with_demo[attr] = with_demo["user_id"].map(
+            lambda uid, attr=attr: demographics.get(str(uid), {}).get(attr, "unknown")
+        )
+
+    rows: list[dict[str, Any]] = []
+    for attr in demographic_attrs:
+        for (model_name, subgroup), group_df in with_demo.groupby(["model", attr], sort=True):
+            task_means = group_df.groupby(_task_cols(), sort=True).agg(
+                error=("error", "mean"),
+                n_units=("user_id", "nunique"),
+            ).reset_index()
+            ratios: list[float] = []
+            n_units = set(group_df["user_id"].astype(str).tolist())
+            for _, row in task_means.iterrows():
+                key = tuple(row[col] for col in _task_cols())
+                if key not in baseline_lookup.index:
+                    continue
+                baseline_error = float(baseline_lookup.loc[key])
+                model_error = float(row["error"])
+                if baseline_error <= 0 or not np.isfinite(baseline_error):
+                    continue
+                if not np.isfinite(model_error):
+                    continue
+                ratios.append(model_error / baseline_error)
+
+            ratios_arr = np.asarray(ratios, dtype=float)
+            skill = _score_from_ratios(ratios_arr, clip_lower, clip_upper)
+            gm_ratio = (
+                float(np.exp(np.mean(np.log(np.clip(ratios_arr, clip_lower, clip_upper)))))
+                if ratios_arr.size
+                else float("nan")
+            )
+            rows.append(
+                {
+                    "model": model_name,
+                    "demographic_attr": attr,
+                    "subgroup": str(subgroup),
+                    "skill_score": skill,
+                    "geometric_mean_ratio": gm_ratio,
+                    "n_tasks": int(ratios_arr.size),
+                    "n_units": len(n_units),
+                }
+            )
+
+    if not rows:
+        return pd.DataFrame(columns=columns)
+    ordered_models = list(models)
+    result = pd.DataFrame(rows, columns=columns)
+    result["model"] = pd.Categorical(result["model"], categories=ordered_models, ordered=True)
+    return result.sort_values(["demographic_attr", "model", "subgroup"]).reset_index(drop=True)
+
+
+def _build_fairness_summary(
+    *,
+    subgroup_df: pd.DataFrame,
+    global_df: pd.DataFrame,
+    lambda_fairness: float,
+) -> pd.DataFrame:
+    columns = [
+        "model",
+        "demographic_attr",
+        "S_overall",
+        "disparity",
+        "best_group",
+        "worst_group",
+        "lambda",
+        "attr_fairness_adjusted_score",
+    ]
+    rows: list[dict[str, Any]] = []
+    global_lookup = global_df.set_index("model")["skill_score"] if not global_df.empty else {}
+
+    for (model_name, attr), group_df in subgroup_df.groupby(
+        ["model", "demographic_attr"],
+        sort=True,
+        observed=False,
+    ):
+        valid = group_df[np.isfinite(group_df["skill_score"])]
+        if valid.shape[0] >= 2:
+            best_idx = valid["skill_score"].idxmax()
+            worst_idx = valid["skill_score"].idxmin()
+            best_group = str(valid.loc[best_idx, "subgroup"])
+            worst_group = str(valid.loc[worst_idx, "subgroup"])
+            disparity = float(valid.loc[best_idx, "skill_score"] - valid.loc[worst_idx, "skill_score"])
+        else:
+            best_group = ""
+            worst_group = ""
+            disparity = float("nan")
+
+        overall = float(global_lookup.loc[model_name]) if model_name in global_lookup.index else float("nan")
+        rows.append(
+            {
+                "model": str(model_name),
+                "demographic_attr": attr,
+                "S_overall": overall,
+                "disparity": disparity,
+                "best_group": best_group,
+                "worst_group": worst_group,
+                "lambda": float(lambda_fairness),
+                "attr_fairness_adjusted_score": overall - float(lambda_fairness) * disparity,
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame(columns=columns)
+    return pd.DataFrame(rows, columns=columns)
+
+
+def _build_model_summary(
+    *,
+    global_df: pd.DataFrame,
+    fairness_df: pd.DataFrame,
+    ranks_df: pd.DataFrame,
+    models: dict[str, dict[str, str]],
+    lambda_fairness: float,
+) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    global_lookup = global_df.set_index("model") if not global_df.empty else pd.DataFrame()
+    ranks_lookup = ranks_df.set_index("model") if not ranks_df.empty else pd.DataFrame()
+
+    for model_name in models:
+        overall = (
+            float(global_lookup.loc[model_name, "skill_score"])
+            if model_name in global_lookup.index
+            else float("nan")
+        )
+        avg_rank = (
+            float(ranks_lookup.loc[model_name, "avg_rank"])
+            if model_name in ranks_lookup.index
+            else float("nan")
+        )
+        n_ranked_tasks = (
+            int(ranks_lookup.loc[model_name, "n_ranked_tasks"])
+            if model_name in ranks_lookup.index
+            else 0
+        )
+        model_fairness = fairness_df.loc[fairness_df["model"] == model_name]
+        disparities = {
+            str(row["demographic_attr"]): float(row["disparity"])
+            for _, row in model_fairness.iterrows()
+            if np.isfinite(float(row["disparity"]))
+        }
+        mean_disparity = (
+            float(np.mean(list(disparities.values()))) if disparities else float("nan")
+        )
+        rows.append(
+            {
+                "model": model_name,
+                "S_overall": overall,
+                "avg_rank": avg_rank,
+                "n_ranked_tasks": n_ranked_tasks,
+                "age_group_disparity": disparities.get("age_group", float("nan")),
+                "sex_disparity": disparities.get("sex", float("nan")),
+                "mean_disparity": mean_disparity,
+                "lambda": float(lambda_fairness),
+                "fairness_adjusted_skill_score": overall
+                - float(lambda_fairness) * mean_disparity,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _build_channel_summary(
+    *,
+    error_df: pd.DataFrame,
+    task_errors: pd.DataFrame,
+    demographics: dict[str, dict[str, str]],
+    models: dict[str, dict[str, str]],
+    baseline_model: str,
+    clip_lower: float,
+    clip_upper: float,
+    lambda_fairness: float,
+) -> pd.DataFrame:
+    columns = [
+        "model",
+        "group",
+        "channel_idx",
+        "channel_name",
+        "S_overall",
+        "avg_rank",
+        "n_ranked_tasks",
+        "age_group_disparity",
+        "sex_disparity",
+        "mean_disparity",
+        "lambda",
+        "fairness_adjusted_skill_score",
+    ]
+    if error_df.empty or task_errors.empty:
+        return pd.DataFrame(columns=columns)
+
+    channel_keys = (
+        task_errors[["group", "channel_idx", "channel_name"]]
+        .drop_duplicates()
+        .sort_values(["group", "channel_idx"])
+        .to_dict("records")
+    )
+    frames: list[pd.DataFrame] = []
+    for channel in channel_keys:
+        group_name = channel["group"]
+        channel_idx = int(channel["channel_idx"])
+        channel_name = channel["channel_name"]
+        task_slice = task_errors.loc[
+            (task_errors["group"] == group_name)
+            & (task_errors["channel_idx"] == channel_idx)
+        ]
+        error_slice = error_df.loc[
+            (error_df["group"] == group_name)
+            & (error_df["channel_idx"] == channel_idx)
+        ]
+        channel_global_df = _compute_global_scores(
+            task_errors=task_slice,
+            models=models,
+            baseline_model=baseline_model,
+            clip_lower=clip_lower,
+            clip_upper=clip_upper,
+        )
+        channel_ranks_df = _compute_average_ranks(task_slice)
+        channel_subgroup_df = _compute_subgroup_scores(
+            error_df=error_slice,
+            demographics=demographics,
+            models=models,
+            baseline_model=baseline_model,
+            clip_lower=clip_lower,
+            clip_upper=clip_upper,
+        )
+        channel_fairness_df = _build_fairness_summary(
+            subgroup_df=channel_subgroup_df,
+            global_df=channel_global_df,
+            lambda_fairness=lambda_fairness,
+        )
+        channel_model_df = _build_model_summary(
+            global_df=channel_global_df,
+            fairness_df=channel_fairness_df,
+            ranks_df=channel_ranks_df,
+            models=models,
+            lambda_fairness=lambda_fairness,
+        )
+        channel_model_df.insert(1, "group", group_name)
+        channel_model_df.insert(2, "channel_idx", channel_idx)
+        channel_model_df.insert(3, "channel_name", channel_name)
+        frames.append(channel_model_df)
+
+    if not frames:
+        return pd.DataFrame(columns=columns)
+    result = pd.concat(frames, ignore_index=True)
+    return result[columns].sort_values(["group", "channel_idx", "model"]).reset_index(drop=True)
+
+
+def compute_fairness_skill_score_tables(
+    *,
+    models: dict[str, dict[str, str]],
+    baseline_model: str,
+    continuous_metrics: list[str],
+    binary_metrics: list[str],
+    continuous_channel_indices: tuple[int, ...],
+    binary_channel_indices: tuple[int, ...],
+    clip_lower: float,
+    clip_upper: float,
+    lambda_fairness: float,
+    labels_path: str | Path | None = None,
+    enrollment_path: str | Path | None = None,
+    demographics: dict[str, dict[str, str]] | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Compute subgroup, fairness, model-summary, and channel-summary tables."""
+    if baseline_model not in models:
+        raise ValueError(
+            f"Baseline model '{baseline_model}' is not in model config. "
+            f"Available models: {', '.join(models)}"
+        )
+    if clip_lower <= 0 or clip_upper <= 0 or clip_lower > clip_upper:
+        raise ValueError("clip bounds must be positive with lower <= upper")
+    if lambda_fairness < 0:
+        raise ValueError("lambda_fairness must be non-negative")
+
+    error_df = _build_error_table(
+        models=models,
+        continuous_metrics=continuous_metrics,
+        binary_metrics=binary_metrics,
+        continuous_channel_indices=continuous_channel_indices,
+        binary_channel_indices=binary_channel_indices,
+    )
+    task_errors = _build_task_errors(error_df)
+    global_df = _compute_global_scores(
+        task_errors=task_errors,
+        models=models,
+        baseline_model=baseline_model,
+        clip_lower=clip_lower,
+        clip_upper=clip_upper,
+    )
+    ranks_df = _compute_average_ranks(task_errors)
+
+    if demographics is None:
+        if labels_path is None or enrollment_path is None:
+            raise ValueError("labels_path and enrollment_path are required without demographics")
+        demographics = load_user_demographics(
+            user_ids=set(error_df["user_id"].astype(str).tolist()),
+            labels_path=labels_path,
+            enrollment_path=enrollment_path,
+        )
+
+    subgroup_df = _compute_subgroup_scores(
+        error_df=error_df,
+        demographics=demographics,
+        models=models,
+        baseline_model=baseline_model,
+        clip_lower=clip_lower,
+        clip_upper=clip_upper,
+    )
+    fairness_df = _build_fairness_summary(
+        subgroup_df=subgroup_df,
+        global_df=global_df,
+        lambda_fairness=lambda_fairness,
+    )
+    model_summary_df = _build_model_summary(
+        global_df=global_df,
+        fairness_df=fairness_df,
+        ranks_df=ranks_df,
+        models=models,
+        lambda_fairness=lambda_fairness,
+    )
+    channel_summary_df = _build_channel_summary(
+        error_df=error_df,
+        task_errors=task_errors,
+        demographics=demographics,
+        models=models,
+        baseline_model=baseline_model,
+        clip_lower=clip_lower,
+        clip_upper=clip_upper,
+        lambda_fairness=lambda_fairness,
+    )
+    return subgroup_df, fairness_df, model_summary_df, channel_summary_df
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+    parser = argparse.ArgumentParser(
+        description="Compute forecasting fairness-adjusted skill scores."
+    )
+    parser.add_argument("--config", default=None, help="JSON/YAML config with model mappings.")
+    parser.add_argument("--models-json", default=None, help="Inline JSON model mapping.")
+    parser.add_argument("--baseline", required=True, help="Baseline model key from config.")
+    parser.add_argument("--continuous-channel-indices", default="0,1,2,3,4,5,6")
+    parser.add_argument("--continuous-metrics", nargs="+", default=["mase", "sql"])
+    parser.add_argument("--binary-channel-indices", default="7,8,9,10,11,12,13,14,15,16,17,18")
+    parser.add_argument("--binary-metrics", nargs="+", default=["mse", "f1"])
+    parser.add_argument("--clip-lower", type=float, default=0.01)
+    parser.add_argument("--clip-upper", type=float, default=100.0)
+    parser.add_argument("--lambda-fairness", type=float, default=0.5)
+    parser.add_argument("--labels-path", default="data/labels/last_labels.json")
+    parser.add_argument("--enrollment-path", default="data/labels/enrollment_info.json")
+    parser.add_argument("--output-dir", default="results/metrics_summary")
+    parser.add_argument("--output-prefix", default="paper_forecasting_fairness_skill_score")
+    return parser
+
+
+def main() -> None:
+    """Generate forecasting fairness skill score CSV outputs."""
+    args = build_parser().parse_args()
+    models = _load_models_dict(args)
+    continuous_channel_indices = _parse_channel_indices(
+        args.continuous_channel_indices,
+        default=tuple(range(0, 7)),
+    )
+    binary_channel_indices = _parse_channel_indices(
+        args.binary_channel_indices,
+        default=tuple(range(7, 19)),
+    )
+
+    subgroup_df, fairness_df, model_summary_df, channel_summary_df = (
+        compute_fairness_skill_score_tables(
+            models=models,
+            baseline_model=args.baseline,
+            continuous_metrics=list(args.continuous_metrics),
+            binary_metrics=list(args.binary_metrics),
+            continuous_channel_indices=continuous_channel_indices,
+            binary_channel_indices=binary_channel_indices,
+            clip_lower=float(args.clip_lower),
+            clip_upper=float(args.clip_upper),
+            lambda_fairness=float(args.lambda_fairness),
+            labels_path=args.labels_path,
+            enrollment_path=args.enrollment_path,
+        )
+    )
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    subgroup_path = output_dir / f"{args.output_prefix}_subgroup_scores.csv"
+    fairness_path = output_dir / f"{args.output_prefix}_fairness_summary.csv"
+    model_summary_path = output_dir / f"{args.output_prefix}_model_summary.csv"
+    channel_summary_path = output_dir / f"{args.output_prefix}_channel_summary.csv"
+
+    subgroup_df.to_csv(subgroup_path, index=False)
+    fairness_df.to_csv(fairness_path, index=False)
+    model_summary_df.to_csv(model_summary_path, index=False)
+    channel_summary_df.to_csv(channel_summary_path, index=False)
+
+    print("=== Forecasting fairness skill score summary ===")
+    if model_summary_df.empty:
+        print("(empty)")
+    else:
+        print(model_summary_df.to_string(index=False))
+    print(f"\nSaved subgroup scores: {subgroup_path}")
+    print(f"Saved fairness summary: {fairness_path}")
+    print(f"Saved model summary: {model_summary_path}")
+    print(f"Saved channel summary: {channel_summary_path}")
+    print(f"Baseline: {args.baseline}")
+    print(f"Ratio clip: [{args.clip_lower}, {args.clip_upper}]")
+    print(f"Lambda fairness: {args.lambda_fairness}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/forecasting_evaluation/metrics/grouped_metric_rank_summary.py
+++ b/src/forecasting_evaluation/metrics/grouped_metric_rank_summary.py
@@ -1,0 +1,606 @@
+"""Grouped forecasting metric/rank summary for continuous and binary scopes.
+
+This script combines the reporting shape used by the continuous channel summary
+and binary group summary:
+
+* continuous channels are reported one channel at a time;
+* binary channels are reported as configured groups, defaulting to sleep
+  channels 7-8 and workout channels 9-18.
+
+The minimal unit before model-level aggregation is ``(metric, channel_idx,
+user_id)``. For binary groups, channel-level user metrics are averaged within
+each group/user before model means and ranks are computed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+_CHANNEL_CONSTANTS_PATH = SRC_ROOT / "visualizations" / "constants.py"
+_CHANNEL_SPEC = importlib.util.spec_from_file_location(
+    "_forecasting_grouped_metric_channel_constants",
+    _CHANNEL_CONSTANTS_PATH,
+)
+if _CHANNEL_SPEC is None or _CHANNEL_SPEC.loader is None:
+    CHANNEL_INFO = {}
+else:
+    _channel_module = importlib.util.module_from_spec(_CHANNEL_SPEC)
+    _CHANNEL_SPEC.loader.exec_module(_channel_module)
+    CHANNEL_INFO = getattr(_channel_module, "CHANNEL_INFO", {})
+
+LOWER_IS_BETTER_METRICS = {"mae", "mse", "mase", "mase_all", "ql", "sql"}
+HIGHER_IS_BETTER_METRICS = {"f1", "auprc", "auroc"}
+DEFAULT_CONTINUOUS_CHANNELS = tuple(range(0, 7))
+DEFAULT_BINARY_GROUPS: tuple[tuple[str, tuple[int, ...]], ...] = (
+    ("sleep", (7, 8)),
+    ("workout", tuple(range(9, 19))),
+)
+
+
+def _safe_read_parquet(file_path: str | Path, **kwargs: Any) -> pd.DataFrame | None:
+    path = Path(file_path)
+    try:
+        if not path.exists() or path.stat().st_size == 0:
+            return None
+        return pd.read_parquet(path, **kwargs)
+    except Exception:
+        return None
+
+
+def _list_parquet_files(path: str | Path) -> list[Path]:
+    root = Path(path)
+    if not root.exists():
+        return []
+    return sorted(root.rglob("*.parquet"))
+
+
+def _channel_label(channel_idx: int) -> str:
+    metadata = CHANNEL_INFO.get(int(channel_idx))
+    if metadata is None:
+        return f"Channel {channel_idx}"
+    return str(metadata["name"])
+
+
+def _metric_display_name(metric_name: str) -> str:
+    normalized = metric_name.strip().lower()
+    mapping = {
+        "mae": "MAE",
+        "mse": "MSE",
+        "mase": "MASE",
+        "mase_all": "MASE_all",
+        "ql": "QL",
+        "sql": "sQL",
+        "f1": "F1",
+        "auprc": "AUPRC",
+        "auroc": "AUROC",
+    }
+    return mapping.get(normalized, metric_name)
+
+
+def _metric_lower_is_better(metric_name: str) -> bool:
+    metric_key = metric_name.strip().lower()
+    if metric_key in LOWER_IS_BETTER_METRICS:
+        return True
+    if metric_key in HIGHER_IS_BETTER_METRICS:
+        return False
+    raise ValueError(
+        f"Unknown metric '{metric_name}'. Add it to lower- or higher-is-better sets."
+    )
+
+
+def _parse_channel_indices(raw_value: str | None, default: tuple[int, ...]) -> tuple[int, ...]:
+    if raw_value is None or not raw_value.strip():
+        return default
+    indices = [int(token.strip()) for token in raw_value.split(",") if token.strip()]
+    if not indices:
+        raise ValueError("At least one channel index must be provided.")
+    return tuple(indices)
+
+
+def _parse_group_arg(group_arg: str) -> tuple[str, tuple[int, ...]]:
+    if "=" not in group_arg:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --binary-group value: {group_arg}. Expected GROUP=7,8"
+        )
+    group_name, raw_indices = group_arg.split("=", 1)
+    group_name = group_name.strip()
+    if not group_name:
+        raise argparse.ArgumentTypeError("Binary group name must be non-empty.")
+    indices = [int(token.strip()) for token in raw_indices.split(",") if token.strip()]
+    if not indices:
+        raise argparse.ArgumentTypeError("Binary group must include at least one channel.")
+    return group_name, tuple(indices)
+
+
+def _resolve_binary_groups(group_args: list[str] | None) -> list[tuple[str, tuple[int, ...]]]:
+    if not group_args:
+        return [(name, tuple(indices)) for name, indices in DEFAULT_BINARY_GROUPS]
+    groups: list[tuple[str, tuple[int, ...]]] = []
+    seen: set[str] = set()
+    for item in group_args:
+        name, indices = _parse_group_arg(item)
+        if name in seen:
+            raise ValueError(f"Duplicate binary group name: {name}")
+        seen.add(name)
+        groups.append((name, indices))
+    return groups
+
+
+def _load_models_dict(args: argparse.Namespace) -> dict[str, dict[str, str]]:
+    if args.models_json:
+        parsed = json.loads(args.models_json)
+    elif args.config:
+        config_path = Path(args.config)
+        if not config_path.exists():
+            raise ValueError(f"Config file not found: {config_path}")
+        if config_path.suffix.lower() in {".yaml", ".yml"}:
+            try:
+                import yaml
+            except ImportError as exc:
+                raise ImportError("PyYAML is required for yaml config input") from exc
+            with config_path.open("r", encoding="utf-8") as file:
+                parsed = yaml.safe_load(file)
+        else:
+            with config_path.open("r", encoding="utf-8") as file:
+                parsed = json.load(file)
+    else:
+        raise ValueError("Please provide --models-json or --config")
+
+    if isinstance(parsed, dict) and "models" in parsed:
+        parsed = parsed["models"]
+
+    models: dict[str, dict[str, str]] = {}
+    if isinstance(parsed, dict):
+        for key, value in parsed.items():
+            model_name = str(key).strip()
+            if isinstance(value, dict):
+                model_path = str(value.get("path", "")).strip()
+                display_name = str(value.get("display_name", model_name)).strip()
+            else:
+                model_path = str(value).strip()
+                display_name = model_name
+            if not model_name or not model_path:
+                raise ValueError("Model configuration must use non-empty model names and paths")
+            models[model_name] = {
+                "path": model_path,
+                "display_name": display_name or model_name,
+            }
+    elif isinstance(parsed, list):
+        for item in parsed:
+            if not isinstance(item, dict):
+                raise ValueError("Model configuration list entries must be dictionaries")
+            model_name = str(item.get("name", "")).strip()
+            model_path = str(item.get("path", "")).strip()
+            display_name = str(item.get("display_name", model_name)).strip()
+            if not model_name or not model_path:
+                raise ValueError("Each model entry must contain non-empty name and path")
+            models[model_name] = {
+                "path": model_path,
+                "display_name": display_name or model_name,
+            }
+    else:
+        raise ValueError("Model configuration must be a dict or list")
+
+    if not models:
+        raise ValueError("No model mappings found in configuration")
+    return models
+
+
+def _safe_to_metric_array(value: Any) -> np.ndarray | None:
+    if value is None:
+        return None
+    try:
+        arr = np.asarray(value, dtype=float)
+        if arr.ndim in {1, 2}:
+            return arr
+    except Exception:
+        pass
+
+    try:
+        obj = np.asarray(value, dtype=object)
+    except Exception:
+        return None
+    if obj.ndim != 1:
+        return None
+    rows: list[np.ndarray] = []
+    for item in obj.tolist():
+        try:
+            row = np.asarray(item, dtype=float).reshape(-1)
+        except Exception:
+            return None
+        if row.size == 0:
+            return None
+        rows.append(row)
+    if not rows:
+        return None
+    min_len = min(row.shape[0] for row in rows)
+    if min_len <= 0:
+        return None
+    return np.vstack([row[:min_len] for row in rows])
+
+
+def _metric_channel_value(metric: np.ndarray, channel_idx: int) -> tuple[float, int] | None:
+    if metric.ndim == 1:
+        if channel_idx >= metric.shape[0]:
+            return None
+        value = float(metric[channel_idx])
+        if not np.isfinite(value):
+            return None
+        return value, 1
+
+    if channel_idx >= metric.shape[0]:
+        return None
+    values = metric[channel_idx]
+    finite_values = values[np.isfinite(values)]
+    if finite_values.size == 0:
+        return None
+    return float(np.mean(finite_values)), int(finite_values.size)
+
+
+def _load_channel_user_metrics(
+    *,
+    model_name: str,
+    model_root: str | Path,
+    metric_name: str,
+    channel_indices: tuple[int, ...],
+    scope_type: str,
+) -> pd.DataFrame:
+    metric_dir = Path(model_root) / metric_name
+    rows: list[dict[str, Any]] = []
+    per_user_values: dict[tuple[str, int], list[float]] = {}
+    per_user_counts: dict[tuple[str, int], int] = {}
+
+    for parquet_file in _list_parquet_files(metric_dir):
+        df = _safe_read_parquet(parquet_file, columns=["user_id", metric_name])
+        if df is None or "user_id" not in df.columns or metric_name not in df.columns:
+            continue
+        for _, row in df.iterrows():
+            user_id = str(row.get("user_id"))
+            metric = _safe_to_metric_array(row.get(metric_name))
+            if metric is None:
+                continue
+            for channel_idx in channel_indices:
+                collapsed = _metric_channel_value(metric=metric, channel_idx=channel_idx)
+                if collapsed is None:
+                    continue
+                metric_value, n_values = collapsed
+                per_user_values.setdefault((user_id, int(channel_idx)), []).append(metric_value)
+                per_user_counts[(user_id, int(channel_idx))] = (
+                    per_user_counts.get((user_id, int(channel_idx)), 0) + int(n_values)
+                )
+
+    for (user_id, channel_idx), values in per_user_values.items():
+        finite_values = np.asarray(values, dtype=float)
+        finite_values = finite_values[np.isfinite(finite_values)]
+        if finite_values.size == 0:
+            continue
+        rows.append(
+            {
+                "model": model_name,
+                "scope_type": scope_type,
+                "scope": f"channel_{channel_idx}",
+                "scope_label": _channel_label(channel_idx),
+                "metric": metric_name,
+                "metric_display": _metric_display_name(metric_name),
+                "channel_idx": int(channel_idx),
+                "user_id": user_id,
+                "metric_value": float(np.mean(finite_values)),
+                "n_values": int(per_user_counts.get((user_id, channel_idx), finite_values.size)),
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def _build_continuous_user_rows(
+    *,
+    models: dict[str, dict[str, str]],
+    metrics: list[str],
+    channel_indices: tuple[int, ...],
+) -> pd.DataFrame:
+    frames: list[pd.DataFrame] = []
+    for model_name, model_spec in models.items():
+        for metric_name in metrics:
+            frame = _load_channel_user_metrics(
+                model_name=model_name,
+                model_root=model_spec["path"],
+                metric_name=metric_name,
+                channel_indices=channel_indices,
+                scope_type="continuous_channel",
+            )
+            if not frame.empty:
+                frames.append(frame)
+    if not frames:
+        return pd.DataFrame()
+    return pd.concat(frames, ignore_index=True)
+
+
+def _build_binary_user_rows(
+    *,
+    models: dict[str, dict[str, str]],
+    metrics: list[str],
+    groups: list[tuple[str, tuple[int, ...]]],
+) -> pd.DataFrame:
+    frames: list[pd.DataFrame] = []
+    all_binary_channels = tuple(sorted({idx for _, indices in groups for idx in indices}))
+    for model_name, model_spec in models.items():
+        for metric_name in metrics:
+            channel_rows = _load_channel_user_metrics(
+                model_name=model_name,
+                model_root=model_spec["path"],
+                metric_name=metric_name,
+                channel_indices=all_binary_channels,
+                scope_type="binary_channel",
+            )
+            if channel_rows.empty:
+                continue
+            for group_name, channel_indices in groups:
+                group_slice = channel_rows.loc[
+                    channel_rows["channel_idx"].isin(channel_indices)
+                ].copy()
+                if group_slice.empty:
+                    continue
+                grouped = (
+                    group_slice.groupby(
+                        ["model", "user_id", "metric", "metric_display"],
+                        as_index=False,
+                    )
+                    .agg(
+                        metric_value=("metric_value", "mean"),
+                        n_values=("n_values", "sum"),
+                    )
+                )
+                grouped["scope_type"] = "binary_group"
+                grouped["scope"] = group_name
+                grouped["scope_label"] = group_name
+                grouped["channel_idx"] = -1
+                frames.append(
+                    grouped[
+                        [
+                            "model",
+                            "scope_type",
+                            "scope",
+                            "scope_label",
+                            "metric",
+                            "metric_display",
+                            "channel_idx",
+                            "user_id",
+                            "metric_value",
+                            "n_values",
+                        ]
+                    ]
+                )
+    if not frames:
+        return pd.DataFrame()
+    return pd.concat(frames, ignore_index=True)
+
+
+def _compute_mean_ranks(user_metric_df: pd.DataFrame) -> pd.DataFrame:
+    if user_metric_df.empty:
+        return pd.DataFrame(columns=["scope", "metric", "model", "rank", "rank_n_users"])
+
+    finite_df = user_metric_df.loc[np.isfinite(user_metric_df["metric_value"])].copy()
+    if finite_df.empty:
+        return pd.DataFrame(columns=["scope", "metric", "model", "rank", "rank_n_users"])
+
+    rank_rows: list[pd.DataFrame] = []
+    for (scope, metric_name), group_slice in finite_df.groupby(["scope", "metric"], sort=True):
+        pivot = group_slice.pivot(index="user_id", columns="model", values="metric_value")
+        if pivot.empty:
+            continue
+        rank_df = pivot.rank(
+            axis=1,
+            method="average",
+            ascending=_metric_lower_is_better(metric_name),
+        )
+        long_rank = rank_df.stack(future_stack=True).reset_index()
+        long_rank.columns = ["user_id", "model", "rank"]
+        long_rank["scope"] = scope
+        long_rank["metric"] = metric_name
+        rank_rows.append(long_rank)
+
+    if not rank_rows:
+        return pd.DataFrame(columns=["scope", "metric", "model", "rank", "rank_n_users"])
+    rank_all = pd.concat(rank_rows, ignore_index=True)
+    return (
+        rank_all.groupby(["scope", "metric", "model"], as_index=False)
+        .agg(rank=("rank", "mean"), rank_n_users=("user_id", "nunique"))
+    )
+
+
+def _build_summary_tables(
+    *,
+    user_metric_df: pd.DataFrame,
+    models: dict[str, dict[str, str]],
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    long_columns = [
+        "scope_type",
+        "scope",
+        "scope_label",
+        "metric",
+        "metric_display",
+        "model",
+        "metric_mean",
+        "rank",
+        "n_users",
+        "n_values",
+        "rank_n_users",
+    ]
+    if user_metric_df.empty:
+        return pd.DataFrame(columns=long_columns), pd.DataFrame(columns=["scope_type", "scope"])
+
+    finite_df = user_metric_df.loc[np.isfinite(user_metric_df["metric_value"])].copy()
+    metric_means = (
+        finite_df.groupby(
+            ["scope_type", "scope", "scope_label", "metric", "metric_display", "model"],
+            as_index=False,
+        )
+        .agg(
+            metric_mean=("metric_value", "mean"),
+            n_users=("user_id", "nunique"),
+            n_values=("n_values", "sum"),
+        )
+    )
+    rank_df = _compute_mean_ranks(user_metric_df=user_metric_df)
+    long_df = metric_means.merge(rank_df, on=["scope", "metric", "model"], how="left")
+    model_order = list(models.keys())
+    long_df["model"] = pd.Categorical(long_df["model"], categories=model_order, ordered=True)
+    long_df = long_df.sort_values(["scope_type", "scope", "metric", "model"]).reset_index(drop=True)
+
+    wide_df = (
+        long_df[["scope_type", "scope", "scope_label", "metric", "metric_display"]]
+        .drop_duplicates()
+        .sort_values(["scope_type", "scope", "metric"])
+        .reset_index(drop=True)
+    )
+    for model_name, model_spec in models.items():
+        display_name = model_spec["display_name"]
+        model_slice = long_df.loc[long_df["model"].astype(str) == model_name].copy()
+        model_slice = model_slice[
+            ["scope_type", "scope", "metric", "metric_mean", "rank", "n_users", "rank_n_users"]
+        ].rename(
+            columns={
+                "metric_mean": f"{display_name}_metric",
+                "rank": f"{display_name}_rank",
+                "n_users": f"{display_name}_n_users",
+                "rank_n_users": f"{display_name}_rank_n_users",
+            }
+        )
+        wide_df = wide_df.merge(model_slice, on=["scope_type", "scope", "metric"], how="left")
+    return long_df[long_columns], wide_df
+
+
+def build_grouped_metric_rank_tables(
+    *,
+    models: dict[str, dict[str, str]],
+    continuous_metrics: list[str],
+    binary_metrics: list[str],
+    continuous_channel_indices: tuple[int, ...],
+    binary_groups: list[tuple[str, tuple[int, ...]]],
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Build user-level, long, and wide grouped metric rank tables."""
+    continuous_user = _build_continuous_user_rows(
+        models=models,
+        metrics=[metric.strip().lower() for metric in continuous_metrics if metric.strip()],
+        channel_indices=continuous_channel_indices,
+    )
+    binary_user = _build_binary_user_rows(
+        models=models,
+        metrics=[metric.strip().lower() for metric in binary_metrics if metric.strip()],
+        groups=binary_groups,
+    )
+    frames = [frame for frame in [continuous_user, binary_user] if not frame.empty]
+    if frames:
+        user_metric_df = pd.concat(frames, ignore_index=True)
+    else:
+        user_metric_df = pd.DataFrame()
+    long_df, wide_df = _build_summary_tables(user_metric_df=user_metric_df, models=models)
+    return user_metric_df, long_df, wide_df
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser for grouped metric rank summaries."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Summarize forecasting metrics/ranks with per-continuous-channel rows "
+            "and grouped binary rows."
+        )
+    )
+    parser.add_argument("--config", default=None, help="JSON/YAML config with model mappings.")
+    parser.add_argument(
+        "--models-json",
+        default=None,
+        help='Inline JSON dict, e.g. {"models":{"modelA":"/path/a"}}',
+    )
+    parser.add_argument(
+        "--continuous-channel-indices",
+        default="0,1,2,3,4,5,6",
+        help="Comma-separated continuous channel indices. Defaults to 0-6.",
+    )
+    parser.add_argument(
+        "--continuous-metrics",
+        nargs="+",
+        default=["mae"],
+        help="Continuous metrics to report. Defaults to mae.",
+    )
+    parser.add_argument(
+        "--binary-metrics",
+        nargs="+",
+        default=["auprc"],
+        help="Binary-group metrics to report. Defaults to auprc.",
+    )
+    parser.add_argument(
+        "--binary-group",
+        action="append",
+        default=None,
+        help="Binary group mapping GROUP=idx,idx. Defaults to sleep=7,8 and workout=9-18.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="results/metrics_summary",
+        help="Directory for generated CSV files.",
+    )
+    parser.add_argument(
+        "--output-prefix",
+        default="forecasting_grouped_metric_rank_summary",
+        help="Filename prefix for generated CSV files.",
+    )
+    return parser
+
+
+def main() -> None:
+    """Generate grouped metric rank summary CSV outputs."""
+    args = build_parser().parse_args()
+    models = _load_models_dict(args)
+    continuous_channel_indices = _parse_channel_indices(
+        args.continuous_channel_indices,
+        default=DEFAULT_CONTINUOUS_CHANNELS,
+    )
+    binary_groups = _resolve_binary_groups(args.binary_group)
+
+    user_df, long_df, wide_df = build_grouped_metric_rank_tables(
+        models=models,
+        continuous_metrics=list(args.continuous_metrics),
+        binary_metrics=list(args.binary_metrics),
+        continuous_channel_indices=continuous_channel_indices,
+        binary_groups=binary_groups,
+    )
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    user_path = output_dir / f"{args.output_prefix}_user_level_long.csv"
+    long_path = output_dir / f"{args.output_prefix}_long.csv"
+    wide_path = output_dir / f"{args.output_prefix}_wide.csv"
+    user_df.to_csv(user_path, index=False)
+    long_df.to_csv(long_path, index=False)
+    wide_df.to_csv(wide_path, index=False)
+
+    print("=== Forecasting grouped metric/rank summary ===")
+    if long_df.empty:
+        print("(empty)")
+    else:
+        print(long_df.to_string(index=False))
+    print(f"\nSaved user-level table: {user_path}")
+    print(f"Saved long table: {long_path}")
+    print(f"Saved wide table: {wide_path}")
+    print(f"Continuous channels: {continuous_channel_indices}")
+    print(f"Continuous metrics: {args.continuous_metrics}")
+    print(f"Binary groups: {binary_groups}")
+    print(f"Binary metrics: {args.binary_metrics}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/forecasting_evaluation/metrics/mase_validity_summary.py
+++ b/src/forecasting_evaluation/metrics/mase_validity_summary.py
@@ -1,0 +1,347 @@
+"""Summarize valid MASE coverage by model and channel from metrics parquet files."""
+
+from __future__ import annotations
+
+import argparse
+import random
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+CHANNEL_NAME_MAP = {
+    "first": ["hk_iphone:HKQuantityTypeIdentifierStepCount"],
+    "iPhone": [
+        "hk_iphone:HKQuantityTypeIdentifierStepCount",
+        "hk_iphone:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_iphone:HKQuantityTypeIdentifierFlightsClimbed",
+    ],
+    "watch": [
+        "hk_watch:HKQuantityTypeIdentifierStepCount",
+        "hk_watch:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_watch:HKQuantityTypeIdentifierHeartRate",
+        "hk_watch:HKQuantityTypeIdentifierActiveEnergyBurned",
+    ],
+    "all": [
+        "hk_iphone:HKQuantityTypeIdentifierStepCount",
+        "hk_iphone:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_iphone:HKQuantityTypeIdentifierFlightsClimbed",
+        "hk_watch:HKQuantityTypeIdentifierStepCount",
+        "hk_watch:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_watch:HKQuantityTypeIdentifierHeartRate",
+        "hk_watch:HKQuantityTypeIdentifierActiveEnergyBurned",
+        "sleep:asleep",
+        "sleep:inbed",
+        "workout:HKWorkoutActivityTypeWalking",
+        "workout:HKWorkoutActivityTypeCycling",
+        "workout:HKWorkoutActivityTypeRunning",
+        "workout:HKWorkoutActivityTypeOther",
+        "workout:HKWorkoutActivityTypeMixedMetabolicCardioTraining",
+        "workout:HKWorkoutActivityTypeTraditionalStrengthTraining",
+        "workout:HKWorkoutActivityTypeElliptical",
+        "workout:HKWorkoutActivityTypeHighIntensityIntervalTraining",
+        "workout:HKWorkoutActivityTypeFunctionalStrengthTraining",
+        "workout:HKWorkoutActivityTypeYoga",
+    ],
+}
+
+
+def _safe_read_parquet(file_path: str | Path, **kwargs: Any) -> pd.DataFrame | None:
+    """Read parquet with guard rails; return None on read failures."""
+    path = Path(file_path)
+    try:
+        if not path.exists():
+            print(f"[skip] parquet not found: {path}")
+            return None
+        if path.stat().st_size == 0:
+            print(f"[skip] parquet file is empty: {path}")
+            return None
+        return pd.read_parquet(path, **kwargs)
+    except Exception as exc:  # pragma: no cover - defensive branch
+        print(f"[skip] failed to read parquet: {path} | {type(exc).__name__}: {exc}")
+        return None
+
+
+def _safe_to_2d_array(value: Any) -> np.ndarray | None:
+    """Convert nested values to 2D float array, trimming rows to shared min horizon."""
+    if value is None:
+        return None
+
+    try:
+        arr = np.asarray(value, dtype=float)
+        if arr.ndim == 2:
+            return arr
+    except Exception:
+        pass
+
+    try:
+        obj = np.asarray(value, dtype=object)
+    except Exception:
+        return None
+
+    if obj.ndim != 1:
+        return None
+
+    rows: list[np.ndarray] = []
+    for item in obj.tolist():
+        try:
+            row = np.asarray(item, dtype=float).reshape(-1)
+        except Exception:
+            return None
+        if row.size == 0:
+            return None
+        rows.append(row)
+
+    if not rows:
+        return None
+
+    min_len = min(len(row) for row in rows)
+    if min_len <= 0:
+        return None
+
+    return np.vstack([row[:min_len] for row in rows])
+
+
+def _read_config_channel(model_dir: str | Path) -> str | None:
+    """Read channel key from sibling run config, if present."""
+    root = Path(model_dir)
+    candidates = [root / "config.yaml", root.parent / "config.yaml"]
+    config_path = next((p for p in candidates if p.exists()), None)
+    if config_path is None:
+        return None
+
+    try:
+        import yaml
+    except ImportError:
+        return None
+
+    with config_path.open("r", encoding="utf-8") as file:
+        config = yaml.safe_load(file) or {}
+    return (config.get("features") or {}).get("channel")
+
+
+def _list_parquet_files(model_dir: str | Path) -> list[Path]:
+    path = Path(model_dir)
+    if not path.exists():
+        return []
+    return sorted(path.rglob("*.parquet"))
+
+
+def _collect_users_for_dir(model_dir: str | Path) -> set[str]:
+    """Collect all available user ids for one input directory from parquet files."""
+    users: set[str] = set()
+    for parquet_file in _list_parquet_files(model_dir):
+        df = _safe_read_parquet(parquet_file, columns=["user_id"])
+        if df is None or "user_id" not in df.columns:
+            continue
+        users.update(df["user_id"].astype(str).dropna().unique().tolist())
+    return users
+
+
+def _select_users(users: set[str], max_user: int | None, rng: random.Random) -> set[str]:
+    """Randomly select up to max_user users; return all users when max_user is None."""
+    if max_user is None or max_user <= 0 or len(users) <= max_user:
+        return users
+    user_list = sorted(users)
+    return set(rng.sample(user_list, k=max_user))
+
+
+def _infer_channel_names(model_dir: str | Path, n_features: int) -> list[str]:
+    """Infer channel names from config key; fallback to feature indices."""
+    channel_key = _read_config_channel(model_dir)
+    if channel_key is None:
+        return [f"feature_{i}" for i in range(n_features)]
+
+    mapped = CHANNEL_NAME_MAP.get(channel_key)
+    if not mapped:
+        return [f"feature_{i}" for i in range(n_features)]
+
+    if len(mapped) >= n_features:
+        return mapped[:n_features]
+    return mapped + [f"feature_{i}" for i in range(len(mapped), n_features)]
+
+
+def _parse_model_arg(model_arg: str) -> tuple[str, str]:
+    if "=" not in model_arg:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --model value: {model_arg}. Expected format: MODEL_NAME=/path/to/model_dir"
+        )
+    model_name, model_dir = model_arg.split("=", 1)
+    model_name = model_name.strip()
+    model_dir = model_dir.strip()
+    if not model_name or not model_dir:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --model value: {model_arg}. Model name and path must be non-empty."
+        )
+    return model_name, model_dir
+
+
+def aggregate_mase_validity_streaming(
+    metrics_paths: dict[str, str],
+    max_user: int | None,
+    random_seed: int,
+) -> pd.DataFrame:
+    """Aggregate total and valid MASE timestamps by model and channel."""
+    rng = random.Random(random_seed)
+    acc: dict[tuple[str, str, int], dict[str, int]] = {}
+
+    for input_name, model_dir in metrics_paths.items():
+        files = _list_parquet_files(model_dir)
+        if not files:
+            print(f"[skip] no parquet found for input: {input_name} @ {model_dir}")
+            continue
+
+        users = _collect_users_for_dir(model_dir)
+        selected_users = _select_users(users, max_user=max_user, rng=rng)
+        print(
+            f"input={input_name} users_total={len(users)} users_selected={len(selected_users)}"
+        )
+
+        inferred_n_features = None
+        for parquet_file in files:
+            df = _safe_read_parquet(parquet_file, columns=["mase"])
+            if df is None or "mase" not in df.columns:
+                continue
+            for raw_mase in df["mase"]:
+                mase = _safe_to_2d_array(raw_mase)
+                if mase is not None:
+                    inferred_n_features = mase.shape[0]
+                    break
+            if inferred_n_features is not None:
+                break
+
+        if inferred_n_features is None:
+            print(f"[skip] no valid mase found for input: {input_name}")
+            continue
+
+        channel_names = _infer_channel_names(model_dir, inferred_n_features)
+
+        for parquet_file in files:
+            df = _safe_read_parquet(parquet_file, columns=["user_id", "mase"])
+            if df is None or "user_id" not in df.columns or "mase" not in df.columns:
+                continue
+
+            if selected_users:
+                df = df[df["user_id"].astype(str).isin(selected_users)]
+                if df.empty:
+                    continue
+
+            for _, row in df.iterrows():
+                mase = _safe_to_2d_array(row.get("mase"))
+                if mase is None:
+                    continue
+
+                n_features, horizon = mase.shape
+                channels = channel_names[:n_features]
+                if len(channels) < n_features:
+                    channels += [f"feature_{i}" for i in range(len(channels), n_features)]
+
+                for channel_idx in range(n_features):
+                    channel_values = mase[channel_idx]
+                    total_timestamps = int(channel_values.shape[0])
+                    valid_timestamps = int(np.isfinite(channel_values).sum())
+                    key = (input_name, channels[channel_idx], channel_idx)
+                    if key not in acc:
+                        acc[key] = {
+                            "total_timestamps": 0,
+                            "valid_mase_timestamps": 0,
+                        }
+                    acc[key]["total_timestamps"] += total_timestamps
+                    acc[key]["valid_mase_timestamps"] += valid_timestamps
+
+    rows: list[dict[str, Any]] = []
+    for (model, channel, channel_idx), stats in acc.items():
+        total_timestamps = int(stats["total_timestamps"])
+        valid_mase_timestamps = int(stats["valid_mase_timestamps"])
+        invalid_mase_timestamps = total_timestamps - valid_mase_timestamps
+        valid_ratio = (
+            float(valid_mase_timestamps) / float(total_timestamps)
+            if total_timestamps > 0
+            else np.nan
+        )
+        rows.append(
+            {
+                "model": model,
+                "channel": channel,
+                "channel_idx": channel_idx,
+                "total_timestamps": total_timestamps,
+                "valid_mase_timestamps": valid_mase_timestamps,
+                "invalid_mase_timestamps": invalid_mase_timestamps,
+                "valid_mase_ratio": valid_ratio,
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame(
+            columns=[
+                "model",
+                "channel",
+                "channel_idx",
+                "total_timestamps",
+                "valid_mase_timestamps",
+                "invalid_mase_timestamps",
+                "valid_mase_ratio",
+            ]
+        )
+
+    return pd.DataFrame(rows).sort_values(["model", "channel_idx"]).reset_index(drop=True)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for MASE validity summary generation."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Summarize how many timestamps have valid MASE values by model and channel."
+        )
+    )
+    parser.add_argument(
+        "--model",
+        action="append",
+        default=[],
+        help="Model mapping in format MODEL_NAME=/path/to/model_metrics_dir. Can be repeated.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="/home/lp925/code/MHC-benchmark/results/metrics_summary",
+        help="Output directory for mase_validity_by_model_channel.csv.",
+    )
+    parser.add_argument(
+        "--max-user",
+        type=int,
+        default=None,
+        help="Max number of random users per model for small-scale testing.",
+    )
+    parser.add_argument(
+        "--random-seed",
+        type=int,
+        default=42,
+        help="Random seed used by --max-user sampling.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run streaming MASE validity summary and write CSV output."""
+    args = parse_args()
+    if not args.model:
+        raise ValueError("Please provide at least one --model MODEL_NAME=/path/to/metrics_dir")
+    metrics_paths = dict(_parse_model_arg(item) for item in args.model)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    validity_df = aggregate_mase_validity_streaming(
+        metrics_paths,
+        max_user=args.max_user,
+        random_seed=args.random_seed,
+    )
+    output_path = output_dir / "mase_validity_by_model_channel.csv"
+    validity_df.to_csv(output_path, index=False)
+
+    print("\n=== Output file ===")
+    print(f"mase validity: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/forecasting_evaluation/metrics/offline/__init__.py
+++ b/src/forecasting_evaluation/metrics/offline/__init__.py
@@ -1,0 +1,5 @@
+"""Offline forecasting metrics package."""
+
+from forecasting_evaluation.metrics.offline.runner import OfflineMetricsCalculator
+
+__all__ = ["OfflineMetricsCalculator"]

--- a/src/forecasting_evaluation/metrics/offline/channel_merge.py
+++ b/src/forecasting_evaluation/metrics/offline/channel_merge.py
@@ -1,0 +1,128 @@
+"""Helpers for merging selected forecasting channels before offline metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+DEFAULT_CHANNEL_MERGE_PAIRS: tuple[tuple[int, int], ...] = (
+    (0, 3),
+    (1, 4),
+)
+
+_METRIC_KEYS = ("mae", "mse", "mase", "mase_all", "ql", "sql")
+
+
+@dataclass(frozen=True)
+class ResolvedChannelMerges:
+    """Resolved channel merge plan for one feature layout."""
+
+    merge_pairs: tuple[tuple[int, int], ...]
+    zero_feature_indices: tuple[int, ...]
+
+
+def resolve_channel_merges(
+    variable_names: list[str],
+    merge_pairs: tuple[tuple[int, int], ...] = DEFAULT_CHANNEL_MERGE_PAIRS,
+) -> ResolvedChannelMerges:
+    """Resolve a fixed merge plan against the current feature layout length."""
+    resolved_pairs: list[tuple[int, int]] = []
+    zero_feature_indices: list[int] = []
+    feature_count = len(variable_names)
+
+    for primary_idx, secondary_idx in merge_pairs:
+        if primary_idx < 0 or secondary_idx < 0:
+            continue
+        if primary_idx >= feature_count or secondary_idx >= feature_count:
+            continue
+        if primary_idx == secondary_idx:
+            continue
+        resolved_pairs.append((int(primary_idx), int(secondary_idx)))
+        zero_feature_indices.append(int(secondary_idx))
+
+    return ResolvedChannelMerges(
+        merge_pairs=tuple(resolved_pairs),
+        zero_feature_indices=tuple(sorted(set(zero_feature_indices))),
+    )
+
+
+def merge_channel_first_array(
+    values: np.ndarray | None,
+    merge_plan: ResolvedChannelMerges,
+    *,
+    zero_fill_value: float = 0.0,
+) -> np.ndarray | None:
+    """Merge a channel-first array using pointwise nan-aware averaging."""
+    if values is None:
+        return None
+
+    arr = np.asarray(values, dtype=float).copy()
+    if arr.ndim < 2:
+        return arr
+
+    for primary_idx, secondary_idx in merge_plan.merge_pairs:
+        primary_values = arr[primary_idx]
+        secondary_values = arr[secondary_idx]
+        arr[primary_idx] = _pointwise_nanmean(primary_values, secondary_values)
+        arr[secondary_idx] = np.full(arr[secondary_idx].shape, float(zero_fill_value), dtype=float)
+
+    return arr
+
+
+def zero_out_metrics_output(
+    metrics_output: dict[str, Any],
+    zero_feature_indices: tuple[int, ...],
+    metric_keys: tuple[str, ...] = _METRIC_KEYS,
+) -> dict[str, Any]:
+    """Force merged-away feature rows to all zeros in saved metric outputs."""
+    if not zero_feature_indices:
+        return metrics_output
+
+    updated = dict(metrics_output)
+    for metric_key in metric_keys:
+        metric_value = updated.get(metric_key)
+        updated[metric_key] = zero_out_channel_rows(metric_value, zero_feature_indices)
+    return updated
+
+
+def zero_out_channel_rows(
+    metric_value: Any,
+    zero_feature_indices: tuple[int, ...],
+) -> Any:
+    """Set selected feature rows to zero while preserving the original nested shape."""
+    if metric_value is None:
+        return None
+
+    arr = np.asarray(metric_value, dtype=float)
+    if arr.ndim != 2:
+        return metric_value
+
+    arr = arr.copy()
+    for feature_idx in zero_feature_indices:
+        if 0 <= feature_idx < arr.shape[0]:
+            arr[feature_idx] = 0.0
+
+    return arr.tolist()
+
+
+def _pointwise_nanmean(primary_values: np.ndarray, secondary_values: np.ndarray) -> np.ndarray:
+    """Average two aligned arrays pointwise while ignoring missing values."""
+    primary_arr = np.asarray(primary_values, dtype=float)
+    secondary_arr = np.asarray(secondary_values, dtype=float)
+    if primary_arr.shape != secondary_arr.shape:
+        raise ValueError(
+            "Merged channels must share the same shape, "
+            f"got {primary_arr.shape} and {secondary_arr.shape}"
+        )
+
+    stacked = np.stack([primary_arr, secondary_arr], axis=0)
+    valid_mask = np.isfinite(stacked)
+    valid_count = valid_mask.sum(axis=0)
+    summed = np.where(valid_mask, stacked, 0.0).sum(axis=0)
+
+    merged = np.full(primary_arr.shape, np.nan, dtype=float)
+    non_empty_mask = valid_count > 0
+    merged[non_empty_mask] = summed[non_empty_mask] / valid_count[non_empty_mask]
+    return merged

--- a/src/forecasting_evaluation/metrics/offline/common.py
+++ b/src/forecasting_evaluation/metrics/offline/common.py
@@ -1,0 +1,61 @@
+"""Shared helpers for offline forecasting metrics."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from forecasting_evaluation.config import ForecastingModelConfig
+
+
+def get_model_name(config: ForecastingModelConfig) -> str:
+    """Get deterministic model name used in output paths."""
+    return config.name if config.name else config.type
+
+
+def sanitize_name(name: str) -> str:
+    """Convert name into filesystem-safe string."""
+    sanitized = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in name)
+    return sanitized or "unknown"
+
+
+def coerce_non_negative_int(value: Any) -> int | None:
+    """Parse a non-negative integer value."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def coerce_1d_float_array(value: Any) -> np.ndarray | None:
+    """Coerce value to 1D float array."""
+    if value is None:
+        return None
+    arr = np.asarray(value, dtype=float)
+    return arr if arr.ndim == 1 else None
+
+
+def coerce_2d_float_array(value: Any) -> np.ndarray | None:
+    """Coerce value to 2D float array."""
+    if value is None:
+        return None
+    arr = np.asarray(value, dtype=float)
+    return arr if arr.ndim == 2 else None
+
+
+def coerce_3d_float_array(value: Any) -> np.ndarray | None:
+    """Coerce value to 3D float array."""
+    if value is None:
+        return None
+    arr = np.asarray(value, dtype=float)
+    return arr if arr.ndim == 3 else None
+
+
+def resolve_quantile_levels(levels: np.ndarray | None, n_quantiles: int) -> np.ndarray:
+    """Resolve quantile levels with evenly spaced fallback."""
+    if levels is not None and levels.shape[0] == n_quantiles:
+        return levels
+    return np.linspace(1.0 / (n_quantiles + 1), n_quantiles / (n_quantiles + 1), n_quantiles)

--- a/src/forecasting_evaluation/metrics/offline/config_io.py
+++ b/src/forecasting_evaluation/metrics/offline/config_io.py
@@ -1,0 +1,60 @@
+"""Run-config loading and copying helpers for offline metrics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from forecasting_evaluation.config import (
+    DataConfig,
+    FeaturesConfig,
+    ForecastingConfig,
+    ForecastingEvalConfig,
+    ForecastingModelConfig,
+    OutputConfig,
+)
+
+
+def load_run_config(run_path: Path) -> ForecastingEvalConfig:
+    """Load forecasting config from run directory config.yaml."""
+    config_path = run_path / "config.yaml"
+    if not config_path.exists():
+        raise FileNotFoundError(f"Missing config.yaml under run path: {run_path}")
+
+    with config_path.open("r", encoding="utf-8") as handle:
+        raw_cfg: dict[str, Any] = yaml.safe_load(handle)
+
+    data_cfg = DataConfig(**raw_cfg.get("data", {}))
+
+    forecasting_raw = raw_cfg.get("forecasting", {})
+    forecasting_cfg = ForecastingConfig(
+        forecasting_length=forecasting_raw.get("forecasting_length", 24),
+        daily_start_hour_offset=forecasting_raw.get("daily_start_hour_offset", 0),
+    )
+
+    model_cfg = ForecastingModelConfig(**raw_cfg.get("model", {}))
+    features_cfg = FeaturesConfig(**raw_cfg.get("features", {}))
+    output_cfg = OutputConfig(**raw_cfg.get("output", {}))
+
+    return ForecastingEvalConfig(
+        seed=raw_cfg.get("seed", 42),
+        experiment_name=raw_cfg.get("experiment_name"),
+        debug_mode=raw_cfg.get("debug_mode", False),
+        time_granularity=raw_cfg.get("time_granularity", "hourly"),
+        data=data_cfg,
+        forecasting=forecasting_cfg,
+        model=model_cfg,
+        features=features_cfg,
+        output=output_cfg,
+    )
+
+
+def copy_run_config(source_run_dir: Path, target_run_dir: Path) -> None:
+    """Copy run config.yaml into metrics output directory for reproducibility."""
+    src = source_run_dir / "config.yaml"
+    dst = target_run_dir / "config.yaml"
+    if not src.exists() or dst.exists():
+        return
+    dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")

--- a/src/forecasting_evaluation/metrics/offline/data_context.py
+++ b/src/forecasting_evaluation/metrics/offline/data_context.py
@@ -1,0 +1,86 @@
+"""Shared offline-metrics data loading helpers aligned with evaluator data flow."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import h5py
+import numpy as np
+
+from forecasting_evaluation.data.data_loader import ForecastingDataLoader
+from forecasting_evaluation.forecasting_training.cache_bundle import (
+    prepare_history_cf_cache_bundle,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_cache_model_config(config, test_ds) -> SimpleNamespace:
+    """Build the minimal cache config needed to materialize evaluator-style history rows."""
+    if len(test_ds) > 0:
+        n_features = int(np.asarray(test_ds[0]["values"]).shape[1])
+    else:
+        n_features = 19
+
+    return SimpleNamespace(
+        n_steps=1,
+        n_pred_steps=int(config.forecasting.forecasting_length),
+        n_features=n_features,
+    )
+
+
+def load_offline_user_contexts_from_eval_flow(
+    *,
+    config,
+    prediction_files: dict[str, list[Path]],
+) -> dict[str, dict[str, Any]]:
+    """Load per-user history tensors via the same split/cache flow used by evaluation."""
+    data_loader = ForecastingDataLoader(config.data)
+    train_ds, val_ds, test_ds = data_loader.load_splits()
+
+    model_config = _resolve_cache_model_config(config, test_ds)
+    _cache_dir, cache_paths, row_groups_by_split, _scaler_stats = prepare_history_cf_cache_bundle(
+        split_datasets={
+            "train": train_ds,
+            "val": val_ds,
+            "test": test_ds,
+        },
+        data_config=config.data,
+        model_config=model_config,
+        features_config=config.features,
+        h5_output_dir="data/processed/forecasting_eval_h5",
+        overwrite=False,
+    )
+
+    user_contexts: dict[str, dict[str, Any]] = {}
+    processed_users: set[str] = set()
+
+    with h5py.File(cache_paths["test"], "r") as history_handle:
+        history_rows = history_handle["history_cf_rows"]
+        for row_group in row_groups_by_split["test"]:
+            user_id = str(row_group.user_id)
+            if user_id in processed_users:
+                continue
+            processed_users.add(user_id)
+            if user_id not in prediction_files:
+                continue
+
+            row = test_ds[int(row_group.dataset_row_idx)]
+            history = np.asarray(
+                history_rows[str(row_group.dataset_row_idx)][...],
+                dtype=float,
+            )
+            user_contexts[user_id] = {
+                "history": history,
+                "variable_names": list(row["channel_names"]),
+                "dataset_row_idx": int(row_group.dataset_row_idx),
+            }
+
+    logger.info(
+        "Loaded %d offline user contexts via evaluator-aligned cache flow",
+        len(user_contexts),
+    )
+    return user_contexts

--- a/src/forecasting_evaluation/metrics/offline/metric_core.py
+++ b/src/forecasting_evaluation/metrics/offline/metric_core.py
@@ -1,0 +1,324 @@
+"""Metric core and ground-truth slicing for offline forecasting metrics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from forecasting_evaluation.evaluation.point_metrics import compute_mase, compute_mase_all
+from forecasting_evaluation.evaluation.quantiles_metrics import compute_quantiles_metrics
+from forecasting_evaluation.metrics.offline.common import resolve_quantile_levels
+
+
+def to_2d_float_list(values: np.ndarray) -> list[list[float]]:
+    """Convert 2D array to nested float lists, preserving NaN for missing values."""
+    if values.ndim != 2:
+        raise ValueError(f"Expected 2D array, got shape {values.shape}")
+
+    result: list[list[float]] = []
+    for row in values:
+        row_list: list[float] = []
+        for x in row:
+            val = float(x)
+            row_list.append(val if np.isfinite(val) else float("nan"))
+        result.append(row_list)
+    return result
+
+
+def slice_ground_truth(
+    history: np.ndarray,
+    history_length: int,
+    forecast_length: int,
+) -> tuple[np.ndarray, np.ndarray] | None:
+    """Slice GT segment and derive observed mask from finite values."""
+    if history.ndim != 2:
+        return None
+
+    start = history_length
+    end = start + forecast_length
+    if start < 0 or end > history.shape[1]:
+        return None
+
+    ground_truth = history[:, start:end]
+    ground_truth_observed_mask = np.isfinite(ground_truth)
+    return ground_truth, ground_truth_observed_mask
+
+
+def ensure_quantile_predictions(
+    *,
+    point_predictions: np.ndarray | None,
+    quantile_predictions: np.ndarray | None,
+) -> np.ndarray | None:
+    """Fallback missing quantile forecasts to a single point-based quantile.
+
+    When a model only provides point forecasts, offline QL/sQL still expects a
+    quantile tensor. In that case, wrap the point forecast as a single quantile
+    level so downstream code can resolve it to the default median quantile.
+    """
+    if quantile_predictions is not None:
+        return quantile_predictions
+
+    if point_predictions is None or point_predictions.ndim != 2:
+        return None
+
+    return point_predictions[:, :, np.newaxis]
+
+
+class MetricsComputer:
+    """Compute per-sample forecasting metrics matrices by feature and horizon."""
+
+    def __init__(
+        self,
+        global_scales_by_feature: np.ndarray | None = None,
+        global_scales_all_by_feature: np.ndarray | None = None,
+        season_length: int = 24,
+    ):
+        """Initialize metric scaling inputs and season length."""
+        self.global_scales_by_feature = (
+            None if global_scales_by_feature is None else np.asarray(global_scales_by_feature, dtype=float)
+        )
+        self.global_scales_all_by_feature = (
+            None if global_scales_all_by_feature is None else np.asarray(global_scales_all_by_feature, dtype=float)
+        )
+        self.season_length = int(season_length)
+
+    def compute(
+        self,
+        *,
+        point_predictions: np.ndarray | None,
+        quantile_predictions: np.ndarray | None,
+        full_trajectory: np.ndarray,
+        target_start_idx: int,
+        ground_truth: np.ndarray,
+        ground_truth_observed_mask: np.ndarray,
+        variable_names: list[str],
+        quantile_levels: np.ndarray | None,
+    ) -> dict[str, Any]:
+        """Compute offline metrics for one prediction sample.
+
+        Args:
+            point_predictions: Point forecast matrix, shape (n_features, horizon), or None.
+            quantile_predictions: Quantile forecast tensor, shape
+                (n_features, horizon, n_quantiles), or None.
+            full_trajectory: Full transformed trajectory for the user, shape
+                (n_features, trajectory_length), used for MASE/sQL scaling.
+            target_start_idx: Absolute 0-based start index of ``ground_truth`` inside
+                ``full_trajectory``.
+            ground_truth: Ground-truth matrix, shape (n_features, horizon).
+            ground_truth_observed_mask: Boolean observed-value mask with same shape as
+                ground_truth.
+            variable_names: Feature names aligned with first dimension.
+            quantile_levels: Quantile levels aligned with quantile_predictions, if present.
+
+        Returns:
+            Dict containing flattened metric matrices under keys ``mae``, ``mse``,
+            ``mase``, ``mase_all``, ``ql``, and ``sql``.
+        """
+        quantile_predictions = ensure_quantile_predictions(
+            point_predictions=point_predictions,
+            quantile_predictions=quantile_predictions,
+        )
+
+        mae_result = self._compute_mae(
+            point_predictions=point_predictions,
+            ground_truth=ground_truth,
+            ground_truth_observed_mask=ground_truth_observed_mask,
+        )
+        mse_result = self._compute_mse(
+            point_predictions=point_predictions,
+            ground_truth=ground_truth,
+            ground_truth_observed_mask=ground_truth_observed_mask,
+        )
+        ql_result, sql_result = self._compute_quantile_metrics(
+            quantile_predictions=quantile_predictions,
+            full_trajectory=full_trajectory,
+            target_start_idx=target_start_idx,
+            ground_truth=ground_truth,
+            ground_truth_observed_mask=ground_truth_observed_mask,
+            variable_names=variable_names,
+            quantile_levels=quantile_levels,
+        )
+        mase_result = self._compute_mase(
+            point_predictions=point_predictions,
+            full_trajectory=full_trajectory,
+            target_start_idx=target_start_idx,
+            ground_truth=ground_truth,
+            ground_truth_observed_mask=ground_truth_observed_mask,
+        )
+        mase_all_result = self._compute_mase_all(
+            point_predictions=point_predictions,
+            ground_truth=ground_truth,
+            ground_truth_observed_mask=ground_truth_observed_mask,
+        )
+        return {
+            "mae": mae_result,
+            "mse": mse_result,
+            "mase": mase_result,
+            "mase_all": mase_all_result,
+            "ql": ql_result,
+            "sql": sql_result,
+        }
+
+    def _compute_mae(
+        self,
+        *,
+        point_predictions: np.ndarray | None,
+        ground_truth: np.ndarray,
+        ground_truth_observed_mask: np.ndarray,
+    ) -> list[list[float]]:
+        if point_predictions is None or point_predictions.shape != ground_truth.shape:
+            return to_2d_float_list(np.full(ground_truth.shape, np.nan, dtype=float))
+
+        abs_error = np.abs(point_predictions - ground_truth)
+        masked_error = np.where(ground_truth_observed_mask, abs_error, np.nan)
+        return to_2d_float_list(masked_error)
+
+    def _compute_mse(
+        self,
+        *,
+        point_predictions: np.ndarray | None,
+        ground_truth: np.ndarray,
+        ground_truth_observed_mask: np.ndarray,
+    ) -> list[list[float]]:
+        if point_predictions is None or point_predictions.shape != ground_truth.shape:
+            return to_2d_float_list(np.full(ground_truth.shape, np.nan, dtype=float))
+
+        squared_error = (point_predictions - ground_truth) ** 2
+        masked_error = np.where(ground_truth_observed_mask, squared_error, np.nan)
+        return to_2d_float_list(masked_error)
+
+    def _compute_quantile_metrics(
+        self,
+        *,
+        quantile_predictions: np.ndarray | None,
+        full_trajectory: np.ndarray,
+        target_start_idx: int,
+        ground_truth: np.ndarray,
+        ground_truth_observed_mask: np.ndarray,
+        variable_names: list[str],
+        quantile_levels: np.ndarray | None,
+    ) -> tuple[list[list[float]], list[list[float]]]:
+        if quantile_predictions is None or quantile_predictions.ndim != 3:
+            empty = to_2d_float_list(np.full(ground_truth.shape, np.nan, dtype=float))
+            return empty, empty
+
+        if quantile_predictions.shape[:2] != ground_truth.shape:
+            empty = to_2d_float_list(np.full(ground_truth.shape, np.nan, dtype=float))
+            return empty, empty
+
+        n_quantiles = quantile_predictions.shape[2]
+        resolved_levels = resolve_quantile_levels(quantile_levels, n_quantiles)
+
+        quantiles_metrics = compute_quantiles_metrics(
+            predictions=quantile_predictions,
+            ground_truth=ground_truth,
+            variable_names=variable_names,
+            quantile_levels=resolved_levels,
+            scales_by_feature=self.global_scales_by_feature,
+            mask=ground_truth_observed_mask,
+            target_start_idx=target_start_idx,
+        )
+
+        ql_by_feature = quantiles_metrics.get("ql")
+        sql_by_feature = quantiles_metrics.get("sQL")
+        if not isinstance(ql_by_feature, dict) or not isinstance(sql_by_feature, dict):
+            empty = to_2d_float_list(np.full(ground_truth.shape, np.nan, dtype=float))
+            return empty, empty
+
+        ql_matrix = np.full(ground_truth.shape, np.nan, dtype=float)
+        sql_matrix = np.full(ground_truth.shape, np.nan, dtype=float)
+        for feature_idx, var_name in enumerate(variable_names):
+            ql_values = ql_by_feature.get(var_name)
+            sql_values = sql_by_feature.get(var_name)
+            if ql_values is None:
+                continue
+            ql_values_arr = np.asarray(ql_values, dtype=float)
+            if ql_values_arr.ndim != 1 or ql_values_arr.shape[0] != ground_truth.shape[1]:
+                continue
+            ql_matrix[feature_idx] = ql_values_arr
+
+            if sql_values is None:
+                continue
+            sql_values_arr = np.asarray(sql_values, dtype=float)
+            if sql_values_arr.ndim != 1 or sql_values_arr.shape[0] != ground_truth.shape[1]:
+                continue
+            sql_matrix[feature_idx] = sql_values_arr
+
+        return to_2d_float_list(ql_matrix), to_2d_float_list(sql_matrix)
+
+    def _compute_mase(
+        self,
+        *,
+        point_predictions: np.ndarray | None,
+        full_trajectory: np.ndarray,
+        target_start_idx: int,
+        ground_truth: np.ndarray,
+        ground_truth_observed_mask: np.ndarray,
+    ) -> list[list[float]]:
+        if point_predictions is None or point_predictions.shape != ground_truth.shape:
+            return to_2d_float_list(np.full(ground_truth.shape, np.nan, dtype=float))
+
+        if self.global_scales_by_feature is None:
+            return to_2d_float_list(np.full(ground_truth.shape, np.nan, dtype=float))
+
+        if self.global_scales_by_feature.ndim != 2:
+            return to_2d_float_list(np.full(ground_truth.shape, np.nan, dtype=float))
+
+        if self.global_scales_by_feature.shape[0] != ground_truth.shape[0]:
+            return to_2d_float_list(np.full(ground_truth.shape, np.nan, dtype=float))
+
+        mase_matrix = np.full(ground_truth.shape, np.nan, dtype=float)
+        for feature_idx in range(ground_truth.shape[0]):
+            feature_mase = np.asarray(
+                compute_mase(
+                    predictions=point_predictions[feature_idx : feature_idx + 1, :],
+                    ground_truth=ground_truth[feature_idx : feature_idx + 1, :],
+                    scales_by_hour=self.global_scales_by_feature[feature_idx],
+                    season_length=self.season_length,
+                    target_start_idx=target_start_idx,
+                ),
+                dtype=float,
+            )
+            mase_matrix[feature_idx] = np.where(
+                ground_truth_observed_mask[feature_idx],
+                feature_mase,
+                np.nan,
+            )
+
+        return to_2d_float_list(mase_matrix)
+
+    def _compute_mase_all(
+        self,
+        *,
+        point_predictions: np.ndarray | None,
+        ground_truth: np.ndarray,
+        ground_truth_observed_mask: np.ndarray,
+    ) -> list[list[float]]:
+        if point_predictions is None or point_predictions.shape != ground_truth.shape:
+            return to_2d_float_list(np.full(ground_truth.shape, np.nan, dtype=float))
+
+        if self.global_scales_all_by_feature is None:
+            return to_2d_float_list(np.full(ground_truth.shape, np.nan, dtype=float))
+
+        global_scales = np.asarray(self.global_scales_all_by_feature, dtype=float).reshape(-1)
+        if global_scales.shape[0] != ground_truth.shape[0]:
+            return to_2d_float_list(np.full(ground_truth.shape, np.nan, dtype=float))
+
+        mase_all_matrix = np.full(ground_truth.shape, np.nan, dtype=float)
+        for feature_idx in range(ground_truth.shape[0]):
+            feature_mase_all = np.asarray(
+                compute_mase_all(
+                    predictions=point_predictions[feature_idx : feature_idx + 1, :],
+                    ground_truth=ground_truth[feature_idx : feature_idx + 1, :],
+                    global_scale=float(global_scales[feature_idx]),
+                ),
+                dtype=float,
+            )
+            mase_all_matrix[feature_idx] = np.where(
+                ground_truth_observed_mask[feature_idx],
+                feature_mase_all,
+                np.nan,
+            )
+
+        return to_2d_float_list(mase_all_matrix)

--- a/src/forecasting_evaluation/metrics/offline/parquet_io.py
+++ b/src/forecasting_evaluation/metrics/offline/parquet_io.py
@@ -1,0 +1,161 @@
+"""Parquet read/write helpers for offline metrics."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pyarrow.parquet as pq
+
+from forecasting_evaluation.metrics.offline.common import sanitize_name
+
+logger = logging.getLogger(__name__)
+
+_METRIC_COLUMNS = ("mae", "mse", "mase", "mase_all", "ql", "sql")
+
+
+def append_metrics_to_parquet(
+    output_dir: Path,
+    model_key: str,
+    user_id: str,
+    records: list[dict[str, Any]],
+) -> None:
+    """Append metrics records to output_dir/user_id.parquet."""
+    if not records:
+        return
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    user_key = sanitize_name(user_id)
+    output_file = output_dir / f"{user_key}.parquet"
+    df_new = pd.DataFrame(records)
+
+    if output_file.exists():
+        df_existing = pd.read_parquet(output_file)
+        df = pd.concat([df_existing, df_new], ignore_index=True)
+    else:
+        df = df_new
+
+    df.to_parquet(output_file, engine="pyarrow", compression="snappy")
+    logger.info("Saved metrics for %s/%s: %s (rows=%d)", model_key, user_id, output_file, len(records))
+
+
+def save_metrics_result_dict(
+    output_dir: Path,
+    model_key: str,
+    records_by_user: dict[str, list[dict[str, Any]]],
+) -> dict[str, str]:
+    """Save a metrics-result dict produced by the structured offline pipeline.
+
+    Args:
+        output_dir: Directory where user-level parquet files should be written.
+        model_key: Filesystem-safe model identifier used only for logging.
+        records_by_user: Mapping ``user_id -> list[metrics row dict]``.
+
+    Returns:
+        Mapping ``user_id -> saved parquet path`` for all users that had records.
+    """
+    saved_files: dict[str, str] = {}
+    for user_id, records in records_by_user.items():
+        append_metrics_to_parquet(
+            output_dir=output_dir,
+            model_key=model_key,
+            user_id=user_id,
+            records=records,
+        )
+        saved_files[user_id] = str(output_dir / f"{sanitize_name(user_id)}.parquet")
+    return saved_files
+
+
+def save_metrics_result_by_metric(
+    output_root: Path,
+    model_key: str,
+    records_by_user: dict[str, list[dict[str, Any]]],
+    metric_columns: tuple[str, ...] = _METRIC_COLUMNS,
+) -> dict[str, dict[str, str]]:
+    """Save offline metrics into per-metric directories.
+
+    Output layout:
+        ``output_root/<metric_name>/<user_id>.parquet``
+
+    Each parquet keeps only the requested metric column plus row-identifying
+    metadata columns needed by downstream readers.
+    """
+    saved_files_by_metric: dict[str, dict[str, str]] = {}
+
+    for metric_name in metric_columns:
+        metric_output_dir = output_root / metric_name
+        metric_records_by_user: dict[str, list[dict[str, Any]]] = {}
+
+        for user_id, records in records_by_user.items():
+            metric_rows: list[dict[str, Any]] = []
+            for record in records:
+                if metric_name not in record:
+                    continue
+                metric_row = {
+                    "user_id": record.get("user_id"),
+                    "model": record.get("model"),
+                    "history_length": record.get("history_length"),
+                    "forecasting_length": record.get("forecasting_length"),
+                    metric_name: record.get(metric_name),
+                }
+                metric_rows.append(metric_row)
+
+            if metric_rows:
+                metric_records_by_user[user_id] = metric_rows
+
+        if metric_records_by_user:
+            saved_files_by_metric[metric_name] = save_metrics_result_dict(
+                output_dir=metric_output_dir,
+                model_key=model_key,
+                records_by_user=metric_records_by_user,
+            )
+
+    return saved_files_by_metric
+
+
+def infer_user_id_from_filename(path: Path) -> str | None:
+    """Infer user id from filename format: {user_id}.parquet."""
+    return path.stem or None
+
+
+def read_user_id_from_parquet(path: Path) -> str | None:
+    """Fallback reader to fetch user_id from parquet content."""
+    table = pq.read_table(path, columns=["user_id"])
+    if table.num_rows == 0:
+        return None
+    return str(table.column("user_id")[0].as_py())
+
+
+def read_parquet_rows(path: Path) -> list[dict[str, Any]]:
+    """Read all parquet rows as python dicts."""
+    try:
+        table = pq.read_table(path)
+    except Exception as exc:
+        logger.warning("Failed to read parquet file %s: %s. Skipping.", path, exc)
+        return []
+    return table.to_pylist()
+
+
+def index_prediction_files(
+    model_dir: Path,
+    model_name: str,
+) -> dict[str, list[Path]]:
+    """Index prediction parquet files by user id for a single model directory."""
+    if not model_dir.exists():
+        logger.warning("Model output folder not found for %s under %s", model_name, model_dir)
+        return {}
+
+    user_to_files: dict[str, list[Path]] = {}
+    for parquet_path in sorted(model_dir.glob("*.parquet")):
+        user_id = infer_user_id_from_filename(parquet_path)
+        if user_id is None:
+            user_id = read_user_id_from_parquet(parquet_path)
+        if user_id is None:
+            logger.warning("Unable to infer user_id from %s, skipping", parquet_path)
+            continue
+        user_to_files.setdefault(user_id, []).append(parquet_path)
+
+    return user_to_files

--- a/src/forecasting_evaluation/metrics/offline/pipeline.py
+++ b/src/forecasting_evaluation/metrics/offline/pipeline.py
@@ -1,0 +1,342 @@
+"""Structured offline metrics pipeline for forecasting evaluation.
+
+This module centralizes the offline forecasting-metrics workflow into one explicit
+pipeline:
+
+1. Load run config and dataset context
+2. Read saved prediction parquet rows
+3. Compute benchmark-global scales
+4. Compute minimal-unit metrics for every ``(channel, hour-of-day)`` occurrence
+5. Save metrics parquet outputs
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from forecasting_evaluation.evaluation.point_metrics import (
+    accumulate_global_scale_statistics,
+    accumulate_hour_of_day_scale_statistics,
+    finalize_global_scales,
+    finalize_hour_of_day_scales,
+)
+from forecasting_evaluation.metrics.offline.channel_merge import (
+    merge_channel_first_array,
+    resolve_channel_merges,
+    zero_out_metrics_output,
+)
+from forecasting_evaluation.metrics.offline.common import (
+    coerce_1d_float_array,
+    coerce_2d_float_array,
+    coerce_3d_float_array,
+    coerce_non_negative_int,
+    get_model_name,
+    sanitize_name,
+)
+from forecasting_evaluation.metrics.offline.config_io import copy_run_config, load_run_config
+from forecasting_evaluation.metrics.offline.data_context import (
+    load_offline_user_contexts_from_eval_flow,
+)
+from forecasting_evaluation.metrics.offline.metric_core import (
+    MetricsComputer,
+    slice_ground_truth,
+)
+from forecasting_evaluation.metrics.offline.parquet_io import (
+    index_prediction_files,
+    read_parquet_rows,
+    save_metrics_result_by_metric,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class OfflineMetricsPipeline:
+    """Explicit end-to-end offline metrics pipeline for one forecasting run."""
+
+    def __init__(
+        self,
+        *,
+        run_key: str,
+        run_path: Path,
+        metrics_output_path: Path,
+        max_user: int | None = None,
+    ):
+        """Initialize the offline metrics pipeline for one run."""
+        self.run_key = str(run_key)
+        self.run_path = Path(run_path)
+        self.metrics_output_path = Path(metrics_output_path)
+        self.max_user = int(max_user) if max_user is not None else None
+
+    def run(self) -> dict[str, Any]:
+        """Execute the full structured metrics pipeline for one run."""
+        pipeline_inputs = self.load_inputs()
+        scale_result = self.compute_scales(pipeline_inputs)
+        metrics_result = self.compute_minimal_unit_metrics(
+            pipeline_inputs=pipeline_inputs,
+            scale_result=scale_result,
+        )
+        save_result = self.save_metrics_result(
+            pipeline_inputs=pipeline_inputs,
+            metrics_result=metrics_result,
+        )
+
+        return {
+            "run_key": self.run_key,
+            "run_path": str(self.run_path),
+            "model_name": pipeline_inputs["model_name"],
+            "forecast_length": pipeline_inputs["forecast_length"],
+            "scale_result": scale_result,
+            "metrics_result": metrics_result,
+            "save_result": save_result,
+            "saved_rows": int(metrics_result["saved_rows"]),
+            "skipped_rows": int(metrics_result["skipped_rows"]),
+            "computed_user_count": int(metrics_result["computed_user_count"]),
+            "max_user": self.max_user,
+            "output_run_dir": str(pipeline_inputs["output_run_dir"]),
+            "metrics_dir": str(pipeline_inputs["metrics_dir"]),
+        }
+
+    def load_inputs(self) -> dict[str, Any]:
+        """Step 1-2: load config, dataset context, and saved prediction parquet rows."""
+        config = load_run_config(self.run_path)
+        forecast_length = int(config.forecasting.forecasting_length)
+        model_name = get_model_name(config.model)
+        prediction_files = index_prediction_files(self.run_path, model_name)
+
+        output_run_dir = self.metrics_output_path / sanitize_name(self.run_key)
+        metrics_dir = output_run_dir
+
+        user_contexts = load_offline_user_contexts_from_eval_flow(
+            config=config,
+            prediction_files=prediction_files,
+        )
+        for user_context in user_contexts.values():
+            history = np.asarray(user_context["history"], dtype=float)
+            variable_names = list(user_context["variable_names"])
+            merge_plan = resolve_channel_merges(variable_names)
+            user_context["history"] = merge_channel_first_array(history, merge_plan)
+            user_context["merge_plan"] = merge_plan
+
+        prediction_rows_by_user: dict[str, list[dict[str, Any]]] = {}
+        for user_id, parquet_paths in prediction_files.items():
+            rows: list[dict[str, Any]] = []
+            for parquet_path in parquet_paths:
+                rows.extend(read_parquet_rows(parquet_path))
+            if rows:
+                prediction_rows_by_user[user_id] = rows
+
+        return {
+            "config": config,
+            "forecast_length": forecast_length,
+            "model_name": model_name,
+            "output_run_dir": output_run_dir,
+            "metrics_dir": metrics_dir,
+            "user_contexts": user_contexts,
+            "prediction_rows_by_user": prediction_rows_by_user,
+        }
+
+    def compute_scales(self, pipeline_inputs: dict[str, Any]) -> dict[str, Any]:
+        """Step 3: compute benchmark-global scales used by normalized metrics."""
+        forecast_length = int(pipeline_inputs["forecast_length"])
+        user_contexts = pipeline_inputs["user_contexts"]
+        prediction_rows_by_user = pipeline_inputs["prediction_rows_by_user"]
+
+        scale_sum: np.ndarray | None = None
+        scale_count: np.ndarray | None = None
+        global_scale_sum: np.ndarray | None = None
+        global_scale_count: np.ndarray | None = None
+
+        for user_id, user_context in user_contexts.items():
+            history = np.asarray(user_context["history"], dtype=float)
+            for row in prediction_rows_by_user.get(user_id, []):
+                history_length = coerce_non_negative_int(row.get("history_length"))
+                if history_length is None:
+                    continue
+                gt_pack = slice_ground_truth(
+                    history=history,
+                    history_length=history_length,
+                    forecast_length=forecast_length,
+                )
+                if gt_pack is None:
+                    continue
+
+                scale_sum, scale_count = accumulate_hour_of_day_scale_statistics(
+                    values=history,
+                    target_start_idx=history_length,
+                    prediction_length=forecast_length,
+                    season_length=24,
+                    scale_sum=scale_sum,
+                    scale_count=scale_count,
+                )
+                global_scale_sum, global_scale_count = accumulate_global_scale_statistics(
+                    values=history,
+                    target_start_idx=history_length,
+                    prediction_length=forecast_length,
+                    season_length=24,
+                    scale_sum=global_scale_sum,
+                    scale_count=global_scale_count,
+                )
+
+        global_scales_by_feature = None
+        if scale_sum is not None and scale_count is not None:
+            global_scales_by_feature = finalize_hour_of_day_scales(
+                scale_sum=scale_sum,
+                scale_count=scale_count,
+            )
+        global_scales_all_by_feature = None
+        if global_scale_sum is not None and global_scale_count is not None:
+            global_scales_all_by_feature = finalize_global_scales(
+                scale_sum=global_scale_sum,
+                scale_count=global_scale_count,
+            )
+
+        return {
+            "season_length": 24,
+            "global_scales_by_feature": global_scales_by_feature,
+            "global_scales_all_by_feature": global_scales_all_by_feature,
+        }
+
+    def compute_minimal_unit_metrics(
+        self,
+        *,
+        pipeline_inputs: dict[str, Any],
+        scale_result: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Step 4: compute all minimal-unit metrics for every saved prediction row."""
+        forecast_length = int(pipeline_inputs["forecast_length"])
+        model_name = str(pipeline_inputs["model_name"])
+        user_contexts = pipeline_inputs["user_contexts"]
+        prediction_rows_by_user = pipeline_inputs["prediction_rows_by_user"]
+        metrics_dir = Path(pipeline_inputs["metrics_dir"])
+
+        metrics_computer = MetricsComputer(
+            global_scales_by_feature=scale_result.get("global_scales_by_feature"),
+            global_scales_all_by_feature=scale_result.get("global_scales_all_by_feature"),
+            season_length=int(scale_result.get("season_length", 24)),
+        )
+
+        records_by_user: dict[str, list[dict[str, Any]]] = {}
+        saved_rows = 0
+        skipped_rows = 0
+        computed_user_count = 0
+
+        for user_id, user_context in user_contexts.items():
+            if self.max_user is not None and computed_user_count >= self.max_user:
+                logger.info(
+                    "Reached max_user limit for run=%s: max_user=%s",
+                    self.run_key,
+                    self.max_user,
+                )
+                break
+
+            user_metrics_file = metrics_dir / "mae" / f"{sanitize_name(user_id)}.parquet"
+            if user_metrics_file.exists():
+                logger.info(
+                    "Metrics parquet for user exists, skipping user. run=%s user=%s file=%s",
+                    self.run_key,
+                    user_id,
+                    user_metrics_file,
+                )
+                continue
+
+            history = np.asarray(user_context["history"], dtype=float)
+            variable_names = list(user_context["variable_names"])
+            merge_plan = user_context["merge_plan"]
+            user_records: list[dict[str, Any]] = []
+
+            for row in prediction_rows_by_user.get(user_id, []):
+                history_length = coerce_non_negative_int(row.get("history_length"))
+                if history_length is None:
+                    skipped_rows += 1
+                    continue
+
+                gt_pack = slice_ground_truth(
+                    history=history,
+                    history_length=history_length,
+                    forecast_length=forecast_length,
+                )
+                if gt_pack is None:
+                    skipped_rows += 1
+                    continue
+
+                ground_truth, ground_truth_observed_mask = gt_pack
+                point_predictions = merge_channel_first_array(
+                    coerce_2d_float_array(row.get("point_predictions")),
+                    merge_plan,
+                )
+                quantile_predictions = merge_channel_first_array(
+                    coerce_3d_float_array(row.get("quantile_predictions")),
+                    merge_plan,
+                )
+                metrics_output = metrics_computer.compute(
+                    point_predictions=point_predictions,
+                    quantile_predictions=quantile_predictions,
+                    full_trajectory=history,
+                    target_start_idx=history_length,
+                    ground_truth=ground_truth,
+                    ground_truth_observed_mask=ground_truth_observed_mask,
+                    variable_names=variable_names,
+                    quantile_levels=coerce_1d_float_array(row.get("quantile_levels")),
+                )
+                metrics_output = zero_out_metrics_output(
+                    metrics_output,
+                    merge_plan.zero_feature_indices,
+                )
+
+                record = {
+                    "user_id": user_id,
+                    "model": model_name,
+                    "history_length": history_length,
+                    "forecasting_length": forecast_length,
+                    "mae": metrics_output.get("mae"),
+                    "mse": metrics_output.get("mse"),
+                    "mase": metrics_output.get("mase"),
+                    "mase_all": metrics_output.get("mase_all"),
+                    "ql": metrics_output.get("ql"),
+                    "sql": metrics_output.get("sql"),
+                }
+                perf = row.get("performance") or {}
+                record.update({f"perf_{k}": v for k, v in perf.items()})
+                user_records.append(record)
+                saved_rows += 1
+
+            if user_records:
+                records_by_user[user_id] = user_records
+                computed_user_count += 1
+
+        return {
+            "records_by_user": records_by_user,
+            "saved_rows": saved_rows,
+            "skipped_rows": skipped_rows,
+            "computed_user_count": computed_user_count,
+        }
+
+    def save_metrics_result(
+        self,
+        *,
+        pipeline_inputs: dict[str, Any],
+        metrics_result: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Step 5: persist computed metrics parquet outputs to disk."""
+        output_run_dir = Path(pipeline_inputs["output_run_dir"])
+        metrics_dir = Path(pipeline_inputs["metrics_dir"])
+        model_key = sanitize_name(str(pipeline_inputs["model_name"]))
+
+        output_run_dir.mkdir(parents=True, exist_ok=True)
+        copy_run_config(self.run_path, output_run_dir)
+
+        saved_files_by_metric = save_metrics_result_by_metric(
+            output_root=metrics_dir,
+            model_key=model_key,
+            records_by_user=metrics_result["records_by_user"],
+        )
+
+        return {
+            "saved_files_by_metric": saved_files_by_metric,
+            "output_run_dir": str(output_run_dir),
+            "metrics_dir": str(metrics_dir),
+        }

--- a/src/forecasting_evaluation/metrics/offline/runner.py
+++ b/src/forecasting_evaluation/metrics/offline/runner.py
@@ -1,0 +1,57 @@
+"""Thin orchestrator for structured offline forecasting metrics pipelines."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from forecasting_evaluation.metrics.offline.pipeline import OfflineMetricsPipeline
+
+logger = logging.getLogger(__name__)
+
+
+class OfflineMetricsCalculator:
+    """Run the structured offline metrics pipeline for one or more forecasting runs."""
+
+    def __init__(
+        self,
+        evaluation_result_paths: dict[str, str],
+        metrics_output_path: str,
+        max_user: int | None = None,
+    ):
+        """Initialize the multi-run offline metrics calculator."""
+        self.evaluation_result_paths = {
+            str(name): Path(path) for name, path in evaluation_result_paths.items()
+        }
+        self.metrics_output_path = Path(metrics_output_path)
+        self.metrics_output_path.mkdir(parents=True, exist_ok=True)
+        self.max_user = int(max_user) if max_user is not None else None
+
+    def run(self) -> dict[str, Any]:
+        """Run the offline metrics pipeline for all provided runs."""
+        run_summaries: list[dict[str, Any]] = []
+
+        for run_key, run_path in self.evaluation_result_paths.items():
+            if not run_path.exists():
+                logger.warning("Run path does not exist for key=%s, skipped: %s", run_key, run_path)
+                continue
+
+            logger.info("Processing key=%s run path=%s", run_key, run_path)
+            pipeline = OfflineMetricsPipeline(
+                run_key=run_key,
+                run_path=run_path,
+                metrics_output_path=self.metrics_output_path,
+                max_user=self.max_user,
+            )
+            run_summaries.append(pipeline.run())
+
+        total_saved = int(sum(summary["saved_rows"] for summary in run_summaries))
+        total_skipped = int(sum(summary["skipped_rows"] for summary in run_summaries))
+
+        return {
+            "runs": run_summaries,
+            "total_runs": len(run_summaries),
+            "total_saved_rows": total_saved,
+            "total_skipped_rows": total_skipped,
+        }

--- a/src/forecasting_evaluation/metrics/offline_calculate.py
+++ b/src/forecasting_evaluation/metrics/offline_calculate.py
@@ -1,0 +1,101 @@
+"""CLI entry point for offline forecasting metrics calculation."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from forecasting_evaluation.metrics.offline.runner import OfflineMetricsCalculator
+
+
+def _parse_named_paths(items: list[str]) -> dict[str, str]:
+    """Parse CLI items in key=path format."""
+    parsed: dict[str, str] = {}
+    for item in items:
+        if "=" not in item:
+            raise argparse.ArgumentTypeError(
+                f"Invalid run mapping '{item}', expected format: name=/abs/or/rel/path"
+            )
+        key, path = item.split("=", 1)
+        key = key.strip()
+        path = path.strip()
+        if not key or not path:
+            raise argparse.ArgumentTypeError(
+                f"Invalid run mapping '{item}', expected non-empty name and path"
+            )
+        parsed[key] = path
+    return parsed
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build CLI parser."""
+    parser = argparse.ArgumentParser(
+        description="Compute offline forecasting metrics from saved forecasting run outputs.",
+    )
+    parser.add_argument(
+        "--evaluation-result-paths",
+        "--run-dirs",
+        nargs="+",
+        default=[],
+        help=(
+            "One or more named forecasting run mappings in key=path format. "
+            "Each path should point to one model output directory containing "
+            "config.yaml and user parquet files (e.g. results/forecasting_eval/<experiment>/<model>)."
+        ),
+    )
+    parser.add_argument(
+        "--metrics-output-path",
+        "--output-dir",
+        default="/home/lp925/code/MHC-benchmark/results/metrics",
+        help="Root output directory to store offline metrics results.",
+    )
+    parser.add_argument(
+        "--max-user",
+        type=int,
+        default=None,
+        help=(
+            "Optional sequential cap on how many user parquet metrics files to compute "
+            "per run. Use None to process all users."
+        ),
+    )
+    return parser
+
+
+def main() -> None:
+    """Run offline forecasting metrics calculation from CLI arguments."""
+    args = build_parser().parse_args()
+    if not args.evaluation_result_paths:
+        raise ValueError("Please provide --evaluation-result-paths in key=path format")
+    evaluation_result_paths = _parse_named_paths(args.evaluation_result_paths)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    calculator = OfflineMetricsCalculator(
+        evaluation_result_paths=evaluation_result_paths,
+        metrics_output_path=args.metrics_output_path,
+        max_user=args.max_user,
+    )
+    summary = calculator.run()
+    compact_summary = {
+        "total_runs": summary.get("total_runs"),
+        "total_saved_rows": summary.get("total_saved_rows"),
+        "total_skipped_rows": summary.get("total_skipped_rows"),
+        "runs": [
+            {
+                "run_key": run_summary.get("run_key"),
+                "model_name": run_summary.get("model_name"),
+                "saved_rows": run_summary.get("saved_rows"),
+                "skipped_rows": run_summary.get("skipped_rows"),
+                "computed_user_count": run_summary.get("computed_user_count"),
+                "output_run_dir": run_summary.get("output_run_dir"),
+            }
+            for run_summary in summary.get("runs", [])
+        ],
+    }
+    logging.getLogger(__name__).info("Offline metrics finished: %s", compact_summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/forecasting_evaluation/metrics/paper_result_generator_all_channels.py
+++ b/src/forecasting_evaluation/metrics/paper_result_generator_all_channels.py
@@ -1,0 +1,758 @@
+"""Generate paper-ready grouped forecasting results across channel collections.
+
+This module reads offline metrics parquet outputs (e.g. under
+``results/metrics/<model_name>/<metric_name>``) and exports one combined table
+that:
+
+1. Reports aggregate results for three channel collections:
+   - channels 0-6 using ``mase`` and ``sql``
+   - channels 7-8 using ``mse`` and ``f1``
+   - channels 9-18 using ``mse`` and ``f1``
+2. Then reports each individual channel using the metric family assigned to its
+   collection. For channels 0-6, the individual-channel rows use ``mae`` and
+   ``mase`` rather than ``sql``.
+
+Rows keep the same 3-hour grouped layout as the one-channel paper export while
+adding a leading ``Channel`` column to identify the aggregate collection or
+individual channel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from forecasting_evaluation.metrics.paper_result_generator_one_channel import (
+    aggregate_metric_3hour as _aggregate_metric_3hour_one_channel,
+)
+from forecasting_evaluation.metrics.paper_result_generator_one_channel import (
+    rank_metric_by_user_3hour as _rank_metric_by_user_3hour_one_channel,
+)
+
+CHANNEL_NAME_MAP = {
+    "first": ["hk_iphone:HKQuantityTypeIdentifierStepCount"],
+    "iPhone": [
+        "hk_iphone:HKQuantityTypeIdentifierStepCount",
+        "hk_iphone:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_iphone:HKQuantityTypeIdentifierFlightsClimbed",
+    ],
+    "watch": [
+        "hk_watch:HKQuantityTypeIdentifierStepCount",
+        "hk_watch:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_watch:HKQuantityTypeIdentifierHeartRate",
+        "hk_watch:HKQuantityTypeIdentifierActiveEnergyBurned",
+    ],
+    "all": [
+        "hk_iphone:HKQuantityTypeIdentifierStepCount",
+        "hk_iphone:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_iphone:HKQuantityTypeIdentifierFlightsClimbed",
+        "hk_watch:HKQuantityTypeIdentifierStepCount",
+        "hk_watch:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_watch:HKQuantityTypeIdentifierHeartRate",
+        "hk_watch:HKQuantityTypeIdentifierActiveEnergyBurned",
+        "sleep:asleep",
+        "sleep:inbed",
+        "workout:HKWorkoutActivityTypeWalking",
+        "workout:HKWorkoutActivityTypeCycling",
+        "workout:HKWorkoutActivityTypeRunning",
+        "workout:HKWorkoutActivityTypeOther",
+        "workout:HKWorkoutActivityTypeMixedMetabolicCardioTraining",
+        "workout:HKWorkoutActivityTypeTraditionalStrengthTraining",
+        "workout:HKWorkoutActivityTypeElliptical",
+        "workout:HKWorkoutActivityTypeHighIntensityIntervalTraining",
+        "workout:HKWorkoutActivityTypeFunctionalStrengthTraining",
+        "workout:HKWorkoutActivityTypeYoga",
+    ],
+}
+
+
+@dataclass(frozen=True)
+class ScopeSpec:
+    """Definition for one aggregate or per-channel reporting scope."""
+
+    label: str
+    channel_indices: tuple[int, ...]
+    metric_columns: tuple[str, ...]
+
+
+def _safe_read_parquet(file_path: str | Path, **kwargs: Any) -> pd.DataFrame | None:
+    path = Path(file_path)
+    try:
+        if not path.exists() or path.stat().st_size == 0:
+            return None
+        return pd.read_parquet(path, **kwargs)
+    except Exception:
+        return None
+
+
+def _list_parquet_files(model_dir: str | Path) -> list[Path]:
+    path = Path(model_dir)
+    if not path.exists():
+        return []
+    return sorted(path.rglob("*.parquet"))
+
+
+def _resolve_metric_dir(model_dir: str | Path, metric_name: str) -> Path:
+    """Resolve one model root to the corresponding metric directory."""
+    path = Path(model_dir)
+    metric_dir = path / metric_name
+    return metric_dir
+
+
+def _safe_to_2d_array(value: Any) -> np.ndarray | None:
+    if value is None:
+        return None
+
+    try:
+        arr = np.asarray(value, dtype=float)
+        if arr.ndim == 2:
+            return arr
+    except Exception:
+        pass
+
+    try:
+        obj = np.asarray(value, dtype=object)
+    except Exception:
+        return None
+
+    if obj.ndim != 1:
+        return None
+
+    rows: list[np.ndarray] = []
+    for item in obj.tolist():
+        try:
+            row = np.asarray(item, dtype=float).reshape(-1)
+        except Exception:
+            return None
+        if row.size == 0:
+            return None
+        rows.append(row)
+
+    if not rows:
+        return None
+
+    min_len = min(row.shape[0] for row in rows)
+    if min_len <= 0:
+        return None
+    return np.vstack([row[:min_len] for row in rows])
+
+
+def _collect_users_for_model(model_dir: str | Path, metric_column: str) -> set[str]:
+    resolved_dir = _resolve_metric_dir(model_dir, metric_column)
+    if not resolved_dir.is_dir():
+        return set()
+    users: set[str] = set()
+    for parquet_file in _list_parquet_files(resolved_dir):
+        df = _safe_read_parquet(parquet_file, columns=["user_id"])
+        if df is None or "user_id" not in df.columns:
+            continue
+        users.update(df["user_id"].astype(str).dropna().unique().tolist())
+    return users
+
+
+def _project_hour_index(hour: int, horizon: int) -> int:
+    if horizon >= 48:
+        return int(hour % 24)
+    return int(hour)
+
+
+def _group_start_from_hour(hour: int) -> int:
+    return int((hour // 3) * 3)
+
+
+def _group_label(group_start: int) -> str:
+    return f"{group_start:02d}-{group_start + 2:02d}"
+
+
+def _format_group_label_for_paper(group_label: str) -> str:
+    start_str, end_str = group_label.split("-")
+    return f"{int(start_str)}-{int(end_str)}"
+
+
+def _read_config_channel(model_dir: str | Path) -> str | None:
+    root = Path(model_dir)
+    candidates = [root / "config.yaml", root.parent / "config.yaml"]
+    config_path = next((p for p in candidates if p.exists()), None)
+    if config_path is None:
+        return None
+
+    try:
+        import yaml
+    except ImportError:
+        return None
+
+    with config_path.open("r", encoding="utf-8") as file:
+        config = yaml.safe_load(file) or {}
+    return (config.get("features") or {}).get("channel")
+
+
+def _infer_channel_names(model_dir: str | Path, n_features: int) -> list[str]:
+    channel_key = _read_config_channel(model_dir)
+    if channel_key is None:
+        return [f"feature_{i}" for i in range(n_features)]
+
+    mapped = CHANNEL_NAME_MAP.get(channel_key)
+    if not mapped:
+        return [f"feature_{i}" for i in range(n_features)]
+
+    if len(mapped) >= n_features:
+        return mapped[:n_features]
+    return mapped + [f"feature_{i}" for i in range(len(mapped), n_features)]
+
+
+def _mean_matrices_ignore_nan(mats: list[np.ndarray]) -> np.ndarray | None:
+    if not mats:
+        return None
+
+    min_features = min(m.shape[0] for m in mats)
+    min_horizon = min(m.shape[1] for m in mats)
+    if min_features <= 0 or min_horizon <= 0:
+        return None
+
+    trimmed = [m[:min_features, :min_horizon] for m in mats]
+    stack = np.stack(trimmed, axis=0)
+    finite_mask = np.isfinite(stack)
+    counts = finite_mask.sum(axis=0)
+    sums = np.where(finite_mask, stack, 0.0).sum(axis=0)
+    mean = np.full((min_features, min_horizon), np.nan, dtype=float)
+    valid = counts > 0
+    mean[valid] = sums[valid] / counts[valid]
+    return mean
+
+
+def _load_per_model_user_metric(
+    model_dir: str | Path,
+    metric_column: str,
+    allowed_users: set[str] | None = None,
+) -> dict[str, np.ndarray]:
+    resolved_dir = _resolve_metric_dir(model_dir, metric_column)
+    if not resolved_dir.is_dir():
+        return {}
+    per_user_rows: dict[str, list[np.ndarray]] = {}
+
+    for parquet_file in _list_parquet_files(resolved_dir):
+        df = _safe_read_parquet(parquet_file, columns=["user_id", metric_column])
+        if df is None or "user_id" not in df.columns or metric_column not in df.columns:
+            continue
+
+        for _, row in df.iterrows():
+            user = str(row.get("user_id"))
+            if allowed_users is not None and user not in allowed_users:
+                continue
+            metric = _safe_to_2d_array(row.get(metric_column))
+            if metric is None:
+                continue
+            per_user_rows.setdefault(user, [])
+            per_user_rows[user].append(metric)
+
+    per_user_avg: dict[str, np.ndarray] = {}
+    for user, rows in per_user_rows.items():
+        mean_metric = _mean_matrices_ignore_nan(rows)
+        if mean_metric is not None:
+            per_user_avg[user] = mean_metric
+    return per_user_avg
+
+
+def _metric_label_from_column(metric_column: str) -> str:
+    normalized = metric_column.strip().lower()
+    if normalized == "mae":
+        return "MAE"
+    if normalized == "mse":
+        return "MSE"
+    if normalized == "f1":
+        return "F1"
+    if normalized == "mase":
+        return "MASE"
+    if normalized == "ql":
+        return "QL"
+    if normalized == "sql":
+        return "sQL"
+    return metric_column
+
+
+def _rank_label_from_metric_label(metric_label: str) -> str:
+    return f"Rank_{metric_label}"
+
+
+def _format_output_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return "/"
+
+    if not np.isfinite(numeric):
+        return "/"
+    return f"{numeric:.2f}"
+
+
+def _render_plaintext_table(df: pd.DataFrame) -> str:
+    columns = df.columns.tolist()
+    str_df = df.copy()
+    for column in columns[3:]:
+        str_df[column] = str_df[column].map(_format_output_value)
+
+    widths: dict[str, int] = {}
+    for column in columns:
+        widths[column] = max(len(str(column)), str_df[column].astype(str).map(len).max())
+
+    header = " | ".join(str(column).ljust(widths[column]) for column in columns)
+    divider = "-+-".join("-" * widths[column] for column in columns)
+    body = [
+        " | ".join(str(row[column]).ljust(widths[column]) for column in columns)
+        for _, row in str_df.iterrows()
+    ]
+    return "\n".join([header, divider, *body])
+
+
+def _render_latex_rows(df: pd.DataFrame) -> str:
+    value_columns = df.columns.tolist()[3:]
+    lines: list[str] = []
+    for _, row in df.iterrows():
+        values = " & ".join(_format_output_value(row[column]) for column in value_columns)
+        lines.append(f"{row['Channel']} & {row['Model']} & {row['Metric']} & {values} \\\\")
+    return "\n".join(lines)
+
+
+def _load_models_dict(args: argparse.Namespace) -> dict[str, str]:
+    if args.models_json:
+        parsed = json.loads(args.models_json)
+    elif args.config:
+        config_path = Path(args.config)
+        if not config_path.exists():
+            raise ValueError(f"Config file not found: {config_path}")
+
+        if config_path.suffix.lower() in {".yaml", ".yml"}:
+            try:
+                import yaml
+            except ImportError as exc:
+                raise ImportError("PyYAML is required for yaml config input") from exc
+            with config_path.open("r", encoding="utf-8") as file:
+                parsed = yaml.safe_load(file)
+        else:
+            with config_path.open("r", encoding="utf-8") as file:
+                parsed = json.load(file)
+    else:
+        raise ValueError("Please provide --models-json or --config")
+
+    if isinstance(parsed, dict) and "models" in parsed:
+        parsed = parsed["models"]
+    if not isinstance(parsed, dict):
+        raise ValueError("Model configuration must be a dict of {model_name: metrics_dir}")
+
+    models = {str(k): str(v) for k, v in parsed.items()}
+    if not models:
+        raise ValueError("No model mappings found in configuration")
+    return models
+
+
+def _build_scope_specs(channel_names: list[str]) -> list[ScopeSpec]:
+    specs: list[ScopeSpec] = [
+        ScopeSpec(label="AVG[0-6]", channel_indices=tuple(range(0, 7)), metric_columns=("mase", "sql")),
+        ScopeSpec(label="AVG[7-8]", channel_indices=(7, 8), metric_columns=("mse", "f1")),
+        ScopeSpec(label="AVG[9-18]", channel_indices=tuple(range(9, 19)), metric_columns=("mse", "f1")),
+    ]
+
+    for channel_idx in range(len(channel_names)):
+        if channel_idx <= 6:
+            metric_columns = ("mae", "mase")
+        else:
+            metric_columns = ("mse", "f1")
+        specs.append(
+            ScopeSpec(
+                label=channel_names[channel_idx],
+                channel_indices=(channel_idx,),
+                metric_columns=metric_columns,
+            )
+        )
+    return specs
+
+
+def _aggregate_scope_results(
+    scope_specs: list[ScopeSpec],
+    channel_names: list[str],
+    base_metric_results: dict[str, tuple[pd.DataFrame, pd.DataFrame]],
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    metric_rows: list[pd.DataFrame] = []
+    rank_rows: list[pd.DataFrame] = []
+
+    for scope in scope_specs:
+        selected_channel_names = [
+            channel_names[idx]
+            for idx in scope.channel_indices
+            if 0 <= idx < len(channel_names)
+        ]
+        if not selected_channel_names:
+            continue
+
+        for metric_column in scope.metric_columns:
+            metric_label = _metric_label_from_column(metric_column)
+            metric_df, rank_df = base_metric_results.get(
+                metric_column,
+                (pd.DataFrame(), pd.DataFrame()),
+            )
+
+            metric_slice = pd.DataFrame()
+            if "channel" in metric_df.columns:
+                metric_slice = metric_df.loc[metric_df["channel"].isin(selected_channel_names)].copy()
+            if not metric_slice.empty:
+                grouped_metric = (
+                    metric_slice.groupby(["model", "group_start", "group_label"], as_index=False)["metric_mean"]
+                    .mean()
+                )
+                grouped_metric["channel"] = scope.label
+                grouped_metric["metric"] = metric_label
+                metric_rows.append(
+                    grouped_metric[["channel", "model", "metric", "group_start", "group_label", "metric_mean"]]
+                )
+
+            rank_slice = pd.DataFrame()
+            if "channel" in rank_df.columns:
+                rank_slice = rank_df.loc[rank_df["channel"].isin(selected_channel_names)].copy()
+            if not rank_slice.empty:
+                grouped_rank = (
+                    rank_slice.groupby(["model", "group_start", "group_label"], as_index=False)["mean_rank"]
+                    .mean()
+                )
+                grouped_rank["channel"] = scope.label
+                grouped_rank["metric"] = metric_label
+                rank_rows.append(
+                    grouped_rank[["channel", "model", "metric", "group_start", "group_label", "mean_rank"]]
+                )
+
+    if metric_rows:
+        metric_means = pd.concat(metric_rows, ignore_index=True)
+    else:
+        metric_means = pd.DataFrame(
+            columns=["channel", "model", "metric", "group_start", "group_label", "metric_mean"]
+        )
+
+    if rank_rows:
+        rank_means = pd.concat(rank_rows, ignore_index=True)
+    else:
+        rank_means = pd.DataFrame(
+            columns=["channel", "model", "metric", "group_start", "group_label", "mean_rank"]
+        )
+
+    return metric_means, rank_means
+
+
+def _compute_scope_user_metric_rows(
+    models: dict[str, str],
+    scope_specs: list[ScopeSpec],
+    metric_data: dict[str, dict[str, dict[str, np.ndarray]]],
+) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+
+    for scope in scope_specs:
+        for metric_column in scope.metric_columns:
+            per_model_user_metric = metric_data.get(metric_column, {})
+            display_metric = _metric_label_from_column(metric_column)
+
+            for model_name in models:
+                user_map = per_model_user_metric.get(model_name, {})
+                for user_id, arr in user_map.items():
+                    selected_indices = [idx for idx in scope.channel_indices if idx < arr.shape[0]]
+                    if not selected_indices:
+                        continue
+
+                    _, horizon = arr.shape
+                    group_hours: dict[int, list[int]] = {}
+                    for hour in range(horizon):
+                        summary_hour = _project_hour_index(hour=hour, horizon=horizon)
+                        group_start = _group_start_from_hour(summary_hour)
+                        group_hours.setdefault(group_start, []).append(hour)
+
+                    for group_start, hours in sorted(group_hours.items()):
+                        group_values = arr[np.asarray(selected_indices, dtype=int)][:, hours]
+                        finite_values = group_values[np.isfinite(group_values)]
+                        if finite_values.size == 0:
+                            continue
+
+                        rows.append(
+                            {
+                                "channel": scope.label,
+                                "model": model_name,
+                                "user_id": user_id,
+                                "metric": display_metric,
+                                "group_start": int(group_start),
+                                "group_label": _group_label(int(group_start)),
+                                "metric_value": float(np.mean(finite_values)),
+                            }
+                        )
+
+    if not rows:
+        return pd.DataFrame(
+            columns=["channel", "model", "user_id", "metric", "group_start", "group_label", "metric_value"]
+        )
+    return pd.DataFrame(rows)
+
+
+def _compute_model_group_means(user_metric_df: pd.DataFrame) -> pd.DataFrame:
+    if user_metric_df.empty:
+        return pd.DataFrame(
+            columns=["channel", "model", "metric", "group_start", "group_label", "metric_mean"]
+        )
+
+    out = (
+        user_metric_df.groupby(["channel", "model", "metric", "group_start", "group_label"], as_index=False)["metric_value"]
+        .mean()
+        .rename(columns={"metric_value": "metric_mean"})
+    )
+    return out
+
+
+def _compute_model_group_ranks(user_metric_df: pd.DataFrame) -> pd.DataFrame:
+    if user_metric_df.empty:
+        return pd.DataFrame(
+            columns=["channel", "model", "metric", "group_start", "group_label", "mean_rank"]
+        )
+
+    rank_rows: list[pd.DataFrame] = []
+
+    for (channel_label, metric_name, group_start, group_label), group_slice in user_metric_df.groupby(
+        ["channel", "metric", "group_start", "group_label"],
+        sort=True,
+    ):
+        pivot = group_slice.pivot(index="user_id", columns="model", values="metric_value")
+        if pivot.empty:
+            continue
+
+        rank_df = pivot.rank(axis=1, method="average", ascending=True)
+        long_rank = rank_df.stack(dropna=True).reset_index()
+        long_rank.columns = ["user_id", "model", "rank"]
+        long_rank["channel"] = channel_label
+        long_rank["metric"] = metric_name
+        long_rank["group_start"] = int(group_start)
+        long_rank["group_label"] = group_label
+        rank_rows.append(long_rank)
+
+    if not rank_rows:
+        return pd.DataFrame(
+            columns=["channel", "model", "metric", "group_start", "group_label", "mean_rank"]
+        )
+
+    rank_all = pd.concat(rank_rows, ignore_index=True)
+    out = (
+        rank_all.groupby(["channel", "model", "metric", "group_start", "group_label"], as_index=False)["rank"]
+        .mean()
+        .rename(columns={"rank": "mean_rank"})
+    )
+    return out
+
+
+def _build_combined_table(
+    metric_means: pd.DataFrame,
+    rank_means: pd.DataFrame,
+    scope_order: list[str],
+    model_order: list[str],
+    scope_metric_order: dict[str, list[str]],
+) -> pd.DataFrame:
+    all_group_starts = sorted(
+        {
+            int(group_start)
+            for df in (metric_means, rank_means)
+            for group_start in df["group_start"].tolist()
+        }
+    )
+    if not all_group_starts:
+        raise ValueError("No grouped metric rows were produced.")
+
+    group_labels: dict[int, str] = {}
+    for group_start in all_group_starts:
+        matched = metric_means.loc[metric_means["group_start"] == group_start, "group_label"]
+        if matched.empty:
+            matched = rank_means.loc[rank_means["group_start"] == group_start, "group_label"]
+        if matched.empty:
+            group_labels[group_start] = _format_group_label_for_paper(_group_label(group_start))
+        else:
+            group_labels[group_start] = _format_group_label_for_paper(str(matched.iloc[0]))
+
+    rows: list[dict[str, Any]] = []
+    for scope_label in scope_order:
+        metric_order = scope_metric_order.get(scope_label, [])
+        for model_name in model_order:
+            metric_slice = metric_means.loc[
+                (metric_means["channel"] == scope_label) & (metric_means["model"] == model_name)
+            ]
+            rank_slice = rank_means.loc[
+                (rank_means["channel"] == scope_label) & (rank_means["model"] == model_name)
+            ]
+
+            for metric_name in metric_order:
+                metric_row = {"Channel": scope_label, "Model": model_name, "Metric": metric_name}
+                for group_start in all_group_starts:
+                    column_name = group_labels[group_start]
+                    matched = metric_slice.loc[
+                        (metric_slice["metric"] == metric_name) & (metric_slice["group_start"] == group_start),
+                        "metric_mean",
+                    ]
+                    if matched.empty:
+                        metric_row[column_name] = "/"
+                    else:
+                        value = float(matched.iloc[0])
+                        metric_row[column_name] = round(value, 2) if np.isfinite(value) else "/"
+                rows.append(metric_row)
+
+            for metric_name in metric_order:
+                rank_metric_name = _rank_label_from_metric_label(metric_name)
+                rank_row = {"Channel": scope_label, "Model": model_name, "Metric": rank_metric_name}
+                for group_start in all_group_starts:
+                    column_name = group_labels[group_start]
+                    matched = rank_slice.loc[
+                        (rank_slice["metric"] == metric_name) & (rank_slice["group_start"] == group_start),
+                        "mean_rank",
+                    ]
+                    if matched.empty:
+                        rank_row[column_name] = "/"
+                    else:
+                        value = float(matched.iloc[0])
+                        rank_row[column_name] = round(value, 2) if np.isfinite(value) else "/"
+                rows.append(rank_row)
+
+    return pd.DataFrame(rows)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for all-channel paper summaries."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate paper-ready grouped metric aggregation and user-level ranking "
+            "across aggregate channel collections plus individual channels."
+        )
+    )
+    parser.add_argument(
+        "--models-json",
+        default=None,
+        help='Inline JSON dict, e.g. {"modelA":"/path/a","modelB":"/path/b"}',
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to JSON/YAML config with model dict (top-level dict or {models: {...}}).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="results/metrics_summary",
+        help="Output directory for generated paper CSV files.",
+    )
+    parser.add_argument(
+        "--output-file",
+        default=None,
+        help=(
+            "Optional output file path. Defaults to "
+            "<output-dir>/paper_result_table_all_channels_grouped.csv."
+        ),
+    )
+    parser.add_argument(
+        "--max-user",
+        type=int,
+        default=None,
+        help="Optional cap for users after computing model user intersection.",
+    )
+    parser.add_argument(
+        "--random-seed",
+        type=int,
+        default=42,
+        help="Random seed used when --max-user is provided.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Generate all-channel paper result summaries."""
+    args = parse_args()
+    models = _load_models_dict(args)
+    user_probe_metric = "mase"
+
+    users_per_model = {
+        name: _collect_users_for_model(path, metric_column=user_probe_metric)
+        for name, path in models.items()
+    }
+    all_users: set[str] = set()
+    for users in users_per_model.values():
+        all_users.update(users)
+
+    if not all_users:
+        raise ValueError("No users found across the provided models.")
+
+    selected_users = all_users
+    if args.max_user is not None and args.max_user > 0 and len(all_users) > args.max_user:
+        rng = random.Random(args.random_seed)
+        selected_users = set(rng.sample(sorted(all_users), k=args.max_user))
+
+    first_model_dir = next(iter(models.values()))
+    channel_names = _infer_channel_names(first_model_dir, n_features=19)
+    scope_specs = _build_scope_specs(channel_names)
+    scope_order = [scope.label for scope in scope_specs]
+    scope_metric_order = {
+        scope.label: [_metric_label_from_column(metric_column) for metric_column in scope.metric_columns]
+        for scope in scope_specs
+    }
+
+    metric_columns_needed = sorted({metric for scope in scope_specs for metric in scope.metric_columns})
+    metric_data: dict[str, dict[str, dict[str, np.ndarray]]] = {}
+    for metric_column in metric_columns_needed:
+        metric_data[metric_column] = {
+            model_name: _load_per_model_user_metric(
+                model_dir=model_dir,
+                metric_column=metric_column,
+                allowed_users=selected_users,
+            )
+            for model_name, model_dir in models.items()
+        }
+
+    base_metric_results: dict[str, tuple[pd.DataFrame, pd.DataFrame]] = {}
+    for metric_column, per_model_user_metric in metric_data.items():
+        base_metric_results[metric_column] = (
+            _aggregate_metric_3hour_one_channel(
+                models=models,
+                per_model_user_metric=per_model_user_metric,
+            ),
+            _rank_metric_by_user_3hour_one_channel(
+                models=models,
+                per_model_user_metric=per_model_user_metric,
+            ),
+        )
+
+    metric_means, rank_means = _aggregate_scope_results(
+        scope_specs=scope_specs,
+        channel_names=channel_names,
+        base_metric_results=base_metric_results,
+    )
+    paper_table_df = _build_combined_table(
+        metric_means=metric_means,
+        rank_means=rank_means,
+        scope_order=scope_order,
+        model_order=list(models.keys()),
+        scope_metric_order=scope_metric_order,
+    )
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if args.output_file:
+        output_path = Path(args.output_file)
+    else:
+        output_path = output_dir / "paper_result_table_all_channels_grouped.csv"
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    paper_table_df.to_csv(output_path, index=False)
+
+    print("=== Paper result table (all channels grouped) ===")
+    print(f"output: {output_path}")
+    print(_render_plaintext_table(paper_table_df))
+    print("=== LaTeX rows ===")
+    print(_render_latex_rows(paper_table_df))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/forecasting_evaluation/metrics/paper_result_generator_one_channel.py
+++ b/src/forecasting_evaluation/metrics/paper_result_generator_one_channel.py
@@ -1,0 +1,751 @@
+"""Generate paper-ready forecasting results from offline metrics parquet files.
+
+This module builds one combined table from offline metrics produced by
+`src/forecasting_evaluation/metrics/offline_calculate.py`. For each requested
+metric column, it computes:
+1. 3-hour grouped metric aggregation per model/channel.
+2. User-level average rank per model/channel/3-hour group.
+
+The final output contains all requested metrics together so that cross-metric
+comparison is possible in a single table.
+
+Model inputs are provided as a dict mapping:
+    {"model_name": "/path/to/model_metrics_root", ...}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+CHANNEL_NAME_MAP = {
+    "first": ["hk_iphone:HKQuantityTypeIdentifierStepCount"],
+    "iPhone": [
+        "hk_iphone:HKQuantityTypeIdentifierStepCount",
+        "hk_iphone:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_iphone:HKQuantityTypeIdentifierFlightsClimbed",
+    ],
+    "watch": [
+        "hk_watch:HKQuantityTypeIdentifierStepCount",
+        "hk_watch:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_watch:HKQuantityTypeIdentifierHeartRate",
+        "hk_watch:HKQuantityTypeIdentifierActiveEnergyBurned",
+    ],
+    "all": [
+        "hk_iphone:HKQuantityTypeIdentifierStepCount",
+        "hk_iphone:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_iphone:HKQuantityTypeIdentifierFlightsClimbed",
+        "hk_watch:HKQuantityTypeIdentifierStepCount",
+        "hk_watch:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_watch:HKQuantityTypeIdentifierHeartRate",
+        "hk_watch:HKQuantityTypeIdentifierActiveEnergyBurned",
+        "sleep:asleep",
+        "sleep:inbed",
+        "workout:HKWorkoutActivityTypeWalking",
+        "workout:HKWorkoutActivityTypeCycling",
+        "workout:HKWorkoutActivityTypeRunning",
+        "workout:HKWorkoutActivityTypeOther",
+        "workout:HKWorkoutActivityTypeMixedMetabolicCardioTraining",
+        "workout:HKWorkoutActivityTypeTraditionalStrengthTraining",
+        "workout:HKWorkoutActivityTypeElliptical",
+        "workout:HKWorkoutActivityTypeHighIntensityIntervalTraining",
+        "workout:HKWorkoutActivityTypeFunctionalStrengthTraining",
+        "workout:HKWorkoutActivityTypeYoga",
+    ],
+}
+
+def _safe_read_parquet(file_path: str | Path, **kwargs: Any) -> pd.DataFrame | None:
+    path = Path(file_path)
+    try:
+        if not path.exists() or path.stat().st_size == 0:
+            return None
+        return pd.read_parquet(path, **kwargs)
+    except Exception:
+        return None
+
+
+def _list_parquet_files(model_dir: str | Path) -> list[Path]:
+    path = Path(model_dir)
+    if not path.exists():
+        return []
+    return sorted(path.rglob("*.parquet"))
+
+
+def _resolve_metric_dir(model_dir: str | Path, metric_name: str) -> Path:
+    """Resolve one model root to the corresponding metric directory."""
+    path = Path(model_dir)
+    metric_dir = path / metric_name
+    return metric_dir
+
+
+def _safe_to_2d_array(value: Any) -> np.ndarray | None:
+    if value is None:
+        return None
+
+    try:
+        arr = np.asarray(value, dtype=float)
+        if arr.ndim == 2:
+            return arr
+    except Exception:
+        pass
+
+    try:
+        obj = np.asarray(value, dtype=object)
+    except Exception:
+        return None
+
+    if obj.ndim != 1:
+        return None
+
+    rows: list[np.ndarray] = []
+    for item in obj.tolist():
+        try:
+            row = np.asarray(item, dtype=float).reshape(-1)
+        except Exception:
+            return None
+        if row.size == 0:
+            return None
+        rows.append(row)
+
+    if not rows:
+        return None
+    min_len = min(row.shape[0] for row in rows)
+    if min_len <= 0:
+        return None
+    return np.vstack([row[:min_len] for row in rows])
+
+
+def _parse_metric_matrix(raw_value: Any) -> np.ndarray | None:
+    return _safe_to_2d_array(raw_value)
+
+
+def _collect_users_for_model(model_dir: str | Path, metric_column: str) -> set[str]:
+    resolved_dir = _resolve_metric_dir(model_dir, metric_column)
+    if not resolved_dir.is_dir():
+        return set()
+    users: set[str] = set()
+    for parquet_file in _list_parquet_files(resolved_dir):
+        df = _safe_read_parquet(parquet_file, columns=["user_id"])
+        if df is None or "user_id" not in df.columns:
+            continue
+        users.update(df["user_id"].astype(str).dropna().unique().tolist())
+    return users
+
+
+def _project_hour_index(hour: int, horizon: int) -> int:
+    # For horizons >= 48, collapse to hour-of-day to align with prior summaries.
+    if horizon >= 48:
+        return int(hour % 24)
+    return int(hour)
+
+
+def _group_start_from_hour(hour: int) -> int:
+    return int((hour // 3) * 3)
+
+
+def _group_label(group_start: int) -> str:
+    return f"{group_start:02d}-{group_start + 2:02d}"
+
+
+def _normalize_model_display_name(model_name: str) -> str:
+    return model_name
+
+
+def _format_group_label_for_paper(group_label: str) -> str:
+    start_str, end_str = group_label.split("-")
+    return f"{int(start_str)}-{int(end_str)}"
+
+
+def _read_config_channel(model_dir: str | Path) -> str | None:
+    root = Path(model_dir)
+    candidates = [root / "config.yaml", root.parent / "config.yaml"]
+    config_path = next((p for p in candidates if p.exists()), None)
+    if config_path is None:
+        return None
+
+    try:
+        import yaml
+    except ImportError:
+        return None
+
+    with config_path.open("r", encoding="utf-8") as f:
+        config = yaml.safe_load(f) or {}
+    return (config.get("features") or {}).get("channel")
+
+
+def _infer_channel_names(model_dir: str | Path, n_features: int) -> list[str]:
+    channel_key = _read_config_channel(model_dir)
+    if channel_key is None:
+        return [f"feature_{i}" for i in range(n_features)]
+    mapped = CHANNEL_NAME_MAP.get(channel_key)
+    if not mapped:
+        return [f"feature_{i}" for i in range(n_features)]
+    if len(mapped) >= n_features:
+        return mapped[:n_features]
+    return mapped + [f"feature_{i}" for i in range(len(mapped), n_features)]
+
+
+def _mean_matrices(mats: list[np.ndarray]) -> np.ndarray | None:
+    if not mats:
+        return None
+    min_features = min(m.shape[0] for m in mats)
+    min_horizon = min(m.shape[1] for m in mats)
+    if min_features <= 0 or min_horizon <= 0:
+        return None
+    trimmed = [m[:min_features, :min_horizon] for m in mats]
+    stack = np.stack(trimmed, axis=0)
+    finite_mask = np.isfinite(stack)
+    counts = finite_mask.sum(axis=0)
+    sums = np.where(finite_mask, stack, 0.0).sum(axis=0)
+    mean = np.full((min_features, min_horizon), np.nan, dtype=float)
+    valid = counts > 0
+    mean[valid] = sums[valid] / counts[valid]
+    return mean
+
+
+def _load_per_model_user_metric(
+    model_dir: str | Path,
+    metric_column: str,
+    allowed_users: set[str] | None = None,
+) -> dict[str, np.ndarray]:
+    resolved_dir = _resolve_metric_dir(model_dir, metric_column)
+    if not resolved_dir.is_dir():
+        return {}
+    per_user_rows: dict[str, list[np.ndarray]] = {}
+
+    for parquet_file in _list_parquet_files(resolved_dir):
+        df = _safe_read_parquet(parquet_file, columns=["user_id", metric_column])
+        if df is None or "user_id" not in df.columns or metric_column not in df.columns:
+            continue
+
+        for _, row in df.iterrows():
+            user = str(row.get("user_id"))
+            if allowed_users is not None and user not in allowed_users:
+                continue
+            metric = _parse_metric_matrix(row.get(metric_column))
+            if metric is None:
+                continue
+            per_user_rows.setdefault(user, [])
+            per_user_rows[user].append(metric)
+
+    per_user_avg: dict[str, np.ndarray] = {}
+    for user, rows in per_user_rows.items():
+        mean_metric = _mean_matrices(rows)
+        if mean_metric is not None:
+            per_user_avg[user] = mean_metric
+    return per_user_avg
+
+
+def aggregate_metric_3hour(
+    models: dict[str, str],
+    per_model_user_metric: dict[str, dict[str, np.ndarray]],
+) -> pd.DataFrame:
+    """Aggregate per-user metric matrices into 3-hour model/channel summaries."""
+    acc: dict[tuple[str, str, int], dict[str, float | int]] = {}
+
+    for model_name, user_map in per_model_user_metric.items():
+        if not user_map:
+            continue
+
+        min_features = min(arr.shape[0] for arr in user_map.values())
+        channels = _infer_channel_names(models[model_name], min_features)
+
+        for arr in user_map.values():
+            arr = arr[:min_features, :]
+            n_features, horizon = arr.shape
+
+            for feature_idx in range(n_features):
+                channel = channels[feature_idx] if feature_idx < len(channels) else f"feature_{feature_idx}"
+                for hour in range(horizon):
+                    value = float(arr[feature_idx, hour])
+                    if not np.isfinite(value):
+                        continue
+                    summary_hour = _project_hour_index(hour=hour, horizon=horizon)
+                    group_start = _group_start_from_hour(summary_hour)
+                    key = (model_name, channel, group_start)
+                    if key not in acc:
+                        acc[key] = {"sum": 0.0, "sum_sq": 0.0, "n": 0}
+                    acc[key]["sum"] = float(acc[key]["sum"]) + value
+                    acc[key]["sum_sq"] = float(acc[key]["sum_sq"]) + value * value
+                    acc[key]["n"] = int(acc[key]["n"]) + 1
+
+    rows: list[dict[str, Any]] = []
+    for (model_name, channel, group_start), stats in acc.items():
+        n = int(stats["n"])
+        if n <= 0:
+            continue
+        mean = float(stats["sum"]) / n
+        var = max(0.0, float(stats["sum_sq"]) / n - mean * mean)
+        rows.append(
+            {
+                "model": model_name,
+                "channel": channel,
+                "group_start": int(group_start),
+                "group_label": _group_label(int(group_start)),
+                "metric_mean": float(mean),
+                "metric_std": float(np.sqrt(var)),
+                "n": n,
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame(
+            columns=["model", "channel", "group_start", "group_label", "metric_mean", "metric_std", "n"]
+        )
+    return pd.DataFrame(rows).sort_values(["model", "channel", "group_start"]).reset_index(
+        drop=True
+    )
+
+
+def rank_metric_by_user_3hour(
+    models: dict[str, str],
+    per_model_user_metric: dict[str, dict[str, np.ndarray]],
+) -> pd.DataFrame:
+    """Rank models per user within each 3-hour group and average the ranks."""
+    if not per_model_user_metric:
+        return pd.DataFrame(
+            columns=["model", "channel", "group_start", "group_label", "mean_rank", "n_users"]
+        )
+
+    model_names = [model_name for model_name in models if per_model_user_metric.get(model_name)]
+    if not model_names:
+        return pd.DataFrame(
+            columns=["model", "channel", "group_start", "group_label", "mean_rank", "n_users"]
+        )
+
+    all_users: set[str] = set()
+    for model_name in model_names:
+        all_users.update(per_model_user_metric.get(model_name, {}).keys())
+
+    if not all_users:
+        return pd.DataFrame(
+            columns=["model", "channel", "group_start", "group_label", "mean_rank", "n_users"]
+        )
+
+    # Use first available model for channel naming, then trim by the feature count among
+    # models that have at least one user.
+    first_model_name = model_names[0]
+    n_features_common = min(
+        min(arr.shape[0] for arr in per_model_user_metric[m].values())
+        for m in model_names
+        if per_model_user_metric.get(m)
+    )
+    channels = _infer_channel_names(models[first_model_name], n_features_common)
+
+    rank_acc: dict[tuple[str, str, int], list[float]] = {}
+
+    for user in sorted(all_users):
+        model_arrs: dict[str, np.ndarray] = {
+            m: per_model_user_metric[m][user]
+            for m in model_names
+            if user in per_model_user_metric.get(m, {})
+        }
+        if len(model_arrs) < 2:
+            continue
+
+        group_hours_per_model: dict[str, dict[int, list[int]]] = {}
+        for model_name, arr in model_arrs.items():
+            arr = arr[:n_features_common, :]
+            model_arrs[model_name] = arr
+            _, horizon = arr.shape
+            group_hours: dict[int, list[int]] = {}
+            for hour in range(horizon):
+                summary_hour = _project_hour_index(hour=hour, horizon=horizon)
+                group_start = _group_start_from_hour(summary_hour)
+                group_hours.setdefault(group_start, []).append(hour)
+            group_hours_per_model[model_name] = group_hours
+        all_groups = sorted({group for groups in group_hours_per_model.values() for group in groups})
+
+        for feature_idx in range(n_features_common):
+            channel = channels[feature_idx] if feature_idx < len(channels) else f"feature_{feature_idx}"
+            for group_start in all_groups:
+                model_scores: list[float] = []
+                model_order: list[str] = []
+                for model_name in model_names:
+                    if model_name not in model_arrs:
+                        continue
+                    arr = model_arrs[model_name]
+                    hours = group_hours_per_model[model_name].get(group_start, [])
+                    if not hours:
+                        continue
+                    group_values = arr[feature_idx, hours]
+                    if group_values.size == 0:
+                        continue
+                    if not np.isfinite(group_values).any():
+                        continue
+                    score = float(np.nanmean(group_values))
+                    if not np.isfinite(score):
+                        continue
+                    model_scores.append(score)
+                    model_order.append(model_name)
+
+                if len(model_scores) < 2:
+                    continue
+
+                # Lower metric is better: rank 1 is best.
+                ranks = pd.Series(model_scores, index=model_order).rank(
+                    method="average", ascending=True
+                )
+                for model_name, rank_value in ranks.items():
+                    key = (model_name, channel, group_start)
+                    rank_acc.setdefault(key, []).append(float(rank_value))
+
+    rows: list[dict[str, Any]] = []
+    for (model_name, channel, group_start), values in rank_acc.items():
+        if not values:
+            continue
+        rows.append(
+            {
+                "model": model_name,
+                "channel": channel,
+                "group_start": int(group_start),
+                "group_label": _group_label(int(group_start)),
+                "mean_rank": float(np.mean(values)),
+                "n_users": int(len(values)),
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame(
+            columns=["model", "channel", "group_start", "group_label", "mean_rank", "n_users"]
+        )
+    return pd.DataFrame(rows).sort_values(["model", "channel", "group_start"]).reset_index(
+        drop=True
+    )
+
+
+def _load_models_dict(args: argparse.Namespace) -> dict[str, str]:
+    if args.models_json:
+        parsed = json.loads(args.models_json)
+    elif args.config:
+        config_path = Path(args.config)
+        if not config_path.exists():
+            raise ValueError(f"Config file not found: {config_path}")
+
+        if config_path.suffix.lower() in {".yaml", ".yml"}:
+            try:
+                import yaml
+            except ImportError as exc:
+                raise ImportError("PyYAML is required for yaml config input") from exc
+            with config_path.open("r", encoding="utf-8") as f:
+                parsed = yaml.safe_load(f)
+        else:
+            with config_path.open("r", encoding="utf-8") as f:
+                parsed = json.load(f)
+    else:
+        raise ValueError("Please provide --models-json or --config")
+
+    if isinstance(parsed, dict) and "models" in parsed:
+        parsed = parsed["models"]
+    if not isinstance(parsed, dict):
+        raise ValueError("Model configuration must be a dict of {model_name: metrics_dir}")
+
+    models = {str(k): str(v) for k, v in parsed.items()}
+    if not models:
+        raise ValueError("No model mappings found in configuration")
+    return models
+
+
+def _build_combined_paper_ready_table(
+    metric_results: dict[str, tuple[pd.DataFrame, pd.DataFrame]],
+    channel: str,
+    model_order: list[str],
+) -> pd.DataFrame:
+    """Build one paper table that contains all requested metrics and their ranks."""
+    if not metric_results:
+        raise ValueError("No metric results were provided for paper table construction")
+
+    group_order = sorted(
+        {
+            int(group_start)
+            for metric_3h_df, rank_df in metric_results.values()
+            for df in (metric_3h_df, rank_df)
+            if not df.empty
+            for group_start in df.loc[df["channel"] == channel, "group_start"].tolist()
+        }
+    )
+    if not group_order:
+        raise ValueError(f"Channel not found in any metric results: {channel}")
+
+    group_labels: dict[int, str] = {}
+    for group_start in group_order:
+        for metric_3h_df, rank_df in metric_results.values():
+            for df in (metric_3h_df, rank_df):
+                matched = df.loc[
+                    (df["channel"] == channel) & (df["group_start"] == group_start),
+                    "group_label",
+                ]
+                if not matched.empty:
+                    group_labels[group_start] = _format_group_label_for_paper(matched.iloc[0])
+                    break
+            if group_start in group_labels:
+                break
+
+    rows: list[dict[str, Any]] = []
+    for model_name in model_order:
+        display_model_name = _normalize_model_display_name(model_name)
+
+        for metric_column, (metric_3h_df, _) in metric_results.items():
+            metric_label = _metric_label_from_column(metric_column)
+            metric_filtered = metric_3h_df.loc[metric_3h_df["channel"] == channel].copy()
+            metric_pivot = (
+                metric_filtered.assign(model=lambda df: df["model"].map(_normalize_model_display_name))
+                .pivot(index="model", columns="group_start", values="metric_mean")
+                .reindex(index=[display_model_name], columns=group_order)
+            )
+
+            metric_row = {"Model": display_model_name, "Metric": metric_label}
+            for group_start in group_order:
+                column_name = group_labels[group_start]
+                value = metric_pivot.loc[display_model_name, group_start]
+                metric_row[column_name] = (
+                    round(float(value), 2) if pd.notna(value) and np.isfinite(float(value)) else "/"
+                )
+            rows.append(metric_row)
+
+        for metric_column, (_, rank_df) in metric_results.items():
+            metric_label = _metric_label_from_column(metric_column)
+            rank_filtered = rank_df.loc[rank_df["channel"] == channel].copy()
+            rank_pivot = (
+                rank_filtered.assign(model=lambda df: df["model"].map(_normalize_model_display_name))
+                .pivot(index="model", columns="group_start", values="mean_rank")
+                .reindex(index=[display_model_name], columns=group_order)
+            )
+
+            rank_row = {
+                "Model": display_model_name,
+                "Metric": _rank_label_from_metric_label(metric_label),
+            }
+            for group_start in group_order:
+                column_name = group_labels[group_start]
+                value = rank_pivot.loc[display_model_name, group_start]
+                rank_row[column_name] = (
+                    round(float(value), 2) if pd.notna(value) and np.isfinite(float(value)) else "/"
+                )
+            rows.append(rank_row)
+
+    return pd.DataFrame(rows)
+
+
+def _format_output_value(value: Any) -> str:
+    """Format exported table values, using '/' for missing entries."""
+    if isinstance(value, str):
+        return value
+
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return "/"
+
+    if not np.isfinite(numeric):
+        return "/"
+    return f"{numeric:.2f}"
+
+
+def _render_plaintext_table(df: pd.DataFrame) -> str:
+    columns = df.columns.tolist()
+    str_df = df.copy()
+    for column in columns[2:]:
+        str_df[column] = str_df[column].map(_format_output_value)
+
+    widths: dict[str, int] = {}
+    for column in columns:
+        widths[column] = max(len(str(column)), str_df[column].astype(str).map(len).max())
+
+    header = " | ".join(str(column).ljust(widths[column]) for column in columns)
+    divider = "-+-".join("-" * widths[column] for column in columns)
+    body = [
+        " | ".join(str(row[column]).ljust(widths[column]) for column in columns)
+        for _, row in str_df.iterrows()
+    ]
+    return "\n".join([header, divider, *body])
+
+
+def _render_latex_rows(df: pd.DataFrame) -> str:
+    value_columns = df.columns.tolist()[2:]
+    lines: list[str] = []
+    for _, row in df.iterrows():
+        values = " & ".join(_format_output_value(row[column]) for column in value_columns)
+        lines.append(f"{row['Model']} & {row['Metric']} & {values} \\\\")
+    return "\n".join(lines)
+
+
+def _metric_label_from_column(metric_column: str) -> str:
+    """Map parquet metric column names to paper-facing display labels."""
+    normalized = metric_column.strip().lower()
+    if normalized == "mae":
+        return "MAE"
+    if normalized == "mse":
+        return "MSE"
+    if normalized == "f1":
+        return "F1"
+    if normalized == "mase":
+        return "MASE"
+    if normalized == "ql":
+        return "QL"
+    if normalized == "sql":
+        return "sQL"
+    return metric_column
+
+
+def _rank_label_from_metric_label(metric_label: str) -> str:
+    """Build the row label used for metric-specific ranking rows."""
+    return f"Rank_{metric_label}"
+
+
+def _parse_metric_columns_arg(raw_metric_columns: list[list[str]] | None) -> list[str]:
+    """Flatten and deduplicate requested metric columns while preserving order."""
+    if not raw_metric_columns:
+        return ["mae"]
+
+    parsed: list[str] = []
+    seen: set[str] = set()
+    for group in raw_metric_columns:
+        for metric in group:
+            normalized = metric.strip()
+            if not normalized or normalized in seen:
+                continue
+            parsed.append(normalized)
+            seen.add(normalized)
+    return parsed or ["mae"]
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for paper-ready 3-hour metric aggregation."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate paper-ready 3-hour metric aggregation and user-level model ranking."
+        )
+    )
+    parser.add_argument(
+        "--models-json",
+        default=None,
+        help='Inline JSON dict, e.g. {"modelA":"/path/a","modelB":"/path/b"}',
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to JSON/YAML config with model dict (top-level dict or {models: {...}}).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="results/metrics_summary",
+        help="Output directory for generated paper CSV files.",
+    )
+    parser.add_argument(
+        "--metric-column",
+        action="append",
+        nargs="+",
+        default=None,
+        help=(
+            "One or more metric column names in parquet rows. "
+            "Example: --metric-column mae mase ql"
+        ),
+    )
+    parser.add_argument(
+        "--channel",
+        default="hk_iphone:HKQuantityTypeIdentifierStepCount",
+        help="Channel name to export for the paper table.",
+    )
+    parser.add_argument(
+        "--output-file",
+        default=None,
+        help=(
+            "Optional output file path. Defaults to "
+            "<output-dir>/paper_result_table_<sanitized_channel>.csv."
+        ),
+    )
+    parser.add_argument(
+        "--max-user",
+        type=int,
+        default=None,
+        help="Optional cap for users after computing model user intersection.",
+    )
+    parser.add_argument(
+        "--random-seed",
+        type=int,
+        default=42,
+        help="Random seed used when --max-user is provided.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Load model mappings, compute summaries, and write one paper-ready table."""
+    args = parse_args()
+    models = _load_models_dict(args)
+    metric_columns = _parse_metric_columns_arg(args.metric_column)
+
+    primary_metric = metric_columns[0]
+    users_per_model = {
+        name: _collect_users_for_model(path, metric_column=primary_metric)
+        for name, path in models.items()
+    }
+    all_users: set[str] = set()
+    for users in users_per_model.values():
+        all_users.update(users)
+
+    if not all_users:
+        raise ValueError("No users found across the provided models.")
+
+    selected_users = all_users
+    if args.max_user is not None and args.max_user > 0 and len(all_users) > args.max_user:
+        rng = random.Random(args.random_seed)
+        selected_users = set(rng.sample(sorted(all_users), k=args.max_user))
+
+    metric_results: dict[str, tuple[pd.DataFrame, pd.DataFrame]] = {}
+    for metric_column in metric_columns:
+        per_model_user_metric = {
+            model_name: _load_per_model_user_metric(
+                model_dir=model_dir,
+                metric_column=metric_column,
+                allowed_users=selected_users,
+            )
+            for model_name, model_dir in models.items()
+        }
+
+        metric_3h_df = aggregate_metric_3hour(
+            models=models,
+            per_model_user_metric=per_model_user_metric,
+        )
+        rank_df = rank_metric_by_user_3hour(
+            models=models,
+            per_model_user_metric=per_model_user_metric,
+        )
+        metric_results[metric_column] = (metric_3h_df, rank_df)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paper_table_df = _build_combined_paper_ready_table(
+        metric_results=metric_results,
+        channel=args.channel,
+        model_order=list(models.keys()),
+    )
+
+    if args.output_file:
+        output_path = Path(args.output_file)
+    else:
+        safe_channel = args.channel.replace(":", "_").replace("/", "_")
+        metric_suffix = "_".join(metric_columns)
+        output_path = output_dir / f"paper_result_table_{metric_suffix}_{safe_channel}.csv"
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    paper_table_df.to_csv(output_path, index=False)
+
+    print("=== Paper result table ===")
+    print(f"channel: {args.channel}")
+    print(f"metrics: {metric_columns}")
+    print(f"output: {output_path}")
+    print(_render_plaintext_table(paper_table_df))
+    print("=== LaTeX rows ===")
+    print(_render_latex_rows(paper_table_df))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/forecasting_evaluation/metrics/skill_score_summary.py
+++ b/src/forecasting_evaluation/metrics/skill_score_summary.py
@@ -1,0 +1,740 @@
+"""Compute forecasting skill scores against a configurable baseline model.
+
+The input layout matches the offline metrics tree:
+
+``results/metrics/<model_name>/<metric_name>/<user_id>.parquet``
+
+For each metric/channel, metric rows are first collapsed to either user-level
+or sample-level values. Skill scores are then computed from paired model and
+baseline errors using:
+
+``skill = 1 - geometric_mean(clip(E_model / E_baseline, lower, upper))``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+_CHANNEL_CONSTANTS_PATH = SRC_ROOT / "visualizations" / "constants.py"
+_CHANNEL_SPEC = importlib.util.spec_from_file_location(
+    "_forecasting_skill_score_channel_constants",
+    _CHANNEL_CONSTANTS_PATH,
+)
+if _CHANNEL_SPEC is None or _CHANNEL_SPEC.loader is None:
+    CHANNEL_INFO = {}
+else:
+    _channel_module = importlib.util.module_from_spec(_CHANNEL_SPEC)
+    _CHANNEL_SPEC.loader.exec_module(_channel_module)
+    CHANNEL_INFO = getattr(_channel_module, "CHANNEL_INFO", {})
+
+LOWER_IS_BETTER_METRICS = {"mae", "mse", "mase", "mase_all", "ql", "sql"}
+HIGHER_IS_BETTER_METRICS = {"f1", "auprc", "auroc"}
+
+
+def _safe_read_parquet(file_path: str | Path, **kwargs: Any) -> pd.DataFrame | None:
+    path = Path(file_path)
+    try:
+        if not path.exists() or path.stat().st_size == 0:
+            return None
+        return pd.read_parquet(path, **kwargs)
+    except Exception:
+        return None
+
+
+def _list_parquet_files(metric_dir: str | Path) -> list[Path]:
+    path = Path(metric_dir)
+    if not path.exists():
+        return []
+    return sorted(path.rglob("*.parquet"))
+
+
+def _channel_label(channel_idx: int) -> str:
+    metadata = CHANNEL_INFO.get(channel_idx)
+    if metadata is None:
+        return f"Channel {channel_idx}"
+    return str(metadata["name"])
+
+
+def _parse_channel_indices(raw_value: str | None, default: tuple[int, ...]) -> tuple[int, ...]:
+    if raw_value is None or not raw_value.strip():
+        return default
+
+    indices: list[int] = []
+    for part in raw_value.split(","):
+        token = part.strip()
+        if token:
+            indices.append(int(token))
+
+    if not indices:
+        raise ValueError("At least one channel index must be provided.")
+    return tuple(indices)
+
+
+def _load_models_dict(args: argparse.Namespace) -> dict[str, dict[str, str]]:
+    if args.models_json:
+        parsed = json.loads(args.models_json)
+    elif args.config:
+        config_path = Path(args.config)
+        if not config_path.exists():
+            raise ValueError(f"Config file not found: {config_path}")
+        if config_path.suffix.lower() in {".yaml", ".yml"}:
+            try:
+                import yaml
+            except ImportError as exc:
+                raise ImportError("PyYAML is required for yaml config input") from exc
+            with config_path.open("r", encoding="utf-8") as file:
+                parsed = yaml.safe_load(file)
+        else:
+            with config_path.open("r", encoding="utf-8") as file:
+                parsed = json.load(file)
+    else:
+        raise ValueError("Please provide --models-json or --config")
+
+    if isinstance(parsed, dict) and "models" in parsed:
+        parsed = parsed["models"]
+
+    models: dict[str, dict[str, str]] = {}
+    if isinstance(parsed, dict):
+        for key, value in parsed.items():
+            model_name = str(key).strip()
+            if isinstance(value, dict):
+                model_path = str(value.get("path", "")).strip()
+                display_name = str(value.get("display_name", model_name)).strip()
+            else:
+                model_path = str(value).strip()
+                display_name = model_name
+            if not model_name or not model_path:
+                raise ValueError("Model configuration must use non-empty model names and paths")
+            models[model_name] = {
+                "path": model_path,
+                "display_name": display_name or model_name,
+            }
+    elif isinstance(parsed, list):
+        for item in parsed:
+            if not isinstance(item, dict):
+                raise ValueError("Model configuration list entries must be dictionaries")
+            model_name = str(item.get("name", "")).strip()
+            model_path = str(item.get("path", "")).strip()
+            display_name = str(item.get("display_name", model_name)).strip()
+            if not model_name or not model_path:
+                raise ValueError("Each model entry must contain non-empty name and path")
+            models[model_name] = {
+                "path": model_path,
+                "display_name": display_name or model_name,
+            }
+    else:
+        raise ValueError("Model configuration must be a dict or list")
+
+    if not models:
+        raise ValueError("No model mappings found in configuration")
+    return models
+
+
+def _safe_to_metric_array(value: Any) -> np.ndarray | None:
+    if value is None:
+        return None
+    try:
+        arr = np.asarray(value, dtype=float)
+        if arr.ndim in {1, 2}:
+            return arr
+    except Exception:
+        pass
+
+    try:
+        obj = np.asarray(value, dtype=object)
+    except Exception:
+        return None
+    if obj.ndim != 1:
+        return None
+
+    rows: list[np.ndarray] = []
+    for item in obj.tolist():
+        try:
+            row = np.asarray(item, dtype=float).reshape(-1)
+        except Exception:
+            return None
+        if row.size == 0:
+            return None
+        rows.append(row)
+    if not rows:
+        return None
+    min_len = min(row.shape[0] for row in rows)
+    if min_len <= 0:
+        return None
+    return np.vstack([row[:min_len] for row in rows])
+
+
+def _metric_to_error(metric_name: str, metric_value: float) -> float:
+    metric_key = metric_name.strip().lower()
+    if not np.isfinite(metric_value):
+        return float("nan")
+    if metric_key in LOWER_IS_BETTER_METRICS:
+        return float(metric_value) if metric_value >= 0.0 else float("nan")
+    if metric_key in HIGHER_IS_BETTER_METRICS:
+        if metric_value < 0.0 or metric_value > 1.0:
+            return float("nan")
+        return float(1.0 - metric_value)
+    raise ValueError(
+        f"Unknown metric '{metric_name}'. Add it to lower- or higher-is-better sets."
+    )
+
+
+def compute_skill_from_errors(
+    model_errors: np.ndarray,
+    baseline_errors: np.ndarray,
+    *,
+    clip_lower: float = 0.01,
+    clip_upper: float = 100.0,
+    min_pairs: int = 1,
+) -> tuple[float, float, int]:
+    """Compute skill score from paired model and baseline errors."""
+    model_arr = np.asarray(model_errors, dtype=float).reshape(-1)
+    baseline_arr = np.asarray(baseline_errors, dtype=float).reshape(-1)
+    n = min(model_arr.shape[0], baseline_arr.shape[0])
+    if n == 0:
+        return float("nan"), float("nan"), 0
+
+    model_arr = model_arr[:n]
+    baseline_arr = baseline_arr[:n]
+    valid = np.isfinite(model_arr) & np.isfinite(baseline_arr) & (baseline_arr > 0.0)
+    if int(valid.sum()) < int(min_pairs):
+        return float("nan"), float("nan"), int(valid.sum())
+
+    ratios = model_arr[valid] / baseline_arr[valid]
+    ratios = np.clip(ratios, float(clip_lower), float(clip_upper))
+    valid_ratios = ratios[np.isfinite(ratios) & (ratios > 0.0)]
+    if valid_ratios.shape[0] < int(min_pairs):
+        return float("nan"), float("nan"), int(valid_ratios.shape[0])
+
+    geometric_mean_ratio = float(np.exp(np.mean(np.log(valid_ratios))))
+    return float(1.0 - geometric_mean_ratio), geometric_mean_ratio, int(valid_ratios.shape[0])
+
+
+def _metric_channel_value(metric: np.ndarray, channel_idx: int) -> float:
+    if metric.ndim == 1:
+        if channel_idx >= metric.shape[0]:
+            return float("nan")
+        value = float(metric[channel_idx])
+        return value if np.isfinite(value) else float("nan")
+
+    if channel_idx >= metric.shape[0]:
+        return float("nan")
+    values = metric[channel_idx]
+    finite_values = values[np.isfinite(values)]
+    if finite_values.size == 0:
+        return float("nan")
+    return float(np.mean(finite_values))
+
+
+def _row_sample_key(row: pd.Series, occurrence: int) -> str:
+    history_length = row.get("history_length")
+    forecasting_length = row.get("forecasting_length")
+    if pd.notna(history_length):
+        return f"h={int(history_length)}|f={int(forecasting_length) if pd.notna(forecasting_length) else ''}|i={occurrence}"
+    return f"row={occurrence}"
+
+
+def _load_metric_values(
+    *,
+    model_name: str,
+    model_root: str | Path,
+    metric_name: str,
+    channel_indices: tuple[int, ...],
+    group_name: str,
+    aggregation_unit: str,
+) -> pd.DataFrame:
+    metric_dir = Path(model_root) / metric_name
+    rows: list[dict[str, Any]] = []
+    per_unit_values: dict[tuple[str, int, str], list[float]] = {}
+
+    for parquet_file in _list_parquet_files(metric_dir):
+        df = _safe_read_parquet(
+            parquet_file,
+            columns=["user_id", "history_length", "forecasting_length", metric_name],
+        )
+        if df is None or "user_id" not in df.columns or metric_name not in df.columns:
+            continue
+
+        occurrence_by_user_history: dict[tuple[str, str], int] = {}
+        for _, row in df.iterrows():
+            user_id = str(row.get("user_id"))
+            metric = _safe_to_metric_array(row.get(metric_name))
+            if metric is None:
+                continue
+
+            sample_seed = _row_sample_key(row, occurrence=0)
+            occurrence_key = (user_id, sample_seed)
+            occurrence = occurrence_by_user_history.get(occurrence_key, 0)
+            occurrence_by_user_history[occurrence_key] = occurrence + 1
+            sample_id = _row_sample_key(row, occurrence=occurrence)
+            unit_id = user_id if aggregation_unit == "user" else f"{user_id}|{sample_id}"
+
+            for channel_idx in channel_indices:
+                value = _metric_channel_value(metric=metric, channel_idx=channel_idx)
+                if not np.isfinite(value):
+                    continue
+                error = _metric_to_error(metric_name=metric_name, metric_value=value)
+                if not np.isfinite(error):
+                    continue
+                per_unit_values.setdefault((unit_id, int(channel_idx), metric_name), []).append(error)
+
+    for (unit_id, channel_idx, metric), values in per_unit_values.items():
+        finite_values = np.asarray(values, dtype=float)
+        finite_values = finite_values[np.isfinite(finite_values)]
+        if finite_values.size == 0:
+            continue
+        rows.append(
+            {
+                "model": model_name,
+                "group": group_name,
+                "metric": metric,
+                "channel_idx": int(channel_idx),
+                "channel_name": _channel_label(channel_idx),
+                "unit_id": unit_id,
+                "error": float(np.mean(finite_values)),
+                "n_values": int(finite_values.size),
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def _build_error_table(
+    *,
+    models: dict[str, dict[str, str]],
+    metric_groups: dict[str, dict[str, Any]],
+    aggregation_unit: str,
+) -> pd.DataFrame:
+    frames: list[pd.DataFrame] = []
+    for group_name, group_spec in metric_groups.items():
+        metric_names = group_spec["metrics"]
+        channel_indices = group_spec["channel_indices"]
+        for model_name, model_spec in models.items():
+            for metric_name in metric_names:
+                frame = _load_metric_values(
+                    model_name=model_name,
+                    model_root=model_spec["path"],
+                    metric_name=metric_name,
+                    channel_indices=channel_indices,
+                    group_name=group_name,
+                    aggregation_unit=aggregation_unit,
+                )
+                if not frame.empty:
+                    frames.append(frame)
+
+    if not frames:
+        return pd.DataFrame(
+            columns=[
+                "model",
+                "group",
+                "metric",
+                "channel_idx",
+                "channel_name",
+                "unit_id",
+                "error",
+                "n_values",
+            ]
+        )
+    return pd.concat(frames, ignore_index=True)
+
+
+def _compute_long_skill_scores(
+    *,
+    error_df: pd.DataFrame,
+    models: dict[str, dict[str, str]],
+    baseline_model: str,
+    clip_lower: float,
+    clip_upper: float,
+    min_pairs: int,
+) -> pd.DataFrame:
+    columns = [
+        "model",
+        "baseline_model",
+        "group",
+        "metric",
+        "channel_idx",
+        "channel_name",
+        "skill_score",
+        "geometric_mean_ratio",
+        "n_users",
+        "n_pairs",
+        "model_error_mean",
+        "baseline_error_mean",
+    ]
+    if error_df.empty:
+        return pd.DataFrame(columns=columns)
+
+    baseline_df = error_df.loc[error_df["model"] == baseline_model].copy()
+    if baseline_df.empty:
+        raise ValueError(f"Baseline model '{baseline_model}' has no readable metric rows.")
+
+    rows: list[dict[str, Any]] = []
+    group_cols = ["group", "metric", "channel_idx", "channel_name"]
+    baseline_groups = {
+        key: group.set_index("unit_id")["error"]
+        for key, group in baseline_df.groupby(group_cols, sort=True)
+    }
+
+    for model_name in models:
+        model_df = error_df.loc[error_df["model"] == model_name].copy()
+        for key, model_group in model_df.groupby(group_cols, sort=True):
+            baseline_errors = baseline_groups.get(key)
+            group_name, metric_name, channel_idx, channel_name = key
+            if baseline_errors is None or baseline_errors.empty:
+                rows.append(
+                    {
+                        "model": model_name,
+                        "baseline_model": baseline_model,
+                        "group": group_name,
+                        "metric": metric_name,
+                        "channel_idx": int(channel_idx),
+                        "channel_name": channel_name,
+                        "skill_score": float("nan"),
+                        "geometric_mean_ratio": float("nan"),
+                        "n_users": 0,
+                        "n_pairs": 0,
+                        "model_error_mean": float("nan"),
+                        "baseline_error_mean": float("nan"),
+                    }
+                )
+                continue
+
+            model_errors = model_group.set_index("unit_id")["error"]
+            paired = pd.concat(
+                [model_errors.rename("model_error"), baseline_errors.rename("baseline_error")],
+                axis=1,
+                join="inner",
+            ).dropna()
+
+            skill, gm_ratio, n_pairs = compute_skill_from_errors(
+                paired["model_error"].to_numpy(dtype=float),
+                paired["baseline_error"].to_numpy(dtype=float),
+                clip_lower=clip_lower,
+                clip_upper=clip_upper,
+                min_pairs=min_pairs,
+            )
+            rows.append(
+                {
+                    "model": model_name,
+                    "baseline_model": baseline_model,
+                    "group": group_name,
+                    "metric": metric_name,
+                    "channel_idx": int(channel_idx),
+                    "channel_name": channel_name,
+                    "skill_score": skill,
+                    "geometric_mean_ratio": gm_ratio,
+                    "n_users": _count_users_from_unit_index(paired.index),
+                    "n_pairs": int(n_pairs),
+                    "model_error_mean": float(paired["model_error"].mean()) if not paired.empty else float("nan"),
+                    "baseline_error_mean": float(paired["baseline_error"].mean()) if not paired.empty else float("nan"),
+                }
+            )
+
+    if not rows:
+        return pd.DataFrame(columns=columns)
+    return pd.DataFrame(rows, columns=columns).sort_values(
+        ["group", "channel_idx", "metric", "model"]
+    ).reset_index(drop=True)
+
+
+def _count_users_from_unit_index(index: pd.Index) -> int:
+    users = {str(value).split("|", 1)[0] for value in index.tolist()}
+    users.discard("")
+    return len(users)
+
+
+def _aggregate_rows_score(rows_df: pd.DataFrame) -> tuple[float, int]:
+    if rows_df.empty:
+        return float("nan"), 0
+    ratios = rows_df["geometric_mean_ratio"].to_numpy(dtype=float)
+    ratios = ratios[np.isfinite(ratios) & (ratios > 0.0)]
+    if ratios.size == 0:
+        return float("nan"), 0
+    return float(1.0 - np.exp(np.mean(np.log(ratios)))), int(ratios.size)
+
+
+def _aggregate_group_score(long_df: pd.DataFrame, model_name: str, group_name: str) -> tuple[float, int]:
+    group_rows = long_df.loc[
+        (long_df["model"] == model_name)
+        & (long_df["group"] == group_name)
+        & np.isfinite(long_df["geometric_mean_ratio"])
+    ]
+    return _aggregate_rows_score(group_rows)
+
+
+def _aggregate_channel_score(
+    long_df: pd.DataFrame,
+    model_name: str,
+    channel_idx: int,
+) -> tuple[float, int]:
+    channel_rows = long_df.loc[
+        (long_df["model"] == model_name)
+        & (long_df["group"] == "continuous")
+        & (long_df["channel_idx"] == int(channel_idx))
+        & np.isfinite(long_df["geometric_mean_ratio"])
+    ]
+    return _aggregate_rows_score(channel_rows)
+
+
+def _aggregate_binary_collection_score(
+    long_df: pd.DataFrame,
+    model_name: str,
+    channel_indices: tuple[int, ...],
+) -> tuple[float, int]:
+    collection_rows = long_df.loc[
+        (long_df["model"] == model_name)
+        & (long_df["group"] == "binary")
+        & (long_df["channel_idx"].isin(channel_indices))
+        & np.isfinite(long_df["geometric_mean_ratio"])
+    ]
+    return _aggregate_rows_score(collection_rows)
+
+
+def _build_model_summary(
+    *,
+    long_df: pd.DataFrame,
+    models: dict[str, dict[str, str]],
+    baseline_model: str,
+) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    for model_name in models:
+        row: dict[str, Any] = {
+            "model": model_name,
+            "baseline_model": baseline_model,
+        }
+        continuous_channels = sorted(
+            int(idx)
+            for idx in long_df.loc[long_df["group"] == "continuous", "channel_idx"].dropna().unique()
+        )
+        for channel_idx in continuous_channels:
+            score, n_units = _aggregate_channel_score(long_df, model_name, channel_idx)
+            row[f"channel_{channel_idx}_score"] = score
+            row[f"channel_{channel_idx}_n_units"] = n_units
+
+        sleep_score, n_sleep = _aggregate_binary_collection_score(long_df, model_name, (7, 8))
+        workout_score, n_workout = _aggregate_binary_collection_score(
+            long_df,
+            model_name,
+            tuple(range(9, 19)),
+        )
+        row.update(
+            {
+                "sleep_score": sleep_score,
+                "workout_score": workout_score,
+                "sleep_n_units": n_sleep,
+                "workout_n_units": n_workout,
+            }
+        )
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def _build_wide_summary(long_df: pd.DataFrame, models: dict[str, dict[str, str]]) -> pd.DataFrame:
+    if long_df.empty:
+        return pd.DataFrame(columns=["group", "metric", "channel_idx", "channel_name"])
+
+    wide_df = (
+        long_df[["group", "metric", "channel_idx", "channel_name"]]
+        .drop_duplicates()
+        .sort_values(["group", "channel_idx", "metric"])
+        .reset_index(drop=True)
+    )
+    for model_name, model_spec in models.items():
+        display_name = model_spec["display_name"]
+        model_slice = long_df.loc[long_df["model"] == model_name].copy()
+        model_slice = model_slice[
+            [
+                "group",
+                "metric",
+                "channel_idx",
+                "skill_score",
+                "geometric_mean_ratio",
+                "n_pairs",
+            ]
+        ].rename(
+            columns={
+                "skill_score": f"{display_name}_skill_score",
+                "geometric_mean_ratio": f"{display_name}_geometric_mean_ratio",
+                "n_pairs": f"{display_name}_n_pairs",
+            }
+        )
+        wide_df = wide_df.merge(model_slice, on=["group", "metric", "channel_idx"], how="left")
+    return wide_df
+
+
+def compute_skill_score_tables(
+    *,
+    models: dict[str, dict[str, str]],
+    baseline_model: str,
+    continuous_metrics: list[str],
+    binary_metrics: list[str],
+    continuous_channel_indices: tuple[int, ...],
+    binary_channel_indices: tuple[int, ...],
+    clip_lower: float,
+    clip_upper: float,
+    min_pairs: int,
+    aggregation_unit: str,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Compute long, model summary, and wide skill score tables."""
+    if baseline_model not in models:
+        raise ValueError(
+            f"Baseline model '{baseline_model}' is not in model config. "
+            f"Available models: {', '.join(models)}"
+        )
+    if clip_lower <= 0 or clip_upper <= 0 or clip_lower > clip_upper:
+        raise ValueError("--clip-lower and --clip-upper must be positive with lower <= upper")
+    if aggregation_unit not in {"user", "sample"}:
+        raise ValueError("--aggregation-unit must be either 'user' or 'sample'")
+
+    metric_groups = {
+        "continuous": {
+            "metrics": [m.strip().lower() for m in continuous_metrics if m.strip()],
+            "channel_indices": continuous_channel_indices,
+        },
+        "binary": {
+            "metrics": [m.strip().lower() for m in binary_metrics if m.strip()],
+            "channel_indices": binary_channel_indices,
+        },
+    }
+    error_df = _build_error_table(
+        models=models,
+        metric_groups=metric_groups,
+        aggregation_unit=aggregation_unit,
+    )
+    long_df = _compute_long_skill_scores(
+        error_df=error_df,
+        models=models,
+        baseline_model=baseline_model,
+        clip_lower=clip_lower,
+        clip_upper=clip_upper,
+        min_pairs=min_pairs,
+    )
+    summary_df = _build_model_summary(
+        long_df=long_df,
+        models=models,
+        baseline_model=baseline_model,
+    )
+    wide_df = _build_wide_summary(long_df=long_df, models=models)
+    return long_df, summary_df, wide_df
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser for forecasting skill score summaries."""
+    parser = argparse.ArgumentParser(
+        description="Compute forecasting skill scores from offline metric parquet files."
+    )
+    parser.add_argument("--config", default=None, help="JSON/YAML config with model mappings.")
+    parser.add_argument(
+        "--models-json",
+        default=None,
+        help='Inline JSON dict, e.g. {"models":{"modelA":"/path/a"}}',
+    )
+    parser.add_argument("--baseline", required=True, help="Baseline model key from config.")
+    parser.add_argument(
+        "--continuous-channel-indices",
+        default="0,1,2,3,4,5,6",
+        help="Comma-separated continuous channel indices. Defaults to 0-6.",
+    )
+    parser.add_argument(
+        "--continuous-metrics",
+        nargs="+",
+        default=["mase", "sql"],
+        help="Continuous metrics to include. Defaults to mase sql.",
+    )
+    parser.add_argument(
+        "--binary-channel-indices",
+        default="7,8,9,10,11,12,13,14,15,16,17,18",
+        help="Comma-separated binary channel indices. Defaults to 7-18.",
+    )
+    parser.add_argument(
+        "--binary-metrics",
+        nargs="+",
+        default=["mse", "f1"],
+        help="Binary-channel metrics to include. Defaults to mse f1.",
+    )
+    parser.add_argument("--clip-lower", type=float, default=0.01)
+    parser.add_argument("--clip-upper", type=float, default=100.0)
+    parser.add_argument("--min-pairs", type=int, default=1)
+    parser.add_argument(
+        "--aggregation-unit",
+        choices=["user", "sample"],
+        default="user",
+        help="Collapse metrics to user-level or sample-level before paired ratios.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="results/metrics_summary",
+        help="Directory for generated CSV files.",
+    )
+    parser.add_argument(
+        "--output-prefix",
+        default="forecasting_skill_score",
+        help="Filename prefix for generated CSV files.",
+    )
+    return parser
+
+
+def main() -> None:
+    """Generate forecasting skill score summary CSV outputs."""
+    args = build_parser().parse_args()
+    models = _load_models_dict(args)
+    continuous_channel_indices = _parse_channel_indices(
+        args.continuous_channel_indices,
+        default=tuple(range(0, 7)),
+    )
+    binary_channel_indices = _parse_channel_indices(
+        args.binary_channel_indices,
+        default=tuple(range(7, 19)),
+    )
+
+    long_df, summary_df, wide_df = compute_skill_score_tables(
+        models=models,
+        baseline_model=args.baseline,
+        continuous_metrics=list(args.continuous_metrics),
+        binary_metrics=list(args.binary_metrics),
+        continuous_channel_indices=continuous_channel_indices,
+        binary_channel_indices=binary_channel_indices,
+        clip_lower=float(args.clip_lower),
+        clip_upper=float(args.clip_upper),
+        min_pairs=int(args.min_pairs),
+        aggregation_unit=str(args.aggregation_unit),
+    )
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    long_path = output_dir / f"{args.output_prefix}_long.csv"
+    summary_path = output_dir / f"{args.output_prefix}_model_summary.csv"
+    wide_path = output_dir / f"{args.output_prefix}_wide.csv"
+
+    long_df.to_csv(long_path, index=False)
+    summary_df.to_csv(summary_path, index=False)
+    wide_df.to_csv(wide_path, index=False)
+
+    print("=== Forecasting skill score summary ===")
+    if summary_df.empty:
+        print("(empty)")
+    else:
+        print(summary_df.to_string(index=False))
+    print(f"\nSaved long table: {long_path}")
+    print(f"Saved model summary: {summary_path}")
+    print(f"Saved wide table: {wide_path}")
+    print(f"Baseline: {args.baseline}")
+    print(f"Aggregation unit: {args.aggregation_unit}")
+    print(f"Ratio clip: [{args.clip_lower}, {args.clip_upper}]")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/forecasting_evaluation/metrics/summary_metrics_result.py
+++ b/src/forecasting_evaluation/metrics/summary_metrics_result.py
@@ -1,0 +1,489 @@
+"""Stream aggregation from forecasting metrics parquet files.
+
+This script exports two CSVs:
+- ``mae_by_model_channel_hour.csv``
+- ``statistical_result.csv``
+
+It reads files incrementally and never materializes a full MAE long table,
+which keeps memory usage bounded for large runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+CHANNEL_NAME_MAP = {
+    "first": ["hk_iphone:HKQuantityTypeIdentifierStepCount"],
+    "iPhone": [
+        "hk_iphone:HKQuantityTypeIdentifierStepCount",
+        "hk_iphone:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_iphone:HKQuantityTypeIdentifierFlightsClimbed",
+    ],
+    "watch": [
+        "hk_watch:HKQuantityTypeIdentifierStepCount",
+        "hk_watch:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_watch:HKQuantityTypeIdentifierHeartRate",
+        "hk_watch:HKQuantityTypeIdentifierActiveEnergyBurned",
+    ],
+    "all": [
+        "hk_iphone:HKQuantityTypeIdentifierStepCount",
+        "hk_iphone:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_iphone:HKQuantityTypeIdentifierFlightsClimbed",
+        "hk_watch:HKQuantityTypeIdentifierStepCount",
+        "hk_watch:HKQuantityTypeIdentifierDistanceWalkingRunning",
+        "hk_watch:HKQuantityTypeIdentifierHeartRate",
+        "hk_watch:HKQuantityTypeIdentifierActiveEnergyBurned",
+        "sleep:asleep",
+        "sleep:inbed",
+        "workout:HKWorkoutActivityTypeWalking",
+        "workout:HKWorkoutActivityTypeCycling",
+        "workout:HKWorkoutActivityTypeRunning",
+        "workout:HKWorkoutActivityTypeOther",
+        "workout:HKWorkoutActivityTypeMixedMetabolicCardioTraining",
+        "workout:HKWorkoutActivityTypeTraditionalStrengthTraining",
+        "workout:HKWorkoutActivityTypeElliptical",
+        "workout:HKWorkoutActivityTypeHighIntensityIntervalTraining",
+        "workout:HKWorkoutActivityTypeFunctionalStrengthTraining",
+        "workout:HKWorkoutActivityTypeYoga",
+    ]
+}
+
+
+def _safe_read_parquet(file_path: str | Path, **kwargs: Any) -> pd.DataFrame | None:
+    """Read parquet with guard rails; return None on read failures."""
+    path = Path(file_path)
+    try:
+        if not path.exists():
+            print(f"[skip] parquet not found: {path}")
+            return None
+        if path.stat().st_size == 0:
+            print(f"[skip] parquet file is empty: {path}")
+            return None
+        return pd.read_parquet(path, **kwargs)
+    except Exception as exc:  # pragma: no cover - defensive branch
+        print(f"[skip] failed to read parquet: {path} | {type(exc).__name__}: {exc}")
+        return None
+
+
+def _safe_read_with_optional_columns(  # noqa: D206
+    file_path: str | Path,
+    required_columns: list[str],
+    optional_columns: list[str],
+) -> pd.DataFrame | None:
+    """Read parquet with required columns and best-effort optional columns."""  # noqa: D206
+    """If reading required+optional fails due schema mismatch, fallback to required-only."""
+    columns_full = required_columns + optional_columns
+    path = Path(file_path)
+    try:
+        if not path.exists():
+            print(f"[skip] parquet not found: {path}")
+            return None
+        if path.stat().st_size == 0:
+            print(f"[skip] parquet file is empty: {path}")
+            return None
+        return pd.read_parquet(path, columns=columns_full)
+    except Exception:
+        return _safe_read_parquet(path, columns=required_columns)
+
+
+def _safe_to_2d_array(value: Any) -> np.ndarray | None:
+    """Convert nested values to 2D float array, trimming rows to shared min horizon."""
+    if value is None:
+        return None
+
+    try:
+        arr = np.asarray(value, dtype=float)
+        if arr.ndim == 2:
+            return arr
+    except Exception:
+        pass
+
+    try:
+        obj = np.asarray(value, dtype=object)
+    except Exception:
+        return None
+
+    if obj.ndim != 1:
+        return None
+
+    rows: list[np.ndarray] = []
+    for item in obj.tolist():
+        try:
+            row = np.asarray(item, dtype=float).reshape(-1)
+        except Exception:
+            return None
+        if row.size == 0:
+            return None
+        rows.append(row)
+
+    if not rows:
+        return None
+
+    min_len = min(len(row) for row in rows)
+    if min_len <= 0:
+        return None
+
+    return np.vstack([row[:min_len] for row in rows])
+
+
+def _read_config_channel(model_dir: str | Path) -> str | None:
+    """Read channel key from sibling run config, if present."""
+    root = Path(model_dir)
+    candidates = [root / "config.yaml", root.parent / "config.yaml"]
+    config_path = next((p for p in candidates if p.exists()), None)
+    if config_path is None:
+        return None
+
+    try:
+        import yaml
+    except ImportError:
+        return None
+
+    with config_path.open("r", encoding="utf-8") as file:
+        config = yaml.safe_load(file) or {}
+    return (config.get("features") or {}).get("channel")
+
+
+def _list_parquet_files(model_dir: str | Path) -> list[Path]:
+    path = Path(model_dir)
+    if not path.exists():
+        return []
+    return sorted(path.rglob("*.parquet"))
+
+
+def _collect_users_for_dir(model_dir: str | Path) -> set[str]:
+    """Collect all available user ids for one input directory from parquet files."""
+    users: set[str] = set()
+    for parquet_file in _list_parquet_files(model_dir):
+        df = _safe_read_parquet(parquet_file, columns=["user_id"])
+        if df is None or "user_id" not in df.columns:
+            continue
+        users.update(df["user_id"].astype(str).dropna().unique().tolist())
+    return users
+
+
+def _select_users(users: set[str], max_user: int | None, rng: random.Random) -> set[str]:
+    """Randomly select up to max_user users; return all users when max_user is None."""
+    if max_user is None or max_user <= 0 or len(users) <= max_user:
+        return users
+    user_list = sorted(users)
+    return set(rng.sample(user_list, k=max_user))
+
+
+def _infer_channel_names(model_dir: str | Path, n_features: int) -> list[str]:
+    """Infer channel names from config key; fallback to feature indices."""
+    channel_key = _read_config_channel(model_dir)
+    if channel_key is None:
+        return [f"feature_{i}" for i in range(n_features)]
+
+    mapped = CHANNEL_NAME_MAP.get(channel_key)
+    if not mapped:
+        return [f"feature_{i}" for i in range(n_features)]
+
+    if len(mapped) >= n_features:
+        return mapped[:n_features]
+    return mapped + [f"feature_{i}" for i in range(len(mapped), n_features)]
+
+
+def _parse_mae_value(raw_value: Any) -> np.ndarray | None:
+    """Parse MAE matrix from list-like values stored in `mae` column."""
+    if raw_value is None:
+        return None
+    return _safe_to_2d_array(raw_value)
+
+
+def _project_hour_index(hour: int, horizon: int) -> int:
+    """Project raw horizon index to summary hour index.
+
+    For multi-day forecasts (horizon >= 48), aggregate by hour-of-day so
+    hours like 0 and 24 contribute to the same summary bucket (0).
+    """
+    if horizon >= 48:
+        return int(hour % 24)
+    return int(hour)
+
+
+def aggregate_mae_by_channel_hour_streaming(  # noqa: D206
+    metrics_paths: dict[str, str],
+    max_user: int | None,
+    random_seed: int,
+) -> pd.DataFrame:
+    """Stream MAE rows and aggregate stats per model/channel/hour."""  # noqa: D206
+    """The aggregator keeps only running stats in memory: sum, sum of squares, and count."""
+    rng = random.Random(random_seed)
+    acc: dict[tuple[str, str, int, int], dict[str, float | int]] = {}
+
+    for input_name, model_dir in metrics_paths.items():
+        files = _list_parquet_files(model_dir)
+        if not files:
+            print(f"[skip] no parquet found for input: {input_name} @ {model_dir}")
+            continue
+
+        users = _collect_users_for_dir(model_dir)
+        selected_users = _select_users(users, max_user=max_user, rng=rng)
+        print(
+            f"input={input_name} users_total={len(users)} users_selected={len(selected_users)}"
+        )
+
+        inferred_n_features = None
+        for parquet_file in files:
+            df = _safe_read_parquet(parquet_file, columns=["mae"])
+            if df is None:
+                continue
+            if "mae" not in df.columns:
+                continue
+            for raw_mae in df["mae"]:
+                mae = _parse_mae_value(raw_mae)
+                if mae is not None:
+                    inferred_n_features = mae.shape[0]
+                    break
+            if inferred_n_features is not None:
+                break
+
+        if inferred_n_features is None:
+            print(f"[skip] no valid mae found for input: {input_name}")
+            continue
+
+        channel_names = _infer_channel_names(model_dir, inferred_n_features)
+
+        for parquet_file in files:
+            df = _safe_read_parquet(parquet_file, columns=["user_id", "model", "mae"])
+            if df is None:
+                continue
+            if "user_id" not in df.columns:
+                continue
+            if "mae" not in df.columns:
+                continue
+
+            if selected_users:
+                df = df[df["user_id"].astype(str).isin(selected_users)]
+                if df.empty:
+                    continue
+
+            for _, row in df.iterrows():
+                mae = _parse_mae_value(row.get("mae"))
+                if mae is None:
+                    continue
+
+                row_model_name = input_name
+
+                n_features, horizon = mae.shape
+                channels = channel_names[:n_features]
+                if len(channels) < n_features:
+                    channels += [f"feature_{i}" for i in range(len(channels), n_features)]
+
+                for channel_idx in range(n_features):
+                    for hour in range(horizon):
+                        value = mae[channel_idx, hour]
+                        if not np.isfinite(value):
+                            continue
+
+                        summary_hour = _project_hour_index(hour=hour, horizon=horizon)
+                        key = (row_model_name, channels[channel_idx], channel_idx, summary_hour)
+                        if key not in acc:
+                            acc[key] = {"sum": 0.0, "sum_sq": 0.0, "n": 0}
+                        acc[key]["sum"] = float(acc[key]["sum"]) + float(value)
+                        acc[key]["sum_sq"] = float(acc[key]["sum_sq"]) + float(value) * float(value)
+                        acc[key]["n"] = int(acc[key]["n"]) + 1
+
+    rows: list[dict[str, Any]] = []
+    for (model, channel, channel_idx, hour), stats in acc.items():
+        n = int(stats["n"])
+        if n <= 0:
+            continue
+        sum_value = float(stats["sum"])
+        sum_sq = float(stats["sum_sq"])
+        mean = sum_value / n
+        var = max(0.0, (sum_sq / n) - (mean * mean))
+        std = float(np.sqrt(var))
+
+        rows.append(
+            {
+                "model": model,
+                "channel": channel,
+                "channel_idx": channel_idx,
+                "hour": hour,
+                "mae_mean": mean,
+                "mae_std": std,
+                "n": n,
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame(
+            columns=["model", "channel", "channel_idx", "hour", "mae_mean", "mae_std", "n"]
+        )
+
+    return pd.DataFrame(rows).sort_values(["model", "channel_idx", "hour"]).reset_index(drop=True)
+
+
+def aggregate_model_statistics_streaming(  # noqa: D206
+    metrics_paths: dict[str, str],
+    max_user: int | None,
+    random_seed: int,
+) -> pd.DataFrame:
+    """Aggregate model-level user/sample counts and average prediction time."""  # noqa: D206
+    """Output columns: model, user_count, sample_count, avg_prediction_time_seconds."""
+    rng = random.Random(random_seed)
+    acc: dict[str, dict[str, Any]] = {}
+
+    for input_name, model_dir in metrics_paths.items():
+        files = _list_parquet_files(model_dir)
+        if not files:
+            print(f"[skip] no parquet found for input: {input_name} @ {model_dir}")
+            continue
+
+        users = _collect_users_for_dir(model_dir)
+        selected_users = _select_users(users, max_user=max_user, rng=rng)
+
+        for parquet_file in files:
+            df = _safe_read_with_optional_columns(
+                parquet_file,
+                required_columns=["user_id", "model"],
+                optional_columns=["perf_prediction_time_seconds"],
+            )
+            if df is None or "user_id" not in df.columns:
+                continue
+
+            df = df[df["user_id"].astype(str).isin(selected_users)]
+            if df.empty:
+                continue
+
+            entry = acc.setdefault(
+                input_name,
+                {
+                    "users": set(),
+                    "sample_count": 0,
+                    "prediction_time_sum": 0.0,
+                    "prediction_time_count": 0,
+                },
+            )
+            entry["users"].update(df["user_id"].astype(str).dropna().tolist())
+            entry["sample_count"] = int(entry["sample_count"]) + int(len(df))
+
+            if "perf_prediction_time_seconds" in df.columns:
+                times = pd.to_numeric(df["perf_prediction_time_seconds"], errors="coerce")
+                finite_mask = np.isfinite(times.to_numpy(dtype=float, na_value=np.nan))
+                if finite_mask.any():
+                    finite_times = times[finite_mask]
+                    entry["prediction_time_sum"] = (
+                        float(entry["prediction_time_sum"]) + float(finite_times.sum())
+                    )
+                    entry["prediction_time_count"] = (
+                        int(entry["prediction_time_count"]) + int(finite_times.shape[0])
+                    )
+
+    if not acc:
+        return pd.DataFrame(
+            columns=["model", "user_count", "sample_count", "avg_prediction_time_seconds"]
+        )
+
+    rows: list[dict[str, Any]] = []
+    for model_name, entry in acc.items():
+        prediction_time_count = int(entry["prediction_time_count"])
+        avg_prediction_time = (
+            float(entry["prediction_time_sum"]) / prediction_time_count
+            if prediction_time_count > 0
+            else np.nan
+        )
+        rows.append(
+            {
+                "model": model_name,
+                "user_count": int(len(entry["users"])),
+                "sample_count": int(entry["sample_count"]),
+                "avg_prediction_time_seconds": float(avg_prediction_time)
+                if np.isfinite(avg_prediction_time)
+                else np.nan,
+            }
+        )
+
+    return pd.DataFrame(rows).sort_values(["model"]).reset_index(drop=True)
+
+
+def _parse_model_arg(model_arg: str) -> tuple[str, str]:
+    if "=" not in model_arg:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --model value: {model_arg}. Expected format: MODEL_NAME=/path/to/model_dir"
+        )
+    model_name, model_dir = model_arg.split("=", 1)
+    model_name = model_name.strip()
+    model_dir = model_dir.strip()
+    if not model_name or not model_dir:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --model value: {model_arg}. Model name and path must be non-empty."
+        )
+    return model_name, model_dir
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for metrics summary generation."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Summarize forecasting metrics and export MAE plus model-level statistics."
+        )
+    )
+    parser.add_argument(
+        "--model",
+        action="append",
+        default=[],
+        help="Model mapping in format MODEL_NAME=/path/to/model_metrics_dir. Can be repeated.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="/home/lp925/code/MHC-benchmark/results/metrics_summary",
+        help="Output directory for mae_by_model_channel_hour.csv and statistical_result.csv.",
+    )
+    parser.add_argument(
+        "--max-user",
+        type=int,
+        default=None,
+        help="Max number of random users per model for small-scale testing.",
+    )
+    parser.add_argument(
+        "--random-seed",
+        type=int,
+        default=42,
+        help="Random seed used by --max-user sampling.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run streaming metric summaries and write CSV outputs."""
+    args = parse_args()
+    if not args.model:
+        raise ValueError("Please provide at least one --model MODEL_NAME=/path/to/metrics_dir")
+    metrics_paths = dict(_parse_model_arg(item) for item in args.model)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    mae_agg_df = aggregate_mae_by_channel_hour_streaming(
+        metrics_paths,
+        max_user=args.max_user,
+        random_seed=args.random_seed,
+    )
+    mae_agg_path = output_dir / "mae_by_model_channel_hour.csv"
+    mae_agg_df.to_csv(mae_agg_path, index=False)
+
+    stat_df = aggregate_model_statistics_streaming(
+        metrics_paths,
+        max_user=args.max_user,
+        random_seed=args.random_seed,
+    )
+    stat_path = output_dir / "statistical_result.csv"
+    stat_df.to_csv(stat_path, index=False)
+
+    print("\n=== Output file ===")
+    print(f"mae agg: {mae_agg_path}")
+    print(f"stats: {stat_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/forecasting_evaluation/models/__init__.py
+++ b/src/forecasting_evaluation/models/__init__.py
@@ -1,0 +1,1 @@
+"""Forecasting model implementations and registries."""

--- a/src/forecasting_evaluation/models/base.py
+++ b/src/forecasting_evaluation/models/base.py
@@ -1,0 +1,81 @@
+"""Base protocol for forecasting models."""
+
+from __future__ import annotations
+
+import time
+import tracemalloc
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+from forecasting_evaluation.data.types import SubTrajectoryInput
+
+
+class BasePredictionModel(ABC):
+    """Protocol for Base Prediction Models."""
+    model_name: str  # Optional name attribute for model instance (e.g. "ARIMA")
+    quantile_levels: np.ndarray | None = None
+    
+    @abstractmethod
+    def predict(
+        self,
+        inputs: SubTrajectoryInput,
+    ) -> tuple[np.ndarray | None, np.ndarray | None]:
+        """Predict future values for given time series data.
+
+        Args:
+            inputs: Typed forecasting sub-trajectory input containing target,
+                covariates, horizon, and metadata.
+
+        Returns:
+            Tuple of:
+                - point forecast of shape (n_features, prediction_length), or None.
+                - quantile forecast of shape (n_features, prediction_length, n_quantiles), or None.
+        """
+        pass
+
+    def reset(self) -> None:
+        """Reset model state if applicable (e.g. for stateful models)."""
+        pass
+
+    def predict_wrapper(
+        self,
+        inputs: SubTrajectoryInput
+    ) -> tuple[np.ndarray | None, np.ndarray | None, dict]:
+        """Wrapper around predict() that handles performance tracking.
+        
+        This method:
+        1. Starts performance tracking (time and memory)
+        2. Calls the model's predict() method
+        3. Collects performance metrics
+        4. Returns predictions along with performance metadata
+        
+        Args:
+            inputs: Typed forecasting sub-trajectory input.
+            
+        Returns:
+            Tuple of:
+                - point forecast of shape (n_features, prediction_length), or None.
+                - quantile forecast of shape (n_features, prediction_length, n_quantiles), or None.
+                - base_result: dict with total performance metrics for this prediction call:
+                    - 'prediction_time_seconds': total prediction wall time in seconds
+                    - 'memory_usage_mb': total peak traced memory in MB
+        """
+        # Start performance tracking
+        tracemalloc.start()
+        start_time = time.time()
+        
+        # Call model's predict method
+        point_result, quantiles_result = self.predict(inputs)
+        
+        # Collect performance metrics
+        prediction_time = time.time() - start_time
+        _current_mem, peak_mem = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        
+        base_result = {
+            "prediction_time_seconds": float(prediction_time),
+            "memory_usage_mb": float(peak_mem / 1024 / 1024),
+        }
+
+        return point_result, quantiles_result, base_result

--- a/src/forecasting_evaluation/models/deep_learning_model/pypots_forecasting_base.py
+++ b/src/forecasting_evaluation/models/deep_learning_model/pypots_forecasting_base.py
@@ -1,0 +1,23 @@
+"""Stub for the PyPOTS deep-forecasting base class.
+
+The full implementation lives in the private repo and pulls in pypots /
+pygrinder / torch-Lightning. The public OpenMHC API only runs naive and
+statistical forecasters (no PyPOTS dependency), so the only thing the
+evaluator actually needs from this module is a class symbol to use in
+``isinstance(model, BasePyPOTSForecastingModel)`` checks — those checks
+return False for naive forecasters and the PyPOTS-specific branches are
+skipped.
+
+If you want to evaluate a real PyPOTS-based forecaster against this
+benchmark, install the private package (``pip install mhc-benchmark``)
+and use that pipeline.
+"""
+
+from __future__ import annotations
+
+
+class BasePyPOTSForecastingModel:
+    """No-op stub. See module docstring."""
+
+    uses_standard_scaler = False
+    scaler_stats = None

--- a/src/forecasting_evaluation/models/naive/__init__.py
+++ b/src/forecasting_evaluation/models/naive/__init__.py
@@ -1,0 +1,1 @@
+"""Naive forecasting models."""

--- a/src/forecasting_evaluation/models/naive/seasonal_naive.py
+++ b/src/forecasting_evaluation/models/naive/seasonal_naive.py
@@ -1,0 +1,172 @@
+"""Seasonal naive baseline forecasting model."""
+
+import random
+
+import numpy as np
+
+from forecasting_evaluation.data.types import SubTrajectoryInput
+from forecasting_evaluation.models.base import BasePredictionModel
+
+
+class SeasonalNaiveModel(BasePredictionModel):
+    """Seasonal naive model using the latest non-empty seasonal cycle."""
+
+    def __init__(
+        self,
+        seed: int = 42,
+        seasonal: int = 24,
+        quantile_levels: tuple[float, ...] | list[float] | np.ndarray = (
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.9,
+        ),
+    ):
+        """Initialize model state.
+
+        Args:
+            seed: Random seed for reproducibility.
+            seasonal: Seasonal cycle length in hours.
+            quantile_levels: Quantile levels returned alongside point forecasts.
+        """
+        # Set random seeds for reproducibility
+        self.seed = seed
+        self.seasonal = seasonal
+        self.quantile_levels = self._validate_quantile_levels(quantile_levels)
+        np.random.seed(seed)
+        random.seed(seed)
+
+    def predict(
+        self,
+        inputs: SubTrajectoryInput,
+    ) -> tuple[np.ndarray | None, np.ndarray | None]:
+        """Predict future values using seasonal naive approach.
+
+        Args:
+            inputs: Typed forecasting sub-trajectory input.
+
+        Returns:
+            Tuple containing (point_result, quantiles_result):
+            - point_result: (n_features, prediction_length) array of point predictions.
+            - quantiles_result: (n_features, prediction_length, n_quantiles) array
+              of empirical seasonal quantile forecasts.
+        """
+        point_result = None
+
+        history = inputs.history
+        prediction_length = inputs.prediction_hours
+
+        n_features, history_length = history.shape
+
+        # Ensure history_length is at least as long as seasonal period
+        effective_seasonal = min(self.seasonal, history_length)
+
+        # Initialize prediction array
+        predictions = np.zeros((n_features, prediction_length))
+
+        # Get the most recent complete seasonal period, skip if all zeros
+        # Shape: (n_features, effective_seasonal)
+        last_season = None
+        offset = 0
+        while offset * effective_seasonal < history_length:
+            start_idx = max(0, history_length - effective_seasonal * (offset + 1))
+            end_idx = history_length - effective_seasonal * offset
+            candidate_season = history[:, start_idx:end_idx]
+
+            # Check if all zeros
+            if np.any(candidate_season != 0):
+                last_season = candidate_season
+                break
+            offset += 1
+
+        # If all historical data is zero, use the most recent period (even if all zeros)
+        if last_season is None:
+            last_season = history[:, -effective_seasonal:]
+
+        # Adjust effective_seasonal to match the actual season length obtained
+        effective_seasonal = last_season.shape[1]
+
+        for k in range(prediction_length):
+            # Use modulo operation for cyclic reference
+            # e.g., k=0, 24, 48... will all map to the same position in last_season
+            idx = k % effective_seasonal
+            predictions[:, k] = last_season[:, idx]
+
+        # Point predictions
+        # Shape: (n_features, prediction_length)
+        point_result = predictions
+        quantiles_result = self._predict_empirical_quantiles(
+            history=history,
+            predictions=predictions,
+            prediction_length=prediction_length,
+            effective_seasonal=effective_seasonal,
+        )
+
+        return point_result, quantiles_result
+
+    @staticmethod
+    def _validate_quantile_levels(
+        quantile_levels: tuple[float, ...] | list[float] | np.ndarray,
+    ) -> np.ndarray:
+        """Validate and normalize configured quantile levels."""
+        quantile_array = np.asarray(quantile_levels, dtype=float)
+        if quantile_array.ndim != 1 or quantile_array.size == 0:
+            raise ValueError("quantile_levels must be a non-empty 1D sequence")
+        if np.any((quantile_array <= 0.0) | (quantile_array >= 1.0)):
+            raise ValueError("quantile_levels must be strictly between 0 and 1")
+        if np.unique(quantile_array).size != quantile_array.size:
+            raise ValueError("quantile_levels must not contain duplicates")
+        return np.sort(quantile_array)
+
+    def _predict_empirical_quantiles(
+        self,
+        *,
+        history: np.ndarray,
+        predictions: np.ndarray,
+        prediction_length: int,
+        effective_seasonal: int,
+    ) -> np.ndarray:
+        """Estimate quantiles from matching positions in non-empty full seasons."""
+        n_features, history_length = history.shape
+        n_quantiles = len(self.quantile_levels)
+        quantiles = np.zeros((n_features, prediction_length, n_quantiles))
+
+        valid_seasons: list[np.ndarray] = []
+        offset = 0
+        while True:
+            end_idx = history_length - effective_seasonal * offset
+            start_idx = end_idx - effective_seasonal
+            if start_idx < 0:
+                break
+
+            candidate_season = history[:, start_idx:end_idx]
+            if np.any(candidate_season != 0):
+                valid_seasons.append(candidate_season)
+            offset += 1
+
+        for k in range(prediction_length):
+            idx = k % effective_seasonal
+            for feature_idx in range(n_features):
+                if valid_seasons:
+                    seasonal_values = np.asarray(
+                        [season[feature_idx, idx] for season in valid_seasons],
+                        dtype=float,
+                    )
+                    seasonal_values = seasonal_values[np.isfinite(seasonal_values)]
+                else:
+                    seasonal_values = np.asarray([], dtype=float)
+
+                if seasonal_values.size == 0:
+                    quantiles[feature_idx, k, :] = predictions[feature_idx, k]
+                else:
+                    quantiles[feature_idx, k, :] = np.nanquantile(
+                        seasonal_values,
+                        self.quantile_levels,
+                    )
+
+        return quantiles

--- a/src/forecasting_evaluation/models/naive/seasonal_naive_average_history.py
+++ b/src/forecasting_evaluation/models/naive/seasonal_naive_average_history.py
@@ -1,0 +1,87 @@
+"""Seasonal naive baseline using averaged historical seasonal cycles."""
+
+import random
+
+import numpy as np
+
+from forecasting_evaluation.data.types import SubTrajectoryInput
+from forecasting_evaluation.models.base import BasePredictionModel
+
+
+class SeasonalNaiveAverageModel(BasePredictionModel):
+    """Seasonal naive model that averages over multiple historical seasons."""
+
+    def __init__(
+        self,
+        seed: int = 42,
+        seasonal: int = 24,
+    ):
+        """Initialize model state.
+
+        Args:
+            seed: Random seed for reproducibility.
+            seasonal: Seasonal cycle length in hours.
+        """
+        self.seed = seed
+        self.seasonal = seasonal
+        np.random.seed(seed)
+        random.seed(seed)
+
+    def predict(
+        self,
+        inputs: SubTrajectoryInput,
+    ) -> tuple[np.ndarray | None, np.ndarray | None]:
+        """Predict future values using averaged seasonal naive approach.
+
+        For each seasonal position (e.g. each hour within a day when seasonal=24),
+        this model collects values from all valid historical seasonal cycles and
+        uses their mean as the prediction template.
+
+        Args:
+            inputs: Typed forecasting sub-trajectory input.
+
+        Returns:
+            Tuple containing (point_result, quantiles_result):
+            - point_result: (n_features, prediction_length) array of point predictions.
+            - quantiles_result: None for this deterministic baseline.
+        """
+        point_result = None
+        quantiles_result = None
+
+        history = inputs.history
+        prediction_length = inputs.prediction_hours
+
+        n_features, history_length = history.shape
+        effective_seasonal = min(self.seasonal, history_length)
+
+        predictions = np.zeros((n_features, prediction_length))
+
+        valid_seasons: list[np.ndarray] = []
+        offset = 0
+
+        while True:
+            end_idx = history_length - effective_seasonal * offset
+            start_idx = end_idx - effective_seasonal
+
+            if start_idx < 0:
+                break
+
+            candidate_season = history[:, start_idx:end_idx]
+
+            if np.any(candidate_season != 0):
+                valid_seasons.append(candidate_season)
+
+            offset += 1
+
+        if valid_seasons:
+            averaged_season = np.mean(np.stack(valid_seasons, axis=0), axis=0)
+        else:
+            averaged_season = history[:, -effective_seasonal:]
+
+        for k in range(prediction_length):
+            idx = k % effective_seasonal
+            predictions[:, k] = averaged_season[:, idx]
+
+        point_result = predictions
+        
+        return point_result, quantiles_result

--- a/src/forecasting_evaluation/models/registry.py
+++ b/src/forecasting_evaluation/models/registry.py
@@ -1,0 +1,196 @@
+"""Forecasting model/function registry and factory."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from forecasting_evaluation.config import (
+        FeaturesConfig,
+        ForecastingConfig,
+        ForecastingModelConfig,
+    )
+    from forecasting_evaluation.models.base import BasePredictionModel
+
+
+def create_forecasting_model(
+    config: ForecastingModelConfig,
+    seed: int | None = None,
+    force_single_core_stats: bool = False,
+    forecasting_config: ForecastingConfig | None = None,
+    features_config: FeaturesConfig | None = None,
+) -> BasePredictionModel:
+    """Create a prediction model from config.
+
+    Args:
+        config: Forecasting model configuration specifying type and hyperparameters.
+        seed: Random seed for deterministic behavior. If None, forecasting may
+            use non-deterministic random number generation.
+        force_single_core_stats: If True, force statistical models to n_jobs=1
+            to avoid nested parallelism when evaluator already runs in parallel.
+        forecasting_config: Forecasting window configuration required by
+            learned forecasting models that depend on fixed history/horizon.
+        features_config: Feature extraction configuration required by learned
+            forecasting models that infer feature dimensionality from channels.
+
+    Returns:
+        Forecasting model with predict method.
+    """
+    return _create_model(
+        config,
+        seed,
+        force_single_core_stats,
+        forecasting_config,
+        features_config,
+    )
+
+
+def _create_model(
+    config: ForecastingModelConfig,
+    seed: int | None,
+    force_single_core_stats: bool,
+    forecasting_config: ForecastingConfig | None,
+    features_config: FeaturesConfig | None,
+) -> BasePredictionModel:
+    """Create a single model from single-model config.
+    
+    Args:
+        config: Single-model configuration.
+        seed: Random seed.
+        force_single_core_stats: If True, override statistical models to run
+            with a single core (`n_jobs=1`) to avoid nested parallelism.
+        forecasting_config: Forecasting window configuration passed through to
+            models that need training-time history and horizon settings.
+        features_config: Feature extraction configuration passed through to
+            models that need channel-dependent feature counts.
+    
+    Returns:
+        Instantiated model with custom name attribute.
+    """
+    model_name = config.name if config.name else config.type
+    
+    # Type-safe model creation based on instance type
+    if config.type == "naive":
+        raise NotImplementedError("Naive model not yet implemented")
+
+    elif config.type == "seasonal_naive":
+        seasonal_cfg = config.seasonal_naive
+        from forecasting_evaluation.models.naive.seasonal_naive import SeasonalNaiveModel
+        model = SeasonalNaiveModel(
+            seed=seed,
+            seasonal=seasonal_cfg.season_length,
+            quantile_levels=seasonal_cfg.quantile_levels,
+        )
+        model.model_name = model_name
+
+    elif config.type == "seasonal_naive_average_history":
+        seasonal_hist_cfg = config.seasonal_naive_average_history
+        from forecasting_evaluation.models.naive.seasonal_naive_average_history import (
+            SeasonalNaiveAverageModel,
+        )
+        model = SeasonalNaiveAverageModel(seed=seed, seasonal=seasonal_hist_cfg.season_length)
+        model.model_name = model_name
+
+    elif config.type == "autoARIMA":
+        arima_cfg = config.autoARIMA
+        from forecasting_evaluation.models.statistic.autoARIMA import AutoARIMAModel
+        n_jobs = 1 if force_single_core_stats else arima_cfg.n_jobs
+        model = AutoARIMAModel(
+            seed=seed,
+            start_p=arima_cfg.start_p,
+            start_q=arima_cfg.start_q,
+            max_p=arima_cfg.max_p,
+            max_q=arima_cfg.max_q,
+            seasonal=arima_cfg.seasonal,
+            start_P=arima_cfg.start_P,
+            start_Q=arima_cfg.start_Q,
+            max_P=arima_cfg.max_P,
+            max_Q=arima_cfg.max_Q,
+            max_d=arima_cfg.max_d,
+            max_D=arima_cfg.max_D,
+            information_criterion=arima_cfg.information_criterion,
+            suppress_warnings=arima_cfg.suppress_warnings,
+            trace=arima_cfg.trace,
+            error_action=arima_cfg.error_action,
+            stepwise=arima_cfg.stepwise,
+            n_jobs=n_jobs,
+            max_history_length=arima_cfg.max_history_length,
+        )
+        model.model_name = model_name
+
+    elif config.type == "autoETS":
+        ets_cfg = config.autoETS
+        from forecasting_evaluation.models.statistic.autoETS import AutoETSModel
+        n_jobs = 1 if force_single_core_stats else ets_cfg.n_jobs
+        model = AutoETSModel(
+            seed=seed,
+            auto=ets_cfg.auto,
+            sp=ets_cfg.sp,
+            information_criterion=ets_cfg.information_criterion,
+            n_jobs=n_jobs,
+            max_history_length=ets_cfg.max_history_length,
+        )
+        model.model_name = model_name
+
+    elif config.type == "chronos2":
+        from forecasting_evaluation.models.foundational_model.chronos2 import Chronos2Model
+        model = Chronos2Model(
+            config=config.chronos2,
+            seed=seed,
+        )
+        model.model_name = model_name
+
+    elif config.type == "toto":
+        from forecasting_evaluation.models.foundational_model.toto import TotoModel
+        model = TotoModel(
+            config=config.toto,
+            seed=seed,
+        )
+        model.model_name = model_name
+
+    elif config.type == "mixlinear":
+        if forecasting_config is None or features_config is None:
+            raise ValueError(
+                "forecasting_config and features_config are required for "
+                "mixlinear model creation"
+            )
+        from forecasting_evaluation.models.deep_learning_model.mixlinear import MixLinearModel
+        model = MixLinearModel(
+            config=config.mixlinear,
+            forecasting_config=forecasting_config,
+            features_config=features_config,
+        )
+        model.model_name = model_name
+
+    elif config.type == "dlinear":
+        if forecasting_config is None or features_config is None:
+            raise ValueError(
+                "forecasting_config and features_config are required for "
+                "dlinear model creation"
+            )
+        from forecasting_evaluation.models.deep_learning_model.dlinear import DLinearModel
+        model = DLinearModel(
+            config=config.dlinear,
+            forecasting_config=forecasting_config,
+            features_config=features_config,
+        )
+        model.model_name = model_name
+
+    elif config.type == "segrnn":
+        if forecasting_config is None or features_config is None:
+            raise ValueError(
+                "forecasting_config and features_config are required for "
+                "segrnn model creation"
+            )
+        from forecasting_evaluation.models.deep_learning_model.segrnn import SegRNNModel
+        model = SegRNNModel(
+            config=config.segrnn,
+            forecasting_config=forecasting_config,
+            features_config=features_config,
+        )
+        model.model_name = model_name
+
+    else:
+        raise ValueError(f"Unknown forecasting model type: {config.type}")
+
+    return model

--- a/src/forecasting_evaluation/models/statistic/__init__.py
+++ b/src/forecasting_evaluation/models/statistic/__init__.py
@@ -1,0 +1,6 @@
+"""Classic time series forecasting models."""
+
+from forecasting_evaluation.models.statistic.autoARIMA import AutoARIMAModel
+from forecasting_evaluation.models.statistic.autoETS import AutoETSModel
+
+__all__ = ["AutoARIMAModel", "AutoETSModel"]

--- a/src/forecasting_evaluation/models/statistic/autoARIMA.py
+++ b/src/forecasting_evaluation/models/statistic/autoARIMA.py
@@ -1,0 +1,258 @@
+"""autoARIMA baseline forecasting model."""
+
+import random
+import warnings
+
+import numpy as np
+import pandas as pd
+from sktime.forecasting.arima import AutoARIMA as sktimeAutoARIMA
+
+try:
+    from statsmodels.tools.sm_exceptions import ConvergenceWarning
+except ImportError:  # pragma: no cover - optional dependency in some envs
+    ConvergenceWarning = Warning
+
+from forecasting_evaluation.data.types import SubTrajectoryInput
+from forecasting_evaluation.models.base import BasePredictionModel
+
+
+class AutoARIMAModel(BasePredictionModel):
+    """AutoARIMA forecasting model using sktime.
+    
+    This model automatically searches for the best ARIMA parameters
+    using information criteria (AIC/BIC). It fits a separate model
+    for each feature in multivariate time series.
+
+    Note: This model refits from scratch on each predict call.
+    """
+    
+    def __init__(
+            self, 
+            seed: int = 42,
+            start_p: int = 2,
+            start_q: int = 2,
+            max_p: int = 5,
+            max_q: int = 5,
+            seasonal: bool = True,
+            start_P: int = 1,
+            start_Q: int = 1,
+            max_P: int = 2,
+            max_Q: int = 2,
+            max_d: int = 2,
+            max_D: int = 1,
+            information_criterion: str = "aic",
+            suppress_warnings: bool = True,
+            trace: bool = False,
+            error_action: str = "ignore",
+            stepwise: bool = False,
+            n_jobs: int = -1,
+            max_history_length: int | None = 24 * 14,  # Limit to recent 336 hours (14 days)
+            quantile_levels: tuple[float, ...] = (0.1, 0.5, 0.9),
+        ):
+        """Initialize AutoARIMA model.
+        
+        Args:
+            seed: Random seed for reproducibility.
+            start_p: Starting value of p in stepwise procedure.
+            start_q: Starting value of q in stepwise procedure.
+            max_p: Maximum value of p.
+            max_q: Maximum value of q.
+            seasonal: Whether to fit a seasonal ARIMA model.
+            m: The period for seasonal differencing (24 for hourly data with daily seasonality).
+            start_P: Starting value of P in stepwise procedure.
+            start_Q: Starting value of Q in stepwise procedure.
+            max_P: Maximum value of P.
+            max_Q: Maximum value of Q.
+            max_d: Maximum value of d (order of first-differencing).
+            max_D: Maximum value of D (order of seasonal differencing).
+            information_criterion: Information criterion for model selection ('aic', 'bic', 'aicc').
+            suppress_warnings: Whether to suppress warnings during fitting.
+            trace: Whether to print status on the fits.
+            error_action: Action to take if a model fails to fit ('ignore', 'raise', 'warn').
+            stepwise: Whether to use stepwise search. Must be False to enable true parallel search.
+            n_jobs: Number of parallel jobs (-1 uses all processors).
+            max_history_length: Maximum number of recent data points to use for fitting.
+                If None, uses all available history. If specified, only the most recent
+                max_history_length points are used for model fitting.
+            quantile_levels: Quantile levels returned alongside point forecasts.
+        """
+        self.seed = seed
+        self.start_p = start_p
+        self.start_q = start_q
+        self.max_p = max_p
+        self.max_q = max_q
+        self.seasonal = seasonal
+        self.start_P = start_P
+        self.start_Q = start_Q
+        self.max_P = max_P
+        self.max_Q = max_Q
+        self.max_d = max_d
+        self.max_D = max_D
+        self.information_criterion = information_criterion
+        self.suppress_warnings = suppress_warnings
+        self.trace = trace
+        self.error_action = error_action
+        self.stepwise = stepwise
+        self.n_jobs = n_jobs
+        self.max_history_length = max_history_length
+        self.quantile_levels = self._validate_quantile_levels(quantile_levels)
+        
+        # Set random seeds
+        np.random.seed(seed)
+        random.seed(seed)
+
+        self.reset()
+
+    def predict(
+            self,
+            inputs: SubTrajectoryInput,
+        ) -> tuple[np.ndarray | None, np.ndarray | None]:
+        """Predict future values using AutoARIMA.
+
+        Fits a new model on all available historical data for each prediction.
+
+        Args:
+            inputs: Typed forecasting sub-trajectory input.
+
+        Returns:
+            Tuple containing (point_result, quantiles_result):
+            - point_result: (n_features, prediction_length) array of point predictions.
+            - quantiles_result: (n_features, prediction_length, n_quantiles) quantile forecasts.
+        """
+        target = inputs.history
+        prediction_length = inputs.prediction_hours
+
+        n_features, _ = target.shape
+        n_quantiles = 0 if self.quantile_levels is None else len(self.quantile_levels)
+
+        predictions = np.zeros((n_features, prediction_length))
+        quantiles = None
+        if n_quantiles > 0:
+            quantiles = np.zeros((n_features, prediction_length, n_quantiles))
+
+        for i in range(n_features):
+            y = target[i, :]
+            y = np.where(np.isnan(y), 0.0, y)
+
+            # Truncate to most recent data if max_history_length is specified
+            if self.max_history_length is not None and len(y) > self.max_history_length:
+                y = y[-self.max_history_length:]
+
+            # Skip if all values are zero or constant
+            if np.all(y == 0) or np.std(y) < 1e-10:
+                predictions[i, :] = y[-1]
+                if quantiles is not None:
+                    quantiles[i, :, :] = y[-1]
+                continue
+
+            try:
+                model = self._fit_new_model(y)
+                fh = np.arange(1, prediction_length + 1)
+                y_pred = model.predict(fh=fh)
+                predictions[i, :] = y_pred.ravel()
+                if quantiles is not None:
+                    y_quantiles = model.predict_quantiles(
+                        fh=fh,
+                        alpha=self.quantile_levels.tolist(),
+                    )
+                    quantiles[i, :, :] = self._coerce_quantiles_array(
+                        y_quantiles,
+                        prediction_length=prediction_length,
+                    )
+            except Exception as e:
+                if not self.suppress_warnings:
+                    print(f"ARIMA fit/predict failed for feature {i}: {e}")
+                predictions[i, :] = y[-1]
+                if quantiles is not None:
+                    quantiles[i, :, :] = y[-1]
+
+        point_result = predictions
+        quantiles_result = quantiles
+
+        return point_result, quantiles_result
+
+    @staticmethod
+    def _validate_quantile_levels(quantile_levels: tuple[float, ...] | list[float] | np.ndarray) -> np.ndarray:
+        """Validate and normalize configured quantile levels."""
+        quantile_array = np.asarray(quantile_levels, dtype=float)
+        if quantile_array.ndim != 1 or quantile_array.size == 0:
+            raise ValueError("quantile_levels must be a non-empty 1D sequence")
+        if np.any((quantile_array <= 0.0) | (quantile_array >= 1.0)):
+            raise ValueError("quantile_levels must be strictly between 0 and 1")
+        if np.unique(quantile_array).size != quantile_array.size:
+            raise ValueError("quantile_levels must not contain duplicates")
+        return np.sort(quantile_array)
+
+    def _coerce_quantiles_array(
+        self,
+        quantile_frame: pd.DataFrame,
+        *,
+        prediction_length: int,
+    ) -> np.ndarray:
+        """Convert sktime quantile output to (prediction_length, n_quantiles)."""
+        quantile_values = quantile_frame.to_numpy(dtype=float)
+        if quantile_values.shape == (prediction_length, len(self.quantile_levels)):
+            return quantile_values
+
+        if isinstance(quantile_frame.columns, pd.MultiIndex):
+            quantile_columns = []
+            for alpha in self.quantile_levels:
+                alpha_slice = quantile_frame.xs(alpha, axis=1, level=-1)
+                if alpha_slice.shape[1] != 1:
+                    raise ValueError(
+                        "Expected one quantile column per alpha for univariate AutoARIMA output"
+                    )
+                quantile_columns.append(alpha_slice.iloc[:, 0].to_numpy(dtype=float))
+            return np.stack(quantile_columns, axis=-1)
+
+        raise ValueError(
+            "Unexpected quantile prediction shape "
+            f"{quantile_values.shape}; expected ({prediction_length}, {len(self.quantile_levels)})"
+        )
+
+    def _fit_new_model(self, y: np.ndarray):
+        """Fit a new AutoARIMA model for a single univariate series."""
+        model = sktimeAutoARIMA(
+            start_p=self.start_p,
+            start_q=self.start_q,
+            max_p=self.max_p,
+            max_q=self.max_q,
+            stepwise=self.stepwise,
+            seasonal=self.seasonal,
+            start_P=self.start_P,
+            start_Q=self.start_Q,
+            max_P=self.max_P,
+            max_Q=self.max_Q,
+            max_d=self.max_d,
+            max_D=self.max_D,
+            information_criterion=self.information_criterion,
+            suppress_warnings=self.suppress_warnings,
+            trace=self.trace,
+            error_action=self.error_action,
+            random_state=self.seed,
+            n_jobs=self.n_jobs
+        )
+
+        # Suppress pmdarima constant series warning
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=".*completely constant.*",
+                category=UserWarning
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message=".*stepwise model cannot be fit in parallel.*",
+                category=UserWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                category=ConvergenceWarning,
+            )
+            model.fit(y)
+
+        return model
+
+    def reset(self):
+        """Reset model state (no-op for stateless model)."""
+        pass

--- a/src/forecasting_evaluation/models/statistic/autoETS.py
+++ b/src/forecasting_evaluation/models/statistic/autoETS.py
@@ -1,0 +1,207 @@
+"""AutoETS baseline forecasting model."""
+
+import random
+import warnings
+
+import numpy as np
+import pandas as pd
+from sktime.forecasting.ets import AutoETS as sktimeAutoETS
+
+try:
+    from statsmodels.tools.sm_exceptions import ConvergenceWarning
+except ImportError:  # pragma: no cover - optional dependency in some envs
+    ConvergenceWarning = Warning
+
+from forecasting_evaluation.data.types import SubTrajectoryInput
+from forecasting_evaluation.models.base import BasePredictionModel
+
+SEASONAL_CYCLE_ERROR_MSG = (
+    "Cannot compute initial seasonals using heuristic method with less than two full seasonal cycles in the data."
+)
+MLE_CONVERGENCE_MSG = "Maximum Likelihood optimization failed to converge"
+
+
+class AutoETSModel(BasePredictionModel):
+    """AutoETS forecasting model using sktime.
+    
+    This model uses Exponential Smoothing (ETS) framework to automatically
+    select the best combination of Error, Trend, and Seasonality components
+    via information criteria (AIC/BIC/AICc). For multivariate time series,
+    it fits a separate model for each feature.
+    
+    Note: Since sktime's AutoETS doesn't have true incremental update,
+    this model refits on all historical data each time.
+    """
+    
+    def __init__(
+            self, 
+            seed: int = 42,
+            auto: bool = True,
+            sp: int = 24,
+            information_criterion: str = "aic",
+            n_jobs: int = -1,
+            max_history_length: int | None = None,
+            quantile_levels: tuple[float, ...] = (0.1, 0.5, 0.9),
+        ):
+        """Initialize AutoETS model.
+        
+        Args:
+            seed: Random seed for reproducibility.
+            auto: Set True to enable automatic model selection.
+            sp: The number of periods in a complete seasonal cycle for seasonal
+                (Holt-Winters) models. For example, 4 for quarterly data with an
+                annual cycle or 24 for hourly data with daily seasonality.
+            information_criterion: Information criterion for model selection
+                ('aic', 'aicc', 'bic').
+            n_jobs: Number of parallel jobs (-1 uses all processors).
+            max_history_length: Maximum number of recent data points to use for fitting.
+                If None, uses all available history. If specified, only the most recent
+                max_history_length points are used for model fitting.
+            quantile_levels: Quantile levels returned alongside point forecasts.
+        """
+        self.seed = seed
+        self.auto = auto
+        self.sp = sp
+        self.information_criterion = information_criterion
+        self.n_jobs = n_jobs
+        self.max_history_length = max_history_length
+        self.quantile_levels = self._validate_quantile_levels(quantile_levels)
+        
+        # Set random seeds
+        np.random.seed(seed)
+        random.seed(seed)
+
+        self.reset()
+
+    def predict(
+            self,
+            inputs: SubTrajectoryInput,
+        ) -> tuple[np.ndarray | None, np.ndarray | None]:
+        """Predict future values using AutoETS.
+        
+        Fits a new model on all available historical data for each prediction.
+        """
+        target = inputs.history
+        prediction_length = inputs.prediction_hours
+        n_features, _ = target.shape
+        n_quantiles = 0 if self.quantile_levels is None else len(self.quantile_levels)
+        
+        predictions = np.zeros((n_features, prediction_length))
+        quantiles = None
+        if n_quantiles > 0:
+            quantiles = np.zeros((n_features, prediction_length, n_quantiles))
+        
+        for i in range(n_features):
+            y = target[i, :]
+            y = np.where(np.isnan(y), 0.0, y)
+            
+            # Truncate to most recent data if max_history_length is specified
+            if self.max_history_length is not None and len(y) > self.max_history_length:
+                y = y[-self.max_history_length:]
+            
+            # Preprocessing: skip constant or all-zero series
+            if np.all(y == 0) or np.std(y) < 1e-10:
+                predictions[i, :] = y[-1]
+                if quantiles is not None:
+                    quantiles[i, :, :] = y[-1]
+                continue
+            
+            # Fit model on (truncated) historical data
+            try:
+                # ETS seasonal initialization needs at least two full cycles.
+                # Fall back to non-seasonal model when history is too short.
+                effective_sp = self.sp if self.sp <= 1 or len(y) >= 2 * self.sp else 1
+
+                model = sktimeAutoETS(
+                    auto=self.auto,
+                    sp=effective_sp,
+                    information_criterion=self.information_criterion,
+                    n_jobs=self.n_jobs,
+                    random_state=self.seed
+                )
+                
+                # Suppress warnings about non-positive time series
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore",
+                        message=".*time series is not strictly positive.*",
+                        category=UserWarning
+                    )
+                    warnings.filterwarnings(
+                        "ignore",
+                        category=ConvergenceWarning,
+                    )
+                    warnings.filterwarnings(
+                        "ignore",
+                        message=f".*{MLE_CONVERGENCE_MSG}.*",
+                        category=Warning,
+                    )
+                    model.fit(y)
+                
+                # Perform prediction
+                fh = np.arange(1, prediction_length + 1)
+                y_pred = model.predict(fh=fh)
+                predictions[i, :] = y_pred.ravel()
+                if quantiles is not None:
+                    y_quantiles = model.predict_quantiles(
+                        fh=fh,
+                        alpha=self.quantile_levels.tolist(),
+                    )
+                    quantiles[i, :, :] = self._coerce_quantiles_array(
+                        y_quantiles,
+                        prediction_length=prediction_length,
+                    )
+            except Exception as e:
+                # Quietly ignore known short-history seasonal initialization failures.
+                if SEASONAL_CYCLE_ERROR_MSG not in str(e):
+                    print(f"ETS fit/predict failed for feature {i}: {e}")
+                predictions[i, :] = y[-1]
+                if quantiles is not None:
+                    quantiles[i, :, :] = y[-1]
+        
+        return predictions, quantiles
+
+    @staticmethod
+    def _validate_quantile_levels(
+        quantile_levels: tuple[float, ...] | list[float] | np.ndarray,
+    ) -> np.ndarray:
+        """Validate and normalize configured quantile levels."""
+        quantile_array = np.asarray(quantile_levels, dtype=float)
+        if quantile_array.ndim != 1 or quantile_array.size == 0:
+            raise ValueError("quantile_levels must be a non-empty 1D sequence")
+        if np.any((quantile_array <= 0.0) | (quantile_array >= 1.0)):
+            raise ValueError("quantile_levels must be strictly between 0 and 1")
+        if np.unique(quantile_array).size != quantile_array.size:
+            raise ValueError("quantile_levels must not contain duplicates")
+        return np.sort(quantile_array)
+
+    def _coerce_quantiles_array(
+        self,
+        quantile_frame: pd.DataFrame,
+        *,
+        prediction_length: int,
+    ) -> np.ndarray:
+        """Convert sktime quantile output to (prediction_length, n_quantiles)."""
+        quantile_values = quantile_frame.to_numpy(dtype=float)
+        if quantile_values.shape == (prediction_length, len(self.quantile_levels)):
+            return quantile_values
+
+        if isinstance(quantile_frame.columns, pd.MultiIndex):
+            quantile_columns = []
+            for alpha in self.quantile_levels:
+                alpha_slice = quantile_frame.xs(alpha, axis=1, level=-1)
+                if alpha_slice.shape[1] != 1:
+                    raise ValueError(
+                        "Expected one quantile column per alpha for univariate AutoETS output"
+                    )
+                quantile_columns.append(alpha_slice.iloc[:, 0].to_numpy(dtype=float))
+            return np.stack(quantile_columns, axis=-1)
+
+        raise ValueError(
+            "Unexpected quantile prediction shape "
+            f"{quantile_values.shape}; expected ({prediction_length}, {len(self.quantile_levels)})"
+        )
+    
+    def reset(self):
+        """Reset model state (no-op for stateless model)."""
+        pass

--- a/src/forecasting_evaluation/runner.py
+++ b/src/forecasting_evaluation/runner.py
@@ -1,0 +1,168 @@
+"""Library entry-point for the forecasting eval pipeline.
+
+The script ``scripts/run_forecasting_eval.py`` in the private repo runs a
+2-phase pipeline: ``ForecastingEvaluator.run()`` writes per-user prediction
+parquets, then ``OfflineMetricsCalculator.run()`` aggregates them into
+per-channel metrics. This module exposes a single ``run_eval(config,
+model)`` function that does both steps and returns the aggregated metrics
+in-memory so the public OpenMHC API can call it without orchestrating the
+full script.
+
+A custom forecaster is supplied via the ``model`` argument (any object
+satisfying :class:`forecasting_evaluation.models.base.BasePredictionModel`)
+so the registry's built-in models aren't required. The internal evaluator
+constructs its own model from the config — we monkey-patch that step by
+overriding ``run()`` on a thin subclass.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from forecasting_evaluation.evaluation.evaluator import ForecastingEvaluator
+from forecasting_evaluation.io.predict_result_writer import PublicWriter
+
+if TYPE_CHECKING:
+    from forecasting_evaluation.config import ForecastingEvalConfig
+    from forecasting_evaluation.models.base import BasePredictionModel
+
+logger = logging.getLogger(__name__)
+
+
+class _CustomModelEvaluator(ForecastingEvaluator):
+    """Subclass that injects a pre-constructed model rather than using the registry."""
+
+    def __init__(self, config: "ForecastingEvalConfig", model: "BasePredictionModel"):
+        super().__init__(config)
+        self._injected_model = model
+
+    def run(self) -> dict:
+        """Same flow as the parent class but skips ``create_forecasting_model``."""
+        from forecasting_evaluation.config import print_config
+
+        print_config(self.config)
+        model = self._injected_model
+        data_context = self._load_evaluation_data(model)
+
+        public_writer = PublicWriter(
+            self.config,
+            experiment_name=self.config.experiment_name,
+        )
+        self._run_sequential(model, data_context, public_writer)
+        run_dir = public_writer.finalize()
+        return {
+            "run_dir": str(run_dir),
+            "prediction_samples": public_writer.total_written,
+            "skipped_users": public_writer.skipped_users,
+        }
+
+
+def run_eval(
+    config: "ForecastingEvalConfig",
+    model: "BasePredictionModel",
+    metrics_output_dir: str | Path | None = None,
+) -> dict:
+    """Run forecasting eval + offline metrics in one call.
+
+    Args:
+        config: Fully-populated :class:`ForecastingEvalConfig`.
+        model: Pre-constructed model (any object satisfying the
+            :class:`BasePredictionModel` protocol — has ``predict()``).
+        metrics_output_dir: Where the offline-metrics pipeline writes its
+            outputs. Defaults to a temp directory adjacent to the eval
+            run dir.
+
+    Returns:
+        Dict with keys:
+        - ``run_dir``: where prediction parquets were written
+        - ``metrics_dir``: where offline metrics were written
+        - ``per_channel``: aggregated per-channel metrics
+        - ``n_samples``: prediction samples emitted
+    """
+    # Phase 1: prediction generation.
+    evaluator = _CustomModelEvaluator(config, model)
+    eval_summary = evaluator.run()
+    run_dir = Path(eval_summary["run_dir"])
+
+    # Phase 2: offline metric aggregation.
+    from forecasting_evaluation.metrics.offline.runner import OfflineMetricsCalculator
+
+    if metrics_output_dir is None:
+        metrics_output_dir = run_dir.parent / f"{run_dir.name}_metrics"
+    metrics_output_dir = Path(metrics_output_dir)
+    metrics_output_dir.mkdir(parents=True, exist_ok=True)
+
+    calculator = OfflineMetricsCalculator(
+        evaluation_result_paths={config.experiment_name or "openmhc_run": str(run_dir)},
+        metrics_output_path=str(metrics_output_dir),
+    )
+    calculator.run()
+
+    per_channel = _load_per_channel_metrics(metrics_output_dir)
+
+    return {
+        "run_dir": str(run_dir),
+        "metrics_dir": str(metrics_output_dir),
+        "per_channel": per_channel,
+        "n_samples": int(eval_summary["prediction_samples"]),
+    }
+
+
+def _load_per_channel_metrics(metrics_dir: Path) -> dict[str, dict]:
+    """Aggregate per-channel metrics from offline-pipeline outputs.
+
+    Offline-pipeline layout (set by
+    :func:`metrics.offline.parquet_io.save_metrics_result_by_metric`)::
+
+        <metrics_dir>/<run_key>/<metric>/<user_id>.parquet
+
+    Each parquet has rows ``(user_id, model, history_length,
+    forecasting_length, <metric>)``. The ``<metric>`` cell holds a 2D
+    nested-list of shape ``(n_features, horizon)`` (i.e. MAE per channel
+    per horizon timestep). We average across rows, users, and horizon to
+    get one scalar per (channel, metric) and key the output by channel
+    index ``ch_<i>``.
+    """
+    import numpy as np
+    import pandas as pd
+
+    out: dict[str, dict] = {}
+    metric_dirs = [p for p in metrics_dir.rglob("*") if p.is_dir() and any(p.glob("*.parquet"))]
+    for metric_dir in metric_dirs:
+        metric_name = metric_dir.name
+        # Stack all per-user values into one (n_rows, n_features, horizon) array.
+        per_channel_values: dict[int, list[float]] = {}
+        for parquet_path in metric_dir.glob("*.parquet"):
+            try:
+                df = pd.read_parquet(parquet_path)
+            except Exception:
+                continue
+            if metric_name not in df.columns:
+                continue
+            for cell in df[metric_name]:
+                if cell is None:
+                    continue
+                # The parquet cell is a list-of-lists (n_features × horizon).
+                # pandas may load it as object array of arrays; flatten per channel.
+                try:
+                    rows = list(cell)
+                except TypeError:
+                    continue
+                for ch_idx, ch_row in enumerate(rows):
+                    try:
+                        ch_arr = np.asarray(list(ch_row), dtype=float)
+                    except Exception:
+                        continue
+                    with np.errstate(invalid="ignore"):
+                        ch_mean = float(np.nanmean(ch_arr)) if ch_arr.size else float("nan")
+                    if np.isfinite(ch_mean):
+                        per_channel_values.setdefault(ch_idx, []).append(ch_mean)
+        for ch_idx, vals in per_channel_values.items():
+            if not vals:
+                continue
+            channel_key = f"ch_{ch_idx}"
+            out.setdefault(channel_key, {})[metric_name] = float(np.mean(vals))
+    return out

--- a/src/forecasting_evaluation/utils/__init__.py
+++ b/src/forecasting_evaluation/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility functions for forecasting evaluation."""

--- a/src/imputation_evaluation/runner.py
+++ b/src/imputation_evaluation/runner.py
@@ -1,0 +1,157 @@
+"""Library entry-point for the imputation eval pipeline.
+
+This is the orchestration code that lives only in
+``scripts/run_imputation_eval.py`` in the private repo. We extracted it
+here so the public ``openmhc`` API can call the eval pipeline without
+shelling out to a script.
+
+The function accepts an already-built ``ImputationEvalConfig`` plus an
+``ImputationMethod``-compatible object (anything with ``name``,
+``channel_stds``, ``fit``, ``impute``). It returns the raw results dict
+produced by :class:`imputation_evaluation.evaluation.evaluator.ImputationEvaluator`.
+
+Skipped vs. the script: writer/output writing, W&B logging,
+visualization plots, sensitivity-analysis subgroup mappings (callers can
+pass ``subgroup_mappings`` if they want).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from imputation_evaluation.data.data_loader import ImputationDataLoader
+from imputation_evaluation.evaluation.evaluator import ImputationEvaluator
+from imputation_evaluation.masking import MaskCacheGenerator, create_mask_generators
+
+if TYPE_CHECKING:
+    from imputation_evaluation.config import ImputationEvalConfig
+    from imputation_evaluation.methods.base import ImputationMethod
+
+logger = logging.getLogger(__name__)
+
+
+def run_eval(
+    config: "ImputationEvalConfig",
+    method: "ImputationMethod",
+    *,
+    subgroup_mappings: dict | None = None,
+) -> dict:
+    """Run the imputation evaluation pipeline end-to-end.
+
+    Mirrors the orchestration in ``scripts/run_imputation_eval.py`` but
+    skips writer/W&B/viz so it's safe to call from a Python process that
+    just wants the metrics dict back.
+
+    Args:
+        config: Fully-populated ``ImputationEvalConfig``.
+        method: An object implementing the :class:`ImputationMethod`
+            protocol. The OpenMHC public API wraps user-supplied
+            ``Imputer`` objects in an internal adapter to satisfy this.
+        subgroup_mappings: Optional pre-built subgroup mappings for
+            sensitivity analysis. Pass ``None`` to skip.
+
+    Returns:
+        The raw results dict (scenario → split → group → metric → value)
+        emitted by :class:`ImputationEvaluator`. Plus a ``"config"`` key.
+    """
+    # 1. Load data.
+    logger.info("Loading data...")
+    data_loader = ImputationDataLoader(config.data)
+    loaded_data = data_loader.load_splits(
+        batch_size=config.data.batch_size,
+        num_workers=config.data.num_workers,
+        pin_memory=config.data.pin_memory,
+    )
+
+    # 2. Create mask generators.
+    generators = create_mask_generators(config.masking)
+    scenario_names = [g.name for g in generators]
+    logger.info("Created %d mask generators: %s", len(generators), scenario_names)
+
+    # 3. Generate masks (no pre-cached masks supported in this entry point).
+    logger.info("Generating masks...")
+    mask_generator = MaskCacheGenerator(
+        hf_dataset=loaded_data.hf_dataset,
+        zero_to_nan_transform=loaded_data.zero_to_nan_transform,
+        num_workers=config.data.num_workers,
+        batch_size=config.data.batch_size,
+    )
+    mask_cache = mask_generator.generate(
+        split_indices={
+            "val": loaded_data.split_indices["val"],
+            "test": loaded_data.split_indices["test"],
+        },
+        generators=generators,
+        base_seed=config.masking.mask_seed,
+    )
+
+    # 4. Fit the method on training data.
+    logger.info("Fitting %s on training data...", method.name)
+    method.fit(loaded_data.train_loader)
+
+    channel_stds = method.channel_stds
+    if channel_stds is None:
+        channel_stds = np.ones(19)
+
+    # 5. Pre-filter eval samples to only those with at least one mask.
+    applicable_indices = None
+    if mask_cache is not None:
+        applicable_indices = {}
+        for split_name in ("val", "test"):
+            indices = mask_cache.get_applicable_indices(split_name)
+            if indices:
+                applicable_indices[split_name] = indices
+        if not applicable_indices:
+            applicable_indices = None
+
+    # 6. Build eval-specific data loaders.
+    eval_dl_workers = (
+        config.data.num_eval_dl_workers
+        if config.data.num_eval_dl_workers is not None
+        else config.data.num_workers
+    )
+    eval_val_loader, eval_test_loader = data_loader.create_eval_loaders(
+        split_indices=loaded_data.split_indices,
+        hf_dataset=loaded_data.hf_dataset,
+        batch_size=config.data.batch_size,
+        num_workers=eval_dl_workers,
+        pin_memory=config.data.pin_memory,
+        window_descriptors=loaded_data.window_descriptors,
+        window_day_offsets=loaded_data.window_day_offsets,
+        applicable_indices=applicable_indices,
+    )
+
+    # 7. Run evaluation.
+    evaluator = ImputationEvaluator(
+        scenarios=scenario_names,
+        num_eval_workers=config.data.num_eval_workers,
+        include_ks=config.evaluation.include_ks,
+        include_wasserstein=config.evaluation.include_wasserstein,
+        n_days=config.data.n_days,
+        compute_metrics=config.evaluation.compute_metrics,
+        save_pairs=False,  # public API doesn't need raw pairs on disk
+        pairs_dir=None,
+    )
+    results = evaluator.run(
+        val_loader=eval_val_loader,
+        test_loader=eval_test_loader,
+        mask_cache=mask_cache,
+        method=method,
+        channel_stds=channel_stds,
+        subgroup_mappings=subgroup_mappings,
+        window_descriptors=loaded_data.window_descriptors,
+        window_day_offsets=loaded_data.window_day_offsets,
+        hf_dataset=loaded_data.hf_dataset,
+        split_indices=loaded_data.split_indices,
+        zero_to_nan_transform=loaded_data.zero_to_nan_transform,
+    )
+
+    results["config"] = {
+        "method": method.name,
+        "seed": config.seed,
+        "mask_seed": config.masking.mask_seed,
+    }
+    return results

--- a/src/openmhc/__init__.py
+++ b/src/openmhc/__init__.py
@@ -3,7 +3,7 @@
 Quick start:
 
     >>> import openmhc
-    >>> results = openmhc.evaluate_downstream(my_encoder)
+    >>> results = openmhc.evaluate_prediction(my_encoder)
     >>> results.summary()
     >>> results.global_score  # mean AUROC across binary tasks
 
@@ -17,16 +17,22 @@ Quick start:
 
 from openmhc._constants import MASKING_SCENARIOS, SENSOR_CHANNELS
 from openmhc._dataset import data_dir, download_dataset
-from openmhc._protocols import Encoder, Imputer
-from openmhc._results import DownstreamResults, ImputationResults
+from openmhc._protocols import Encoder, Forecaster, Imputer
+from openmhc._results import (
+    ForecastingResults,
+    ImputationResults,
+    PredictionResults,
+)
 
 __all__ = [
     # Protocols
     "Encoder",
     "Imputer",
+    "Forecaster",
     # Evaluation functions
-    "evaluate_downstream",
+    "evaluate_prediction",
     "evaluate_imputation",
+    "evaluate_forecasting",
     # Dataset
     "download_dataset",
     "data_dir",
@@ -35,18 +41,19 @@ __all__ = [
     "list_masking_scenarios",
     "SENSOR_CHANNELS",
     # Result types
-    "DownstreamResults",
+    "PredictionResults",
     "ImputationResults",
+    "ForecastingResults",
 ]
 
 
-def evaluate_downstream(
+def evaluate_prediction(
     encoder: Encoder,
     tasks: str | list[str] = "all",
     data_dir: str | None = None,
     seed: int = 42,
-) -> DownstreamResults:
-    """Run downstream health prediction evaluation with a custom encoder.
+) -> PredictionResults:
+    """Run health-prediction evaluation with a custom encoder.
 
     Args:
         encoder: Object implementing the Encoder protocol.
@@ -56,9 +63,9 @@ def evaluate_downstream(
         seed: Random seed for classifiers and splits.
 
     Returns:
-        DownstreamResults with per-task metrics and a global score.
+        PredictionResults with per-task metrics and a global score.
     """
-    from openmhc._evaluate import evaluate_downstream as _eval
+    from openmhc._evaluate import evaluate_prediction as _eval
 
     return _eval(encoder, tasks=tasks, data_dir=data_dir, seed=seed)
 
@@ -87,8 +94,39 @@ def evaluate_imputation(
     return _eval(imputer, masking_scenarios=masking_scenarios, data_dir=data_dir, seed=seed)
 
 
+def evaluate_forecasting(
+    forecaster: Forecaster,
+    forecasting_length: int = 24,
+    data_dir: str | None = None,
+    seed: int = 42,
+    max_samples: int | None = None,
+) -> ForecastingResults:
+    """Run forecasting evaluation (Track 3) with a custom forecaster.
+
+    Args:
+        forecaster: Object implementing the Forecaster protocol —
+            ``predict(history, horizon)`` returns ``(n_channels, horizon)``.
+        forecasting_length: Forecast horizon in hours. Defaults to 24.
+        data_dir: Override for the dataset root. None uses the default.
+        seed: Random seed.
+        max_samples: Limit prediction samples per user (debugging only).
+
+    Returns:
+        ForecastingResults with per-channel metrics.
+    """
+    from openmhc._evaluate import evaluate_forecasting as _eval
+
+    return _eval(
+        forecaster,
+        forecasting_length=forecasting_length,
+        data_dir=data_dir,
+        seed=seed,
+        max_samples=max_samples,
+    )
+
+
 def list_tasks() -> list[str]:
-    """Return all 33 available downstream prediction task names.
+    """Return all 33 available prediction task names.
 
     Returns:
         Sorted list of task name strings.

--- a/src/openmhc/_dataset.py
+++ b/src/openmhc/_dataset.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import tarfile
 import tempfile
 import urllib.request
 import zipfile
@@ -98,20 +99,69 @@ def download_dataset(
 
     print(f"Downloading {version!r} dataset ({doi}) → {target}")
     req = urllib.request.Request(url, headers=headers)
-    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
-        zip_path = tmp.name
+    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as tmp:
+        archive_path = tmp.name
         try:
             with urllib.request.urlopen(req) as resp:
                 shutil.copyfileobj(resp, tmp)
         except Exception:
-            os.unlink(zip_path)
+            os.unlink(archive_path)
             raise
 
     try:
-        with zipfile.ZipFile(zip_path) as zf:
-            zf.extractall(target)
+        _extract_archive_recursive(Path(archive_path), target)
     finally:
-        os.unlink(zip_path)
+        os.unlink(archive_path)
 
     print(f"Done. Set MHC_DATA_DIR={target} to skip the lookup next time.")
     return target
+
+
+def _extract_archive_recursive(archive: Path, dest: Path) -> None:
+    """Extract ``archive`` into ``dest``, recursively unpacking nested archives.
+
+    Dataverse's dataset-access endpoint always wraps files in an outer zip,
+    so a tar.gz upload comes back as zip-of-tarball. After extracting the
+    outer archive, any inner ``.tar``, ``.tar.gz``, ``.tgz``, or ``.zip``
+    files are unpacked in place and removed.
+    """
+    _extract_one(archive, dest)
+    # Walk dest and unpack any nested archives the outer extract produced.
+    for path in list(dest.rglob("*")):
+        if not path.is_file():
+            continue
+        if _looks_like_archive(path):
+            _extract_one(path, path.parent)
+            path.unlink(missing_ok=True)
+
+
+def _looks_like_archive(path: Path) -> bool:
+    """Detect by suffix; falls through ``.bin`` / ``.zip`` / ``.tar*``."""
+    name = path.name.lower()
+    return (
+        name.endswith(".tar.gz")
+        or name.endswith(".tgz")
+        or name.endswith(".tar")
+        or name.endswith(".zip")
+    )
+
+
+def _extract_one(archive: Path, dest: Path) -> None:
+    """Extract a single archive (zip / tar / tar.gz) into ``dest``.
+
+    Detects format via the magic-byte sniffers in :mod:`zipfile` and
+    :mod:`tarfile` so the file extension doesn't matter — handy for the
+    Dataverse download which we save as ``.bin``.
+    """
+    if zipfile.is_zipfile(archive):
+        with zipfile.ZipFile(archive) as zf:
+            zf.extractall(dest)
+        return
+    if tarfile.is_tarfile(archive):
+        with tarfile.open(archive) as tf:
+            tf.extractall(dest)
+        return
+    raise ValueError(
+        f"could not detect archive format for {archive!r}; "
+        "expected zip or tar/tar.gz"
+    )

--- a/src/openmhc/_evaluate.py
+++ b/src/openmhc/_evaluate.py
@@ -1,4 +1,4 @@
-"""Public evaluation functions for MHC-Benchmark.
+"""Public evaluation functions for OpenMHC.
 
 These functions provide a simple interface to the benchmark's evaluation
 pipelines. They accept duck-typed Encoder/Imputer objects and return
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import warnings
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -18,40 +20,65 @@ import numpy as np
 if TYPE_CHECKING:
     from openmhc._protocols import Encoder, Imputer
 
+from openmhc._dataset import data_dir as _resolve_default_data_dir
 from openmhc._results import DownstreamResults, ImputationResults
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Default paths (relative to repo root)
-# ---------------------------------------------------------------------------
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_DEFAULT_DAILY_HOURLY_HF_DIR = _REPO_ROOT / "data" / "processed" / "daily_hourly_hf"
-_DEFAULT_WINDOW_INDEX_PATH = (
-    _REPO_ROOT / "data" / "processed" / "window_index_w7_s7_d5.parquet"
-)
-_DEFAULT_SPLIT_FILE = _REPO_ROOT / "data" / "splits" / "sharable_users_seed42_2026.json"
-_DEFAULT_WEEKLY_LABELS_LOOKUP = (
-    _REPO_ROOT / "data" / "processed" / "weekly_labels_lookup_stride7.parquet"
-)
-_DEFAULT_CLIP_DATES = _REPO_ROOT / "data" / "labels" / "clip_dates.json"
-_DEFAULT_DAILY_HF_DIR = _REPO_ROOT / "data" / "processed" / "daily_hf"
-_DEFAULT_NORM_STATS = _REPO_ROOT / "data" / "processed" / "normalization_stats_hourly.json"
 
+@dataclass
+class _DatasetPaths:
+    """Resolved paths into the dataset directory.
 
-def _resolve_data_dir(data_dir: str | Path | None, default: Path) -> Path:
-    """Resolve a user-provided data directory or fall back to the default.
-
-    Args:
-        data_dir: User-provided path, or None for the default.
-        default: Default path to use when data_dir is None.
-
-    Returns:
-        Resolved Path object.
+    All paths are derived from a single ``root`` so the API stays consistent
+    with what :func:`openmhc.download_dataset` produces. The expected layout
+    matches DATASET.md.
     """
-    if data_dir is not None:
-        return Path(data_dir)
-    return default
+
+    root: Path
+    daily_hourly_hf: Path
+    daily_hf: Path
+    window_index: Path
+    weekly_labels_lookup: Path
+    splits_file: Path
+    norm_stats: Path
+    clip_dates: Path
+    labels_dir: Path
+
+    @classmethod
+    def resolve(cls, override: str | Path | None = None) -> "_DatasetPaths":
+        """Build the paths bundle from an explicit override or the default.
+
+        Resolution order matches :func:`openmhc.data_dir`:
+
+        1. ``override`` argument (if provided)
+        2. ``MHC_DATA_DIR`` env var
+        3. ``~/.cache/openmhc/data``
+        """
+        root = _resolve_default_data_dir(override)
+        return cls(
+            root=root,
+            daily_hourly_hf=root / "processed" / "daily_hourly_hf",
+            daily_hf=root / "processed" / "daily_hf",
+            window_index=root / "processed" / "window_index_w7_s7_d5.parquet",
+            weekly_labels_lookup=root / "processed" / "weekly_labels_lookup_stride7.parquet",
+            splits_file=root / "splits" / "sharable_users_seed42_2026.json",
+            norm_stats=root / "processed" / "normalization_stats_hourly.json",
+            clip_dates=root / "labels" / "clip_dates.json",
+            labels_dir=root / "labels",
+        )
+
+
+def _ensure_labels_env(labels_dir: Path) -> None:
+    """Point the bundled `labels.api` module at the downloaded labels dir.
+
+    `labels.api` reads `LABELS_DATA_PATH` / `CONTEXT_LABELS_PATH` env vars
+    at import time. Set them to the dataset paths if the user hasn't.
+    """
+    if not os.getenv("LABELS_DATA_PATH"):
+        os.environ["LABELS_DATA_PATH"] = str(labels_dir / "last_labels.json")
+    if not os.getenv("CONTEXT_LABELS_PATH"):
+        os.environ["CONTEXT_LABELS_PATH"] = str(labels_dir / "context_labels.json")
 
 
 # ---------------------------------------------------------------------------
@@ -86,6 +113,9 @@ def evaluate_downstream(
     """
     import pandas as pd
 
+    paths = _DatasetPaths.resolve(data_dir)
+    _ensure_labels_env(paths.labels_dir)
+
     from downstream_evaluation.config import ClassifierConfig, parse_time_windows
     from downstream_evaluation.data.splits import load_split_file
     from downstream_evaluation.evaluation.metrics import (
@@ -107,11 +137,11 @@ def evaluate_downstream(
         task_list = list(tasks)
 
     # Resolve paths.
-    daily_hourly_dir = _resolve_data_dir(data_dir, _DEFAULT_DAILY_HOURLY_HF_DIR)
-    split_file = _DEFAULT_SPLIT_FILE
-    window_index_path = _DEFAULT_WINDOW_INDEX_PATH
-    labels_path = _DEFAULT_WEEKLY_LABELS_LOOKUP
-    clip_dates_path = _DEFAULT_CLIP_DATES
+    daily_hourly_dir = paths.daily_hourly_hf
+    split_file = paths.splits_file
+    window_index_path = paths.window_index
+    labels_path = paths.weekly_labels_lookup
+    clip_dates_path = paths.clip_dates
 
     # Load user splits.
     split_users = load_split_file(split_file)
@@ -457,7 +487,9 @@ def evaluate_imputation(
                 f"Valid scenarios: {MASKING_SCENARIOS}"
             )
 
-    daily_hf_dir = _resolve_data_dir(data_dir, _DEFAULT_DAILY_HF_DIR)
+    paths = _DatasetPaths.resolve(data_dir)
+    _ensure_labels_env(paths.labels_dir)
+    daily_hf_dir = paths.daily_hf
 
     # Build a minimal config.
     from imputation_evaluation.config import (
@@ -483,7 +515,7 @@ def evaluate_imputation(
 
     data_cfg = DataConfig(
         daily_hf_dir=str(daily_hf_dir),
-        split_file=str(_DEFAULT_SPLIT_FILE),
+        split_file=str(paths.splits_file),
         split_seed=seed,
         batch_size=5000,
         num_workers=4,

--- a/src/openmhc/_evaluate.py
+++ b/src/openmhc/_evaluate.py
@@ -78,12 +78,25 @@ def _ensure_labels_env(labels_dir: Path) -> None:
     """Point the bundled `labels.api` module at the downloaded labels dir.
 
     `labels.api` reads `LABELS_DATA_PATH` / `CONTEXT_LABELS_PATH` env vars
-    at import time. Set them to the dataset paths if the user hasn't.
+    at import time and caches them in module-level Path constants. We set
+    the env vars if the user hasn't, then reload the module if it was
+    already imported (e.g. via ``openmhc.list_tasks()``) so the cached
+    paths reflect the new values.
     """
+    changed = False
     if not os.getenv("LABELS_DATA_PATH"):
         os.environ["LABELS_DATA_PATH"] = str(labels_dir / "last_labels.json")
+        changed = True
     if not os.getenv("CONTEXT_LABELS_PATH"):
         os.environ["CONTEXT_LABELS_PATH"] = str(labels_dir / "context_labels.json")
+        changed = True
+
+    if changed:
+        import importlib
+        import sys
+
+        if "labels.api" in sys.modules:
+            importlib.reload(sys.modules["labels.api"])
 
 
 # ---------------------------------------------------------------------------
@@ -108,8 +121,11 @@ def evaluate_prediction(
         encoder: Object with an `encode(weekly_tensors) -> embeddings` method.
             Input shape is (B, 168, 38), output shape is (B, D).
         tasks: "all" to run all 33 tasks, or a list of task name strings.
-        data_dir: Path to the `daily_hourly_hf` dataset directory. None uses
-            the default location.
+        data_dir: Override for the dataset root (the same root that
+            ``download_dataset`` writes to). ``None`` uses the default
+            (``MHC_DATA_DIR`` env var or ``~/.cache/openmhc/data``). All
+            sub-paths (`processed/daily_hourly_hf/`, `splits/`, `labels/`,
+            etc.) are derived from this root.
         seed: Random seed for classifiers and splits.
 
     Returns:
@@ -472,8 +488,11 @@ def evaluate_imputation(
             `impute(data, observed_mask, target_mask)` methods.
         masking_scenarios: "all" to run all 6 scenarios, or a list of scenario
             name strings.
-        data_dir: Path to the `daily_hf` dataset directory. None uses the
-            default location.
+        data_dir: Override for the dataset root (the same root that
+            ``download_dataset`` writes to). ``None`` uses the default
+            (``MHC_DATA_DIR`` env var or ``~/.cache/openmhc/data``). All
+            sub-paths (`processed/daily_hf/`, `splits/`, `labels/`, etc.)
+            are derived from this root.
         seed: Random seed for mask generation.
 
     Returns:

--- a/src/openmhc/_evaluate.py
+++ b/src/openmhc/_evaluate.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import tempfile
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
     from openmhc._protocols import Encoder, Imputer
 
 from openmhc._dataset import data_dir as _resolve_default_data_dir
-from openmhc._results import DownstreamResults, ImputationResults
+from openmhc._results import PredictionResults, ImputationResults
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,8 @@ class _DatasetPaths:
     norm_stats: Path
     clip_dates: Path
     labels_dir: Path
+    hourly_trajectory: Path
+    forecasting_sample_index_dir: Path
 
     @classmethod
     def resolve(cls, override: str | Path | None = None) -> "_DatasetPaths":
@@ -66,6 +69,8 @@ class _DatasetPaths:
             norm_stats=root / "processed" / "normalization_stats_hourly.json",
             clip_dates=root / "labels" / "clip_dates.json",
             labels_dir=root / "labels",
+            hourly_trajectory=root / "hourly_trajectory",
+            forecasting_sample_index_dir=root / "forecasting_sample_index",
         )
 
 
@@ -82,17 +87,17 @@ def _ensure_labels_env(labels_dir: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Downstream evaluation
+# Prediction evaluation
 # ---------------------------------------------------------------------------
 
 
-def evaluate_downstream(
+def evaluate_prediction(
     encoder: Encoder,
     tasks: str | list[str] = "all",
     data_dir: str | Path | None = None,
     seed: int = 42,
-) -> DownstreamResults:
-    """Run downstream health prediction evaluation with a custom encoder.
+) -> PredictionResults:
+    """Run health-prediction evaluation with a custom encoder.
 
     Encodes weekly sensor tensors via `encoder.encode()` and evaluates the
     resulting embeddings on up to 33 health prediction tasks using linear
@@ -108,7 +113,7 @@ def evaluate_downstream(
         seed: Random seed for classifiers and splits.
 
     Returns:
-        A DownstreamResults instance with per-task metrics and a global score
+        A PredictionResults instance with per-task metrics and a global score
         (mean AUROC across binary tasks).
     """
     import pandas as pd
@@ -325,7 +330,7 @@ def evaluate_downstream(
 
     global_score = float(np.mean(binary_aurocs)) if binary_aurocs else 0.0
 
-    return DownstreamResults(records=records, global_score=global_score)
+    return PredictionResults(records=records, global_score=global_score)
 
 
 def _extract_encoder_features(
@@ -635,3 +640,111 @@ class _ImputerMethodAdapter:
 
     def prepare_split(self, *args, **kwargs) -> None:
         """No-op; some internal methods use this hook."""
+
+
+# ---------------------------------------------------------------------------
+# Forecasting evaluation (Track 3)
+# ---------------------------------------------------------------------------
+
+
+def evaluate_forecasting(
+    forecaster,
+    forecasting_length: int = 24,
+    data_dir: str | Path | None = None,
+    seed: int = 42,
+    max_samples: int | None = None,
+) -> "ForecastingResults":
+    """Run forecasting evaluation (Track 3) with a custom forecaster.
+
+    Args:
+        forecaster: Object satisfying the :class:`Forecaster` protocol —
+            has ``predict(history, horizon)`` returning a ``(n_channels,
+            horizon)`` array.
+        forecasting_length: Forecast horizon in hours. Defaults to 24
+            (matching the paper's Track 3 sub-task).
+        data_dir: Override for the dataset root. ``None`` uses the default
+            (``MHC_DATA_DIR`` env var or ``~/.cache/openmhc/data``).
+        seed: Random seed.
+        max_samples: Limit prediction samples per user (debugging).
+
+    Returns:
+        :class:`ForecastingResults` with per-channel metrics.
+    """
+    from openmhc._results import ForecastingResults
+
+    paths = _DatasetPaths.resolve(data_dir)
+    _ensure_labels_env(paths.labels_dir)
+
+    from forecasting_evaluation.config import (
+        DataConfig,
+        EvaluatorConfig,
+        FeaturesConfig,
+        ForecastingConfig,
+        ForecastingEvalConfig,
+        ForecastingModelConfig,
+        OutputConfig,
+    )
+    from forecasting_evaluation.runner import run_eval
+
+    # Pick a sample-index file matching the requested forecasting horizon.
+    sample_index_file = paths.forecasting_sample_index_dir / "sample_index_raw.json"
+
+    data_cfg = DataConfig(
+        trajectory_hf_dir=str(paths.hourly_trajectory),
+        split_file=str(paths.splits_file),
+        day_remain_mask=str(paths.forecasting_sample_index_dir / "day_remain_mask.json"),
+        sample_index_file=str(sample_index_file),
+        split_seed=seed,
+        max_samples=max_samples,
+    )
+    forecasting_cfg = ForecastingConfig(forecasting_length=forecasting_length)
+
+    with tempfile.TemporaryDirectory(prefix="openmhc-fc-") as tmp_results:
+        cfg = ForecastingEvalConfig(
+            seed=seed,
+            experiment_name="openmhc_run",
+            debug_mode=False,
+            data=data_cfg,
+            forecasting=forecasting_cfg,
+            model=ForecastingModelConfig(),  # ignored by _CustomModelEvaluator
+            features=FeaturesConfig(),
+            evaluator=EvaluatorConfig(),
+            output=OutputConfig(results_dir=tmp_results),
+        )
+        adapter = _build_forecaster_adapter(forecaster)
+        result = run_eval(cfg, model=adapter)
+
+    return ForecastingResults(
+        per_channel=result.get("per_channel", {}),
+        run_dir=str(result.get("run_dir", "")),
+        n_samples=int(result.get("n_samples", 0)),
+    )
+
+
+def _build_forecaster_adapter(forecaster):
+    """Wrap a user's ``Forecaster`` as an internal ``BasePredictionModel``.
+
+    Subclasses ``BasePredictionModel`` so we inherit ``predict_wrapper`` (which
+    adds timing + memory tracking around the user's ``predict()`` call).
+    """
+    from forecasting_evaluation.models.base import BasePredictionModel
+
+    class _ForecasterAdapter(BasePredictionModel):
+        model_name = "openmhc_custom_forecaster"
+        quantile_levels = None
+        uses_standard_scaler = False
+        scaler_stats = None
+
+        def __init__(self, forecaster):
+            self._forecaster = forecaster
+
+        def predict(self, inputs):
+            """Translate ``SubTrajectoryInput`` → user's ``predict(history, horizon)``."""
+            point = self._forecaster.predict(inputs.history, inputs.prediction_hours)
+            return np.asarray(point, dtype=np.float32), None
+
+        def reset(self):
+            if hasattr(self._forecaster, "reset"):
+                self._forecaster.reset()
+
+    return _ForecasterAdapter(forecaster)

--- a/src/openmhc/_evaluate.py
+++ b/src/openmhc/_evaluate.py
@@ -489,9 +489,7 @@ def evaluate_imputation(
 
     paths = _DatasetPaths.resolve(data_dir)
     _ensure_labels_env(paths.labels_dir)
-    daily_hf_dir = paths.daily_hf
 
-    # Build a minimal config.
     from imputation_evaluation.config import (
         DataConfig,
         EvalConfig,
@@ -503,7 +501,7 @@ def evaluate_imputation(
         VisualizationConfig,
         WandbConfig,
     )
-    from imputation_evaluation.data.data_loader import ImputationDataLoader
+    from imputation_evaluation.runner import run_eval
 
     masking_cfg = MaskingConfig(mask_seed=seed)
     masking_cfg.random_noise.enabled = "random_noise" in scenario_list
@@ -514,7 +512,7 @@ def evaluate_imputation(
     masking_cfg.intensity_failure.enabled = "intensity_failure" in scenario_list
 
     data_cfg = DataConfig(
-        daily_hf_dir=str(daily_hf_dir),
+        daily_hf_dir=str(paths.daily_hf),
         split_file=str(paths.splits_file),
         split_seed=seed,
         batch_size=5000,
@@ -533,7 +531,7 @@ def evaluate_imputation(
         seed=seed,
         data=data_cfg,
         masking=masking_cfg,
-        method=MethodConfig(type="mean"),
+        method=MethodConfig(type="mean"),  # placeholder; not used (custom adapter below)
         output=OutputConfig(),
         evaluation=eval_cfg,
         visualization=VisualizationConfig(),
@@ -541,46 +539,9 @@ def evaluate_imputation(
         wandb=WandbConfig(),
     )
 
-    # Load data.
-    loader = ImputationDataLoader(cfg.data)
-    loaded = loader.load()
-
-    # Generate masks.
-    from imputation_evaluation.masking import MaskCacheGenerator, create_mask_generators
-
-    generators = create_mask_generators(cfg.masking)
-    mask_gen = MaskCacheGenerator(
-        generators=generators,
-        seed=cfg.masking.mask_seed,
-    )
-    mask_cache = mask_gen.generate(loaded.val_loader, loaded.test_loader)
-
-    # Wrap the user's imputer in our internal method interface.
     adapter = _ImputerMethodAdapter(imputer)
-
-    logger.info("Fitting imputer on training data...")
-    adapter.fit(loaded.train_loader)
-
-    # Run evaluation.
-    from imputation_evaluation.evaluation.evaluator import ImputationEvaluator
-
-    evaluator = ImputationEvaluator(
-        scenarios=[g.name for g in generators],
-        num_eval_workers=cfg.data.num_eval_workers,
-        include_ks=cfg.evaluation.include_ks,
-        include_wasserstein=cfg.evaluation.include_wasserstein,
-        compute_metrics=True,
-        save_pairs=False,
-    )
-
-    results = evaluator.run(
-        val_loader=loaded.val_loader,
-        test_loader=loaded.test_loader,
-        mask_cache=mask_cache,
-        method=adapter,
-        channel_stds=loaded.channel_stds,
-    )
-
+    logger.info("Running imputation eval with custom imputer...")
+    results = run_eval(cfg, method=adapter)
     return ImputationResults(scenarios=results.get("scenarios", results))
 
 
@@ -649,19 +610,14 @@ class _ImputerMethodAdapter:
         data: np.ndarray,
         original_masks: np.ndarray,
         artificial_masks: np.ndarray,
+        **kwargs,
     ) -> np.ndarray:
         """Delegate to the user's impute, translating argument names.
 
-        Args:
-            data: Sensor values of shape (N, 19, 1440) with NaN at masked
-                positions.
-            original_masks: Binary mask of shape (N, 19, 1440) where
-                1 = originally observed.
-            artificial_masks: Binary mask of shape (N, 19, 1440) where
-                1 = positions to impute.
-
-        Returns:
-            Array of shape (N, 19, 1440) with imputed values.
+        Internal callers may pass extra kwargs (``sample_indices``,
+        ``day_offsets``) used by personalized / RoPE-aware methods. The
+        public ``Imputer`` protocol doesn't expose those, so we discard
+        them silently.
         """
         return self._imputer.impute(
             data=data,

--- a/src/openmhc/_evaluate.py
+++ b/src/openmhc/_evaluate.py
@@ -236,14 +236,20 @@ def evaluate_downstream(
             clip = all_clip_dates.get(task_name)
 
             for clf_type in classifiers:
+                if task_name not in labels_df.columns:
+                    logger.warning(
+                        "Task %s missing from labels lookup, skipping", task_name
+                    )
+                    break
+                task_labels = labels_df[task_name].values
                 try:
                     splits = store.aggregate_for_task(
-                        labels_df=labels_df,
-                        task_name=task_name,
-                        clip_dates=clip,
-                        time_window=tw,
-                        split_users=split_users,
-                        method="mean",
+                        task_labels,
+                        task_type,
+                        clip,
+                        tw,
+                        split_users,
+                        pooling_method="mean",
                     )
                 except Exception as e:
                     logger.warning(
@@ -251,9 +257,11 @@ def evaluate_downstream(
                     )
                     continue
 
-                X_train, y_train, _ = splits["train"]
-                X_val, y_val, _ = splits["validation"]
-                X_test, y_test, _ = splits["test"]
+                # Current signature returns 4-tuple (X, y, user_ids, n_weeks)
+                # under "train"/"val"/"test" keys (split file used "validation").
+                X_train, y_train, *_ = splits["train"]
+                X_val, y_val, *_ = splits["val"]
+                X_test, y_test, *_ = splits["test"]
 
                 if len(X_train) == 0 or len(X_test) == 0:
                     logger.warning("Task %s: empty split, skipping", task_name)

--- a/src/openmhc/_protocols.py
+++ b/src/openmhc/_protocols.py
@@ -13,7 +13,7 @@ import numpy as np
 
 @runtime_checkable
 class Encoder(Protocol):
-    """Protocol for downstream health prediction encoders.
+    """Protocol for health-prediction encoders.
 
     Encode weekly sensor tensors into fixed-size embeddings.
 
@@ -86,5 +86,38 @@ class Imputer(Protocol):
         Returns:
             Array of shape (N, 19, 1440) with imputed values at target
             positions. Must be float32.
+        """
+        ...
+
+
+@runtime_checkable
+class Forecaster(Protocol):
+    """Protocol for forecasting evaluation (Track 3).
+
+    Forecast future hours from a history window. The benchmark evaluates
+    point predictions; quantile forecasts are optional via a return signature
+    extension (see below).
+
+    Example:
+        >>> class LastValueForecaster:
+        ...     def predict(self, history, horizon):
+        ...         # history: (n_channels, history_length)
+        ...         # returns: (n_channels, horizon)
+        ...         last = history[:, -1:]
+        ...         return np.tile(last, (1, horizon))
+    """
+
+    def predict(self, history: np.ndarray, horizon: int) -> np.ndarray:
+        """Forecast ``horizon`` future hours given the history window.
+
+        Args:
+            history: Float array of shape ``(n_channels, history_length)``
+                with the past observations. May contain NaN at missing
+                positions.
+            horizon: Number of future hours to predict.
+
+        Returns:
+            Float array of shape ``(n_channels, horizon)`` with the point
+            forecast. Must be float32.
         """
         ...

--- a/src/openmhc/_results.py
+++ b/src/openmhc/_results.py
@@ -14,8 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class DownstreamResults:
-    """Results from downstream health prediction evaluation.
+class PredictionResults:
+    """Results from health-prediction evaluation.
 
     Attributes:
         records: List of per-task metric records. Each record is a dict with
@@ -94,9 +94,9 @@ class DownstreamResults:
         fill them in during ingestion. ``paper_url`` is optional — leave
         empty for independent submissions without a write-up.
         """
-        from openmhc._submission import downstream_to_submission_yaml
+        from openmhc._submission import prediction_to_submission_yaml
 
-        return downstream_to_submission_yaml(
+        return prediction_to_submission_yaml(
             self,
             method_name=method_name,
             submitter_team=submitter_team,
@@ -111,7 +111,7 @@ class DownstreamResults:
 
     def __repr__(self) -> str:
         n = len(self.records)
-        return f"DownstreamResults({n} records, global_score={self.global_score:.4f})"
+        return f"PredictionResults({n} records, global_score={self.global_score:.4f})"
 
 
 @dataclass
@@ -240,6 +240,90 @@ class ImputationResults:
     def __repr__(self) -> str:
         n = len(self.scenarios)
         return f"ImputationResults({n} scenarios)"
+
+
+@dataclass
+class ForecastingResults:
+    """Results from forecasting evaluation (Track 3).
+
+    Attributes:
+        per_channel: Dict mapping channel name (e.g. ``"hr"``) to a per-metric
+            dict (``mae``, ``mase``, ``ql``, ``sql`` for continuous; ``auprc``,
+            ``auroc`` for binary).
+        run_dir: Path to the directory where per-user prediction parquets +
+            offline metric outputs were written.
+        n_samples: Total prediction samples emitted.
+    """
+
+    per_channel: dict = field(repr=False)
+    run_dir: str = ""
+    n_samples: int = 0
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Flatten per-channel metrics into a long DataFrame."""
+        rows = []
+        for channel, metrics in self.per_channel.items():
+            if not isinstance(metrics, dict):
+                continue
+            for metric_name, value in metrics.items():
+                rows.append({"channel": channel, "metric": metric_name, "value": value})
+        return pd.DataFrame(rows)
+
+    def to_csv(self, path: str | Path) -> None:
+        """Export per-channel results to CSV."""
+        self.to_dataframe().to_csv(path, index=False)
+        logger.info("Forecasting results saved to %s", path)
+
+    def to_json(self, path: str | Path) -> None:
+        """Export full results dict to JSON."""
+        Path(path).write_text(
+            json.dumps(self.per_channel, indent=2, default=_json_default)
+        )
+        logger.info("Forecasting results saved to %s", path)
+
+    def summary(self) -> pd.DataFrame:
+        """Wide table: rows = channels, cols = metrics."""
+        df = self.to_dataframe()
+        if df.empty:
+            return df
+        return df.pivot_table(
+            index="channel", columns="metric", values="value", aggfunc="first"
+        ).reset_index()
+
+    def to_submission_yaml(
+        self,
+        method_name: str,
+        submitter_team: str,
+        code_url: str,
+        paper_url: str = "",
+        method_category: str = "Other",
+        foundation_variant: str = "N/A (not a foundation model)",
+        feature_dim: str = "—",
+        notes: str = "",
+    ) -> str:
+        """Render a paste-ready submission body for a Track 3 forecasting result.
+
+        Skill scores against the Seasonal Naive baseline are emitted as ``—``
+        because the per-channel baseline file isn't shipped yet; maintainers
+        fill them in from ``raw_metrics`` during ingestion.
+        """
+        from openmhc._submission import forecasting_to_submission_yaml
+
+        return forecasting_to_submission_yaml(
+            self,
+            method_name=method_name,
+            submitter_team=submitter_team,
+            code_url=code_url,
+            paper_url=paper_url,
+            method_category=method_category,
+            foundation_variant=foundation_variant,
+            feature_dim=feature_dim,
+            notes=notes,
+        )
+
+    def __repr__(self) -> str:
+        n = len(self.per_channel)
+        return f"ForecastingResults({n} channels, n_samples={self.n_samples})"
 
 
 def _json_default(obj):

--- a/src/openmhc/_submission.py
+++ b/src/openmhc/_submission.py
@@ -88,14 +88,17 @@ def _imputation_log_ratios(
 ) -> list[tuple[str, str, float]]:
     """Compute per-(scenario, channel) log error ratios vs the baseline.
 
-    Returns a list of (scenario, channel, log_ratio) tuples for finite,
-    in-bounds entries only.
+    Channel type is inferred from which metrics the runtime actually
+    emitted: ``normalized_rmse`` ⇒ continuous, ``roc_auc`` ⇒ binary.
+    Method-side error reads ``normalized_rmse`` / ``roc_auc`` from the
+    runtime; baseline-side reads ``nRMSE`` / ``roc_auc`` from the frozen
+    LOCF JSON (column names differ because the baseline was extracted
+    from the paper-results parquet).
     """
     out: list[tuple[str, str, float]] = []
     bl_scenarios = baseline.get("scenarios", {})
     for scenario, splits in results.scenarios.items():
         bl_channels = bl_scenarios.get(scenario, {})
-        # Pull the test-split per-channel metrics from results.
         test = splits.get("test", {}) if isinstance(splits, dict) else {}
         per_channel = test.get("per_channel") if isinstance(test, dict) else None
         if not isinstance(per_channel, dict):
@@ -103,19 +106,27 @@ def _imputation_log_ratios(
         for channel, m in per_channel.items():
             if not isinstance(m, dict):
                 continue
-            ch_type = m.get("channel_type")
-            if ch_type == "binary" and scenario in _EXCLUDE_BINARY_SCENARIOS:
-                continue
-            if ch_type == "continuous":
-                e_method = m.get("nRMSE")
-                e_baseline = bl_channels.get(channel, {}).get("nRMSE")
-            elif ch_type == "binary":
-                auc_method = m.get("roc_auc")
-                auc_baseline = bl_channels.get(channel, {}).get("roc_auc")
-                e_method = (1.0 - auc_method) if auc_method is not None else None
-                e_baseline = (1.0 - auc_baseline) if auc_baseline is not None else None
+            bl_entry = bl_channels.get(channel, {})
+
+            if "normalized_rmse" in m:
+                ch_type = "continuous"
+            elif "roc_auc" in m:
+                ch_type = "binary"
             else:
                 continue
+
+            if ch_type == "binary" and scenario in _EXCLUDE_BINARY_SCENARIOS:
+                continue
+
+            if ch_type == "continuous":
+                e_method = m.get("normalized_rmse")
+                e_baseline = bl_entry.get("nRMSE")
+            else:  # binary
+                auc_method = m.get("roc_auc")
+                auc_baseline = bl_entry.get("roc_auc")
+                e_method = (1.0 - auc_method) if auc_method is not None else None
+                e_baseline = (1.0 - auc_baseline) if auc_baseline is not None else None
+
             if e_method is None or e_baseline is None:
                 continue
             if not (np.isfinite(e_method) and np.isfinite(e_baseline)) or e_baseline <= 0:

--- a/src/openmhc/_submission.py
+++ b/src/openmhc/_submission.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Iterable
 import numpy as np
 
 if TYPE_CHECKING:
-    from openmhc._results import DownstreamResults, ImputationResults
+    from openmhc._results import PredictionResults, ImputationResults
 
 # ---------------------------------------------------------------------------
 # Constants from the paper
@@ -229,8 +229,8 @@ def imputation_to_submission_yaml(
     )
 
 
-def downstream_to_submission_yaml(
-    results: "DownstreamResults",
+def prediction_to_submission_yaml(
+    results: "PredictionResults",
     method_name: str,
     submitter_team: str,
     code_url: str,
@@ -272,6 +272,52 @@ def downstream_to_submission_yaml(
             "body_biomarkers: —",
             "mental_wellbeing: —",
             "sleep_lifestyle: —",
+        ],
+        raw_block=raw,
+    )
+
+
+def forecasting_to_submission_yaml(
+    results: "ForecastingResults",
+    method_name: str,
+    submitter_team: str,
+    code_url: str,
+    paper_url: str = "",
+    method_category: str = "Other",
+    foundation_variant: str = "N/A (not a foundation model)",
+    feature_dim: str = "—",
+    notes: str = "",
+) -> str:
+    """Render a paste-ready submission body for a Track 3 forecasting result.
+
+    Skill scores against the Seasonal Naive baseline are left as ``—``
+    until the per-channel baseline file is shipped. Subgroup keys match
+    the submission template (``step``, ``flights``, ``hr``, ``energy``,
+    ``sleep``, ``workouts``).
+    """
+    raw = json.dumps(results.per_channel, indent=2, default=_json_default)
+    return _render_yaml_block(
+        track="Track 3 — Forecasting",
+        method_name=method_name,
+        submitter_team=submitter_team,
+        method_category=method_category,
+        foundation_variant=foundation_variant,
+        feature_dim=feature_dim,
+        paper_url=paper_url,
+        code_url=code_url,
+        notes=notes,
+        aggregate_lines=[
+            "skill_score: —  # computed by maintainers vs Seasonal Naive baseline",
+            "fair_skill_score: —",
+            "avg_rank: —",
+        ],
+        subgroup_lines=[
+            "step: —",
+            "flights: —",
+            "hr: —",
+            "energy: —",
+            "sleep: —",
+            "workouts: —",
         ],
         raw_block=raw,
     )

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,119 @@
+"""Path-resolution tests for the openmhc API.
+
+These verify that the API and the dataset downloader agree on where data
+lives. Without this, ``download_dataset`` would write to one location and
+``evaluate_*`` would look in another.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from openmhc._dataset import data_dir
+from openmhc._evaluate import _DatasetPaths
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Clear MHC_DATA_DIR for each test so they start from a known state."""
+    monkeypatch.delenv("MHC_DATA_DIR", raising=False)
+    yield
+
+
+class TestDataDir:
+    def test_default_under_user_cache(self):
+        result = data_dir()
+        assert result == Path.home() / ".cache" / "openmhc" / "data"
+
+    def test_explicit_override_wins(self, tmp_path):
+        result = data_dir(tmp_path / "explicit")
+        assert result == (tmp_path / "explicit").resolve()
+
+    def test_env_var_override(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MHC_DATA_DIR", str(tmp_path / "from-env"))
+        result = data_dir()
+        assert result == (tmp_path / "from-env").resolve()
+
+    def test_explicit_wins_over_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MHC_DATA_DIR", str(tmp_path / "from-env"))
+        result = data_dir(tmp_path / "explicit")
+        assert result == (tmp_path / "explicit").resolve()
+
+    def test_tilde_expansion(self):
+        result = data_dir("~/some-mhc-data")
+        assert result == (Path.home() / "some-mhc-data").resolve()
+
+
+class TestDatasetPaths:
+    """Confirm the eval pipeline routes through ``data_dir`` consistently."""
+
+    def test_default_root_matches_data_dir(self):
+        paths = _DatasetPaths.resolve()
+        assert paths.root == data_dir()
+
+    def test_all_subpaths_under_root(self, tmp_path):
+        paths = _DatasetPaths.resolve(tmp_path)
+        assert paths.daily_hourly_hf == tmp_path / "processed" / "daily_hourly_hf"
+        assert paths.daily_hf == tmp_path / "processed" / "daily_hf"
+        assert paths.window_index == tmp_path / "processed" / "window_index_w7_s7_d5.parquet"
+        assert (
+            paths.weekly_labels_lookup
+            == tmp_path / "processed" / "weekly_labels_lookup_stride7.parquet"
+        )
+        assert paths.splits_file == tmp_path / "splits" / "sharable_users_seed42_2026.json"
+        assert paths.norm_stats == tmp_path / "processed" / "normalization_stats_hourly.json"
+        assert paths.clip_dates == tmp_path / "labels" / "clip_dates.json"
+        assert paths.labels_dir == tmp_path / "labels"
+
+    def test_env_override_propagates(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MHC_DATA_DIR", str(tmp_path))
+        paths = _DatasetPaths.resolve()
+        assert paths.root == tmp_path.resolve()
+        assert paths.daily_hf.parent.parent == tmp_path.resolve()
+
+    def test_explicit_override_propagates(self, tmp_path):
+        paths = _DatasetPaths.resolve(tmp_path / "explicit")
+        assert paths.root == (tmp_path / "explicit").resolve()
+
+
+class TestLabelsEnvWiring:
+    """Verify the labels.api env-var bridge is set when missing."""
+
+    def test_sets_labels_path_when_unset(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("LABELS_DATA_PATH", raising=False)
+        monkeypatch.delenv("CONTEXT_LABELS_PATH", raising=False)
+        from openmhc._evaluate import _ensure_labels_env
+
+        _ensure_labels_env(tmp_path / "labels")
+        assert os.environ["LABELS_DATA_PATH"] == str(tmp_path / "labels" / "last_labels.json")
+        assert os.environ["CONTEXT_LABELS_PATH"] == str(
+            tmp_path / "labels" / "context_labels.json"
+        )
+
+    def test_respects_user_overrides(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("LABELS_DATA_PATH", "/somewhere/else.json")
+        monkeypatch.setenv("CONTEXT_LABELS_PATH", "/somewhere/ctx.json")
+        from openmhc._evaluate import _ensure_labels_env
+
+        _ensure_labels_env(tmp_path / "labels")
+        assert os.environ["LABELS_DATA_PATH"] == "/somewhere/else.json"
+        assert os.environ["CONTEXT_LABELS_PATH"] == "/somewhere/ctx.json"
+
+
+class TestDownloadDatasetSurface:
+    """Verify the download helper signature and error paths."""
+
+    def test_unknown_version_raises(self):
+        from openmhc import download_dataset
+
+        with pytest.raises(ValueError, match="version must be one of"):
+            download_dataset(version="bogus")
+
+    def test_unpublished_version_raises(self):
+        from openmhc import download_dataset
+
+        with pytest.raises(ValueError, match="not yet published"):
+            download_dataset(version="full")

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -18,8 +18,19 @@ from openmhc._evaluate import _DatasetPaths
 
 @pytest.fixture(autouse=True)
 def _isolate_env(monkeypatch):
-    """Clear MHC_DATA_DIR for each test so they start from a known state."""
-    monkeypatch.delenv("MHC_DATA_DIR", raising=False)
+    """Clear dataset / labels env vars so each test starts from a known state.
+
+    Without this, tests that set ``LABELS_DATA_PATH`` / ``CONTEXT_LABELS_PATH``
+    would leak into sibling test modules (e.g. ``src/labels/test_api.py``)
+    and make ordering matter.
+    """
+    for var in (
+        "MHC_DATA_DIR",
+        "LABELS_DATA_PATH",
+        "CONTEXT_LABELS_PATH",
+        "ENROLLMENT_DATA_PATH",
+    ):
+        monkeypatch.delenv(var, raising=False)
     yield
 
 


### PR DESCRIPTION
## Summary
Close the loop between `download_dataset()` and `evaluate_*()`. Before this PR, the downloader unpacked the Dataverse ZIP under `~/.cache/openmhc/data` while the eval pipeline still looked for data at `<repo>/data/processed/...` — a leftover from the internal benchmark layout. They didn't talk to each other.

## Changes
- Replace per-file `_DEFAULT_*` module constants with a single `_DatasetPaths.resolve(override)` bundle anchored at `data_dir()`. Resolution order: explicit `data_dir=` arg → `MHC_DATA_DIR` env → `~/.cache/openmhc/data`.
- Set `LABELS_DATA_PATH` / `CONTEXT_LABELS_PATH` at runtime so the bundled `labels.api` module reads participant labels from the downloaded labels dir.
- DATASET.md adds `clip_dates.json` to the documented layout and explains the resolution order.
- New `tests/test_paths.py` (13 tests, all passing) covering `data_dir()`, `_DatasetPaths.resolve()`, the labels env-var bridge, and `download_dataset()` error paths.

## Test plan
- [x] `pytest tests/test_paths.py` — 13/13 passing
- [x] `import openmhc` smoke — exports list unchanged
- [x] **End-to-end smoke against live Dataverse** — blocked: `doi:10.7910/DVN/ZYMJF6` is currently Draft and requires an API token. Once published or a token is shared, run `openmhc.download_dataset("tiny")` followed by a trivial `MeanImputer` evaluation and compare results to the paper LOCF baseline.