### PR TITLE
labels: sync schema files with upstream MHC-benchmark

### DIFF
--- a/data/labels/label_types.json
+++ b/data/labels/label_types.json
@@ -167,40 +167,20 @@
     "type": "continuous",
     "target": false
   },
-  "field_DiastolicBloodPressure": {
-    "type": "continuous",
-    "target": false
-  },
   "field_smokingHistory": {
     "type": "binary",
-    "target": false
-  },
-  "field_Gender": {
-    "type": "categorical",
     "target": false
   },
   "field_Ethnicity_heartage": {
     "type": "categorical",
     "target": false
   },
-  "field_Age_heartage": {
-    "type": "continuous",
-    "target": false
-  },
   "field_family_history": {
-    "type": "categorical",
-    "target": false
-  },
-  "field_heart_disease": {
-    "type": "categorical",
+    "type": "multi_categorical",
     "target": false
   },
   "field_medications_to_treat": {
-    "type": "categorical",
-    "target": false
-  },
-  "field_vascular": {
-    "type": "categorical",
+    "type": "multi_categorical",
     "target": false
   },
   "field_ethnicity": {
@@ -208,7 +188,7 @@
     "target": false
   },
   "field_race": {
-    "type": "categorical",
+    "type": "multi_categorical",
     "target": false
   },
   "field_education": {
@@ -229,10 +209,6 @@
   },
   "field_riskfactors4": {
     "type": "ordinal",
-    "target": false
-  },
-  "field_zip": {
-    "type": "categorical",
     "target": false
   },
   "field_country": {
@@ -260,11 +236,7 @@
     "target": false
   },
   "field_sleep_diagnosis2": {
-    "type": "categorical",
-    "target": false
-  },
-  "field_CurrentAge": {
-    "type": "continuous",
+    "type": "multi_categorical",
     "target": false
   },
   "field_GoSleepTime": {
@@ -279,12 +251,8 @@
     "type": "continuous",
     "target": false
   },
-  "field_BloodType": {
-    "type": "categorical",
-    "target": false
-  },
   "field_FitzpatrickSkinType": {
-    "type": "categorical",
+    "type": "ordinal",
     "target": false
   },
   "field_fish": {
@@ -300,7 +268,7 @@
     "target": false
   },
   "field_sodium": {
-    "type": "ordinal",
+    "type": "multi_categorical",
     "target": false
   },
   "field_sugar_drinks": {
@@ -367,10 +335,6 @@
     "type": "ordinal",
     "target": false
   },
-  "field_pastSmoking": {
-    "type": "ordinal",
-    "target": false
-  },
   "field_cannabisSmoking": {
     "type": "ordinal",
     "target": false
@@ -404,15 +368,15 @@
     "target": false
   },
   "field_tobaccoProducts": {
-    "type": "categorical",
+    "type": "multi_categorical",
     "target": false
   },
   "field_tobaccoProductsEver": {
-    "type": "categorical",
+    "type": "multi_categorical",
     "target": false
   },
   "field_labwork": {
-    "type": "binary",
+    "type": "categorical",
     "target": false
   },
   "field_device_iphone": {
@@ -615,10 +579,6 @@
     "type": "categorical",
     "target": false
   },
-  "field_blood_type_covid": {
-    "type": "ordinal",
-    "target": false
-  },
   "field_exposure": {
     "type": "ordinal",
     "target": false
@@ -633,18 +593,6 @@
   },
   "field_face_covering": {
     "type": "ordinal",
-    "target": false
-  },
-  "field_covid_relatives": {
-    "type": "binary",
-    "target": false
-  },
-  "field_icu_treated": {
-    "type": "binary",
-    "target": false
-  },
-  "field_ventilator": {
-    "type": "binary",
     "target": false
   },
   "field_days_admitted": {
@@ -689,6 +637,42 @@
   },
   "field_sleep_time_daily": {
     "type": "continuous",
+    "target": false
+  },
+  "field_everQuitSmokeless": {
+    "type": "binary",
+    "target": false
+  },
+  "field_durationQuitSmoking": {
+    "type": "categorical",
+    "target": false
+  },
+  "field_durationQuitVaping": {
+    "type": "categorical",
+    "target": false
+  },
+  "field_durationQuitSmokeless": {
+    "type": "categorical",
+    "target": false
+  },
+  "field_antibiotics": {
+    "type": "multi_categorical",
+    "target": false
+  },
+  "field_conditions": {
+    "type": "multi_categorical",
+    "target": false
+  },
+  "field_symptoms_past_week": {
+    "type": "multi_categorical",
+    "target": false
+  },
+  "field_symptoms_week_preceding": {
+    "type": "multi_categorical",
+    "target": false
+  },
+  "field_zip": {
+    "type": "categorical",
     "target": false
   }
 }

--- a/data/labels/ordinal_dictionary.json
+++ b/data/labels/ordinal_dictionary.json
@@ -67,5 +67,220 @@
     "Short": 1,
     "Normal": 0,
     "Too Long": 2
+  },
+  "field_activity1_intensity": {
+    "light": 0,
+    "moderate": 1,
+    "vigorous": 2
+  },
+  "field_activity2_intensity": {
+    "light": 0,
+    "moderate": 1,
+    "vigorous": 2
+  },
+  "field_activity1_type": {
+    "walking": 0,
+    "jogging": 1,
+    "cycling": 2,
+    "tennis": 3,
+    "team_sports": 4,
+    "weight_lifting": 5,
+    "swimming": 6
+  },
+  "field_activity2_type": {
+    "walking": 0,
+    "jogging": 1,
+    "cycling": 2,
+    "tennis": 3,
+    "team_sports": 4,
+    "weight_lifting": 5,
+    "swimming": 6
+  },
+  "field_phone_on_user": {
+    "all_the_time": 0,
+    "all_day_and_night": 1,
+    "all_day_not_night": 2,
+    "most_of_the_time": 3,
+    "half_of_time": 4,
+    "rarely_if_at_all": 5
+  },
+  "field_country": {
+    "US": 0,
+    "UK": 1,
+    "HK": 2
+  },
+  "field_zip": {
+    "UK": 1000,
+    "HK": 1001
+  },
+  "field_FitzpatrickSkinType": {
+    "light": 0,
+    "medium": 1,
+    "dark": 2
+  },
+  "field_Ethnicity_heartage": {
+    "Alaska Native": 0,
+    "American Indian": 1,
+    "Asian": 2,
+    "Black": 3,
+    "Hispanic": 4,
+    "Pacific Islander": 5,
+    "White": 6,
+    "Other": 7,
+    "I prefer not to indicate an ethnicity": 8
+  },
+  "field_Gender": {
+    "Male": 0,
+    "Female": 1,
+    "Other": 2
+  },
+  "field_healthcare_worker": {
+    "1": 1,
+    "2": 2,
+    "3": 3,
+    "4": 4,
+    "5": 5,
+    "6": 6,
+    "7": 7,
+    "Other": 99
+  },
+  "field_labwork": {
+    "1": 1,
+    "2": 2
+  },
+  "field_race": {
+    "1": "White",
+    "2": "Black, African-American, or Negro",
+    "3": "American Indian",
+    "4": "Alaska Native",
+    "5": "Asian Indian",
+    "6": "Chinese",
+    "7": "Filipino",
+    "8": "Japanese",
+    "9": "Korean",
+    "10": "Vietnamese",
+    "11": "Pacific Islander",
+    "12": "Some other race"
+  },
+  "field_family_history": {
+    "1": "Father or brother with heart attack or coronary artery disease before age 55",
+    "2": "Mother or sister with heart attack or coronary artery disease before age 65",
+    "3": "None of the above"
+  },
+  "field_medications_to_treat": {
+    "1": "To treat and lower cholesterol",
+    "2": "To treat hypertension and lower blood pressure",
+    "3": "To treat diabetes/pre-diabetes and lower blood sugar",
+    "4": "None of the above"
+  },
+  "field_sodium": {
+    "1": "I avoid eating prepackaged and processed foods",
+    "2": "I avoid eating out, but when I do, I seek out low-sodium options",
+    "3": "I avoid salt when I'm cooking at home",
+    "4": "None of the above"
+  },
+  "field_tobaccoProducts": {
+    "1": "Manufactured cigarettes",
+    "2": "Hand rolled cigarettes",
+    "3": "Pipe full of tobacco",
+    "4": "Cigars, cigarillos",
+    "5": "Water Pipe (hookah)",
+    "6": "E-cigarettes",
+    "7": "Chew tobacco",
+    "8": "None of the above"
+  },
+  "field_tobaccoProductsEver": {
+    "1": "Manufactured cigarettes",
+    "2": "Hand rolled cigarettes",
+    "3": "Pipe full of tobacco",
+    "4": "Cigars, cigarillos",
+    "5": "Water Pipe (hookah)",
+    "6": "E-cigarettes",
+    "7": "Chew tobacco",
+    "8": "None of the above"
+  },
+  "field_sleep_diagnosis2": {
+    "1": "Sleep Apnea (breathing stops at night)",
+    "2": "Insomnia",
+    "3": "Circadian Rhythm Disturbance (Advanced/Delayed Sleep Phase, Shift work)",
+    "4": "Restless Legs Syndrome and/or Periodic Limb Movements",
+    "5": "Narcolepsy or Cataplexy",
+    "6": "REM Behavior Disorder (act out dreams in your sleep)",
+    "7": "Sleepwalking",
+    "8": "None of the above"
+  },
+  "field_durationQuitSmoking": {
+    "1": "Days",
+    "2": "Months",
+    "3": "Years",
+    "4": "Never",
+    "5": "Don't know"
+  },
+  "field_durationQuitVaping": {
+    "1": "Days",
+    "2": "Months",
+    "3": "Years",
+    "4": "Never",
+    "5": "Don't know"
+  },
+  "field_durationQuitSmokeless": {
+    "1": "Days",
+    "2": "Months",
+    "3": "Years",
+    "4": "Never",
+    "5": "Don't know"
+  },
+  "field_antibiotics": {
+    "0": "None",
+    "1": "Azithromycin",
+    "2": "Doxycycline",
+    "3": "Other antibiotic (not azithromycin or doxycycline)",
+    "4": "Hydrochloroquine (Plaquenil)",
+    "5": "Oral corticosteroids (eg prednisone)",
+    "6": "Inhaled corticosteroids (eg budesonide, beclamethasone)",
+    "7": "Tocilizumab (Actemra)",
+    "8": "Other Disease Modifying Anti-Rheumatic Drugs",
+    "9": "Other immuno-suppressives",
+    "10": "Study drug (Investigational agent)",
+    "11": "Remdesivir"
+  },
+  "field_conditions": {
+    "0": "None",
+    "1": "Cardiovascular disease, including hypertension",
+    "2": "Immunodeficiency, including HIV",
+    "3": "Diabetes",
+    "4": "Renal disease (ESRD on dialysis or not)",
+    "5": "Liver disease",
+    "6": "Chronic lung disease",
+    "7": "Healthcare worker",
+    "8": "Pregnancy or Post-partum (< 6 weeks)"
+  },
+  "field_symptoms_past_week": {
+    "0": "None",
+    "1": "Cough",
+    "2": "Fever",
+    "3": "Shortness of breath",
+    "4": "Loss of smell / taste",
+    "5": "Fatigue / lethargy",
+    "6": "Chest pain",
+    "7": "Sore throat",
+    "8": "Muscle aches / muscle pain",
+    "9": "Anorexia, loss of appetite",
+    "10": "Diarrhea",
+    "11": "Nausea/vomiting"
+  },
+  "field_symptoms_week_preceding": {
+    "0": "None",
+    "1": "Cough",
+    "2": "Fever",
+    "3": "Shortness of breath",
+    "4": "Loss of smell / taste",
+    "5": "Fatigue / lethargy",
+    "6": "Chest pain",
+    "7": "Sore throat",
+    "8": "Muscle aches / muscle pain",
+    "9": "Anorexia, loss of appetite",
+    "10": "Diarrhea",
+    "11": "Nausea/vomiting"
   }
 }

--- a/data/labels/ordinal_dictionary.json
+++ b/data/labels/ordinal_dictionary.json
@@ -129,11 +129,6 @@
     "Other": 7,
     "I prefer not to indicate an ethnicity": 8
   },
-  "field_Gender": {
-    "Male": 0,
-    "Female": 1,
-    "Other": 2
-  },
   "field_healthcare_worker": {
     "1": 1,
     "2": 2,

--- a/data/labels/survey_documentation/INDEX.md
+++ b/data/labels/survey_documentation/INDEX.md
@@ -81,10 +81,7 @@ Each subdir's `summary.md` contains a one-line description and link for every fi
 
 | Variable | Type | Raw identifier | Source file | Line | Notes |
 |----------|------|----------------|-------------|------|-------|
-| field_Age_heartage | continuous | Age_heartage | CardioHealth/TasksAndSteps/HeartAgeControllers/APHHeartAgeTaskViewController.m | ~100+ | Age entered in Heart Age task |
 | field_BloodGlucose | continuous | BloodGlucose | CardioHealth/TasksAndSteps/HeartAgeControllers/HeartAgeRiskFactorCalculations/APHHeartAgeAndRiskFactors.m | ~68 | Blood glucose value |
-| field_CurrentAge | continuous | (from device) | CardioHealth/TasksAndSteps/HeartAgeControllers/APHHeartAgeTaskViewController.m | ~100+ | Current age from device/survey |
-| field_DiastolicBloodPressure | continuous | heartAgeDataDiastolicBloodPressure | CardioHealth/TasksAndSteps/HeartAgeControllers/HeartAgeRiskFactorCalculations/APHHeartAgeAndRiskFactors.m | ~67 | Diastolic BP |
 | field_GoSleepTime | continuous | GoSleepTime | (derived) | Unknown | Likely from device tracking, not in JSON |
 | field_HeightCentimeters | continuous | (HealthKit) | CardioHealth/Startup/APHAppDelegate.m | ~525 | Height in meters from HealthKit, converted to cm |
 | field_WakeUpTime | continuous | WakeUpTime | (derived) | Unknown | Likely from device tracking, not in JSON |

--- a/data/labels/validity_config.json
+++ b/data/labels/validity_config.json
@@ -1,5 +1,5 @@
 {
-  "age": null,
+  "age": 1095,
   "BiologicalSex": null,
 
   "Diabetes": 365,

--- a/src/labels/README.md
+++ b/src/labels/README.md
@@ -5,7 +5,7 @@ This module exposes a fast, in-memory lookup for label values and age computatio
 ## Public surface
 - `labels.get_labels(health_code: str, timestamp: pandas.Timestamp, label: str, enforce_type: bool = True, return_valid_only: bool = True) -> LabelResult`
 - `labels.LABEL_NAMES`: list of available labels (including `"age"`).
-- `labels.LABEL_TYPES`: dict mapping label names to their semantic types (`binary`, `ordinal`, `categorical`, `continuous`).
+- `labels.LABEL_TYPES`: dict mapping label names to their semantic types (`binary`, `ordinal`, `categorical`, `multi_categorical`, `continuous`).
 - `labels.get_labels_statistics() -> pandas.DataFrame`: returns statistics for all labels as a DataFrame.
 - `labels.print_labels_statistics()`: prints a table with statistics for all labels.
 - `LabelResult`: carries `matched_timestamp` and `value`.
@@ -18,7 +18,7 @@ This module exposes a fast, in-memory lookup for label values and age computatio
 ## Data sources
 - `labels.json`: per-label → healthCode → `timestamps`/`values`.
 - `enrollment_info.json`: per-healthCode metadata with de-identified `birth_year`.
-- `label_types.json`: maps each label to its semantic type (`binary`, `ordinal`, `categorical`, `continuous`).
+- `label_types.json`: maps each label to its semantic type (`binary`, `ordinal`, `categorical`, `multi_categorical`, `continuous`).
 
 ## Variable dictionary
 See [`data/labels/survey_documentation/INDEX.md`](../../data/labels/survey_documentation/INDEX.md) for a per-variable reference (question text, answer options, observed value distributions, iOS source) covering all 169 labels.
@@ -83,6 +83,7 @@ By default, `get_labels()` enforces type conversion based on `label_types.json`:
 | `binary` | `bool` | "Male"→True, "Female"→False, 0/1→bool, "true"/"false"→bool |
 | `ordinal` | `int` | String/float with integer value → int |
 | `categorical` | `int` | String/float with integer value → int |
+| `multi_categorical` | `tuple[int, ...]` | List of ints (multi-select survey answers) → sorted tuple of ints |
 | `continuous` | `float` | Any numeric → float. GoSleepTime/WakeUpTime: datetime string → decimal hours (e.g., "23:30" → 23.5) |
 
 **Exceptions:**
@@ -102,7 +103,7 @@ from labels import LABEL_TYPES
 # Check a label's type
 print(LABEL_TYPES["BiologicalSex"])  # "binary"
 print(LABEL_TYPES["happiness"])       # "ordinal"
-print(LABEL_TYPES["heart_disease"])   # "categorical"
+print(LABEL_TYPES["field_race"])      # "multi_categorical"
 print(LABEL_TYPES["WeightKilograms"]) # "continuous"
 ```
 

--- a/src/labels/test_api.py
+++ b/src/labels/test_api.py
@@ -1635,3 +1635,26 @@ def test_years_between_birth_year_export_present() -> None:
     """years_between_birth_year is re-exported from labels package."""
     import labels
     assert hasattr(labels, "years_between_birth_year")
+
+
+def test_shipped_multi_categorical_fields_have_ordinal_dictionary_entries() -> None:
+    """Every label declared ``multi_categorical`` must have an ordinal_dictionary entry.
+
+    Regression test for the silent schema drift between the initial public scaffold
+    and the labels-API port: ``api.py`` decodes ``multi_categorical`` values via
+    ``ordinal_dictionary.json``, so a missing entry breaks ``_to_tuple_of_int``.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    types = json.loads((repo_root / "data/labels/label_types.json").read_text())
+    ords = json.loads((repo_root / "data/labels/ordinal_dictionary.json").read_text())
+    missing = [
+        k for k, v in types.items() if v.get("type") == "multi_categorical" and k not in ords
+    ]
+    assert not missing, f"multi_categorical fields missing from ordinal_dictionary: {missing}"
+
+
+def test_shipped_label_types_target_count_is_pinned() -> None:
+    """Pin the target count at 41 so silent target/context promotion fails CI."""
+    repo_root = Path(__file__).resolve().parents[2]
+    types = json.loads((repo_root / "data/labels/label_types.json").read_text())
+    assert sum(1 for v in types.values() if v.get("target")) == 41


### PR DESCRIPTION
## What
                                                                                                                                                                                                                                                                                        
  Bring three small schema files in `data/labels/` back in sync with upstream MHC-benchmark, plus a bit of doc follow-through.                                                                                                                                                          
   
  ## Why                                                                                                                                                                                                                                                                                
                                                                  
  When this public repo was first scaffolded, the three schema files were copied from an older snapshot of MHC-benchmark and never refreshed. The labels-API port (#3) updated the **code** but left these schema files behind. The drift caused real but silent breakage:              
   
  - `api.py` knows about a label type called `multi_categorical` (used for multi-select survey answers like `field_race`, `field_family_history`, `field_medications_to_treat`, etc.), but the shipped `label_types.json` still declared all of them as plain `categorical`. The        
  `multi_categorical` branches in the code were dead at runtime and `MULTI_CATEGORICAL_NAMES` was always `[]`.
  - `ordinal_dictionary.json` was missing all 26 context-variable mappings, so any ordinal/categorical context lookup that needed a string→int decode would have failed.                                                                                                                
  - `validity_config.json` still had `age: null` (the dynamic-age default) even though upstream had moved to a static age value with a 3-year validity cap.                                                                                                                             
                                                                                                                                                                                                                                                                                        
  This wasn't caught because every existing test constructs its own synthetic `label_types.json` in `tmp_path` and overrides `LABEL_TYPES_PATH` — no test ever loaded the shipped file.                                                                                                 
                                                                                                                                                                                                                                                                                        
  ## Changes                                                                                                                                                                                                                                                                            
                                                                  
  **Schema (synced from upstream):**                                                                                                                                                                                                                                                    
  - `validity_config.json` — `age: null` → `1095` (3-year cap for the static age value).
  - `label_types.json` — 12 stale fields dropped, 8 new fields added, 7 fields promoted from `categorical` to `multi_categorical`. Totals: 173 → **169** labels (targets unchanged at **41**, context 132 → **128**).                                                                   
  - `ordinal_dictionary.json` — 26 missing context-variable mappings restored.                                                                                                                                                                                                          
   
  **Docs:**                                                                                                                                                                                                                                                                             
  - `src/labels/README.md` — `multi_categorical` added to the type enumeration and type-enforcement table; the removed `heart_disease` example swapped for `field_race`.
  - `data/labels/survey_documentation/INDEX.md` — three ghost Contexts rows removed (`field_Age_heartage`, `field_CurrentAge`, `field_DiastolicBloodPressure`).                                                                                                                         
                                                                                                                                                                                                                                                                                        
  **Regression tests** (`src/labels/test_api.py`):                                                                                                                                                                                                                                      
  - `test_shipped_multi_categorical_fields_have_ordinal_dictionary_entries` — asserts every `multi_categorical` label has an `ordinal_dictionary` entry. Catches the exact drift this PR fixes.                                                                                         
  - `test_shipped_label_types_target_count_is_pinned` — pins the target count at 41 so accidental target/context promotion fails CI.                                                                                                                                                    
                                                                                                                                                                                                                                                                                        
  ## Verification                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                        
  - Runtime after the sync: `LABEL_NAMES=169, TARGET_NAMES=41, CONTEXT_NAMES=128, MULTI_CATEGORICAL_NAMES=11` (matches upstream).                                                                                                                                                       
  - Tests: 69 pass, 1 pre-existing skip in `src/labels/` + `src/context/`.