### PR TITLE
Quickstart fixes + usable XS imputation (eval knobs + precomputed masks)

### DIFF
--- a/data/imputation/masks/sharable_users_seed42_2026_xs/test/intensity_failure.npz
+++ b/data/imputation/masks/sharable_users_seed42_2026_xs/test/intensity_failure.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1e963a56bca1ba9551d7f670b9537adcdf03777a3b0eacafdde4d1acd55f98e
+size 3973

--- a/data/imputation/masks/sharable_users_seed42_2026_xs/test/random_noise.npz
+++ b/data/imputation/masks/sharable_users_seed42_2026_xs/test/random_noise.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44a083cad69479dbb7b9fc454157f2ed9e6e5515c6a6824ac4a5356d3727f236
+size 5581985

--- a/data/imputation/masks/sharable_users_seed42_2026_xs/test/signal_slice.npz
+++ b/data/imputation/masks/sharable_users_seed42_2026_xs/test/signal_slice.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b72d714714dace6643a55cc6f3d86bdb16287ec38c679e9d5471b5ce8ec9d8d8
+size 1629174

--- a/data/imputation/masks/sharable_users_seed42_2026_xs/test/sleep_gap.npz
+++ b/data/imputation/masks/sharable_users_seed42_2026_xs/test/sleep_gap.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:254f12a661cc80e40113e143e57b4327028b89c337053f7f6488c12a8ac857f8
+size 1002158

--- a/data/imputation/masks/sharable_users_seed42_2026_xs/test/temporal_slice.npz
+++ b/data/imputation/masks/sharable_users_seed42_2026_xs/test/temporal_slice.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e503ae6be2a7853c7c6a8769461afdef71e0d4a8ec1b380298d910222449af8c
+size 2052157

--- a/data/imputation/masks/sharable_users_seed42_2026_xs/test/workout_gap.npz
+++ b/data/imputation/masks/sharable_users_seed42_2026_xs/test/workout_gap.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f61d7ed44092a0e93ca77686506409cc47e5c82c25cd878cca6d8dc9b8a02282
+size 183477

--- a/data/imputation/masks/sharable_users_seed42_2026_xs/val/intensity_failure.npz
+++ b/data/imputation/masks/sharable_users_seed42_2026_xs/val/intensity_failure.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e4eee30a954042b241e1067ba9c2edc0a47d997bd0ba8b53680756160d46d8a
+size 866

--- a/data/imputation/masks/sharable_users_seed42_2026_xs/val/random_noise.npz
+++ b/data/imputation/masks/sharable_users_seed42_2026_xs/val/random_noise.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f34c902fbaa7482f6cf9b5e31f3826e40f7d336bcad61c32bb6d6d2481ef94be
+size 199236

--- a/data/imputation/masks/sharable_users_seed42_2026_xs/val/signal_slice.npz
+++ b/data/imputation/masks/sharable_users_seed42_2026_xs/val/signal_slice.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db6412dd508167ca5495cf723b2f8143b48ed8ee72586a990b8f6541ace4f8ec
+size 61165

--- a/data/imputation/masks/sharable_users_seed42_2026_xs/val/sleep_gap.npz
+++ b/data/imputation/masks/sharable_users_seed42_2026_xs/val/sleep_gap.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b254a37fada062ec2fc66a8d1c4b9c64ceceedd1937bad7002f2129da8c76613
+size 33878

--- a/data/imputation/masks/sharable_users_seed42_2026_xs/val/temporal_slice.npz
+++ b/data/imputation/masks/sharable_users_seed42_2026_xs/val/temporal_slice.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:759c11e90b47940e4098ba0b012645d60bbc23e03130f3df36e532863fd25eda
+size 86972

--- a/data/imputation/masks/sharable_users_seed42_2026_xs/val/workout_gap.npz
+++ b/data/imputation/masks/sharable_users_seed42_2026_xs/val/workout_gap.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4eb3a800502554c87331ba619ae8b6ca00e5024589282838f2df8878739381b
+size 2443

--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -22,17 +22,7 @@
    "cell_type": "markdown",
    "id": "5403243e",
    "metadata": {},
-   "source": [
-    "## 1. Install + download the dataset\n",
-    "\n",
-    "If you haven't already:\n",
-    "\n",
-    "```bash\n",
-    "pip install -e ..\n",
-    "```\n",
-    "\n",
-    "Then download the XS dataset (~TBD MB)."
-   ]
+   "source": "## 1. Install + download the dataset\n\nIf you haven't already:\n\n```bash\npip install -e ..\n```\n\nThen download the XS dataset (~1.9 GB)."
   },
   {
    "cell_type": "code",
@@ -183,13 +173,7 @@
    "cell_type": "markdown",
    "id": "902af8f7",
    "metadata": {},
-   "source": [
-    "## 7. Generate a leaderboard submission\n",
-    "\n",
-    "`results.to_submission_yaml(...)` produces a paste-ready body matching the textareas in the [submission issue template](https://github.com/AshleyLab/myheartcounts-dataset/issues/new?template=submission.yml).\n",
-    "\n",
-    "For Track 2 imputation, skill scores and per-category subgroup scores are computed locally against the frozen LOCF baseline (`data/baselines/imputation_locf.json`). For Track 1 and Track 3, those fields are emitted as `—` and filled in by the maintainers from `raw_metrics` during ingestion."
-   ]
+   "source": "## 6. Run forecasting evaluation (Track 3)\n\nFor Track 3 the protocol is `predict(history, horizon) -> forecast`. Here we tile the last observed value across the horizon. `evaluate_forecasting` scores the forecaster on hourly trajectories; `max_samples` keeps it fast on the tiny dataset."
   },
   {
    "cell_type": "code",
@@ -210,13 +194,7 @@
    "cell_type": "markdown",
    "id": "da184ce1",
    "metadata": {},
-   "source": [
-    "## 6. Generate a leaderboard submission\n",
-    "\n",
-    "`results.to_submission_yaml(...)` produces a paste-ready body matching the textareas in the [submission issue template](https://github.com/AshleyLab/myheartcounts-dataset/issues/new?template=submission.yml).\n",
-    "\n",
-    "For Track 2 imputation, skill scores and per-category subgroup scores are computed locally against the frozen LOCF baseline (`data/baselines/imputation_locf.json`). For Track 1, those fields are emitted as `—` and filled in by the maintainers from `raw_metrics` during ingestion."
-   ]
+   "source": "## 7. Generate a leaderboard submission\n\n`results.to_submission_yaml(...)` produces a paste-ready body matching the textareas in the [submission issue template](https://github.com/AshleyLab/myheartcounts-dataset/issues/new?template=submission.yml).\n\nFor Track 2 imputation, skill scores and per-category subgroup scores are computed locally against the frozen LOCF baseline (`data/baselines/imputation_locf.json`). For Track 1 and Track 3, those fields are emitted as `—` and filled in by the maintainers from `raw_metrics` during ingestion."
   },
   {
    "cell_type": "code",

--- a/scripts/precompute_xs_masks.py
+++ b/scripts/precompute_xs_masks.py
@@ -1,0 +1,84 @@
+"""Precompute the canonical XS imputation masks and save them into the repo.
+
+Mirrors the precomputed ``full`` masks shipped at
+``data/imputation/masks/sharable_users_seed42_2026_max91d/``. Generating XS masks
+on the fly costs ~20 min over the full test split on every
+``evaluate_imputation(version="xs")`` call; shipping them lets the public API
+load them instead (the same mechanism ``full`` uses).
+
+The masks are valid for the canonical config the public API uses for XS:
+``mask_seed=42``, ``n_days=1``, all six scenarios, the XS user split. The eval
+path guards on those before loading (see ``openmhc/_evaluate.py``); any other
+config falls back to on-the-fly generation.
+
+Run once (the dataset root must hold the XS bundle):
+
+    MHC_DATA_DIR=~/.cache/openmhc/data-xs python scripts/precompute_xs_masks.py
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
+
+from imputation_evaluation.config import DataConfig, MaskingConfig  # noqa: E402
+from imputation_evaluation.data.data_loader import ImputationDataLoader  # noqa: E402
+from imputation_evaluation.masking import create_mask_generators  # noqa: E402
+from imputation_evaluation.masking.generator import MaskCacheGenerator  # noqa: E402
+from openmhc._evaluate import _DatasetPaths  # noqa: E402
+
+SEED = 42
+SPLITS = ("val", "test")
+OUT_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "data"
+    / "imputation"
+    / "masks"
+    / "sharable_users_seed42_2026_xs"
+)
+
+
+def main() -> None:
+    """Generate and save the XS val/test masks for all six scenarios."""
+    paths = _DatasetPaths.resolve(None, version="xs")  # honors MHC_DATA_DIR / data_dir
+    data_cfg = DataConfig(
+        daily_hf_dir=str(paths.daily_hf),
+        split_file=str(paths.splits_file),
+        version="xs",
+        split_seed=SEED,
+        batch_size=5000,
+        num_workers=4,
+        n_days=1,
+    )
+    loaded = ImputationDataLoader(data_cfg).load_splits(
+        batch_size=5000, num_workers=4, pin_memory=False
+    )
+
+    masking_cfg = MaskingConfig(mask_seed=SEED)  # all six scenarios enabled by default
+    generators = create_mask_generators(masking_cfg)
+    logging.info("Scenarios: %s", [g.name for g in generators])
+
+    generator = MaskCacheGenerator(
+        hf_dataset=loaded.hf_dataset,
+        zero_to_nan_transform=loaded.zero_to_nan_transform,
+        num_workers=4,
+        batch_size=5000,
+    )
+    t0 = time.time()
+    cache = generator.generate(
+        split_indices={s: loaded.split_indices[s] for s in SPLITS},
+        generators=generators,
+        base_seed=SEED,
+    )
+    logging.info("Generated masks in %.1fs", time.time() - t0)
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    cache.save(OUT_DIR)
+    logging.info("Saved XS masks to %s", OUT_DIR)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/openmhc/__init__.py
+++ b/src/openmhc/__init__.py
@@ -102,6 +102,9 @@ def evaluate_imputation(
     n_days: int = 1,
     bootstrap: bool | dict = False,
     max_samples: int | None = None,
+    num_workers: int = 0,
+    num_eval_workers: int = 1,
+    pin_memory: bool = False,
 ) -> ImputationResults:
     """Run imputation evaluation with a custom imputer.
 
@@ -125,6 +128,14 @@ def evaluate_imputation(
             shape of the option.
         max_samples: Limit samples per split for testing/debugging
             (None = no limit). Mirrors ``evaluate_forecasting``.
+        num_workers: DataLoader worker processes (default ``0``). Raise toward
+            your CPU count to overlap data loading with compute.
+        num_eval_workers: Parallel processes for the evaluation loop (default
+            ``1`` = sequential). ``> 1`` runs batches concurrently — much faster
+            on the full split, with identical results. The imputer must be
+            picklable (a class defined in a notebook cell can fail under the
+            ``spawn`` start method; works under Linux ``fork``).
+        pin_memory: DataLoader ``pin_memory`` flag (default ``False``).
 
     Returns:
         ImputationResults with per-scenario, per-split metrics.
@@ -140,6 +151,9 @@ def evaluate_imputation(
         n_days=n_days,
         bootstrap=bootstrap,
         max_samples=max_samples,
+        num_workers=num_workers,
+        num_eval_workers=num_eval_workers,
+        pin_memory=pin_memory,
     )
 
 
@@ -150,6 +164,8 @@ def evaluate_forecasting(
     data_dir: str | Path | None = None,
     seed: int = 42,
     max_samples: int | None = None,
+    *,
+    num_workers: int = 4,
 ) -> ForecastingResults:
     """Run forecasting evaluation (Track 3) with a custom forecaster.
 
@@ -163,6 +179,10 @@ def evaluate_forecasting(
             ``MHC_DATA_DIR`` must be set.
         seed: Random seed.
         max_samples: Limit prediction samples per user (debugging only).
+        num_workers: DataLoader worker processes for loading trajectories
+            (default ``4``). The forecasting evaluator is sequential-only, so
+            this only affects data loading; ``max_samples`` is the main speed
+            lever.
 
     Returns:
         ForecastingResults with per-channel metrics.
@@ -176,6 +196,7 @@ def evaluate_forecasting(
         data_dir=data_dir,
         seed=seed,
         max_samples=max_samples,
+        num_workers=num_workers,
     )
 
 

--- a/src/openmhc/_evaluate.py
+++ b/src/openmhc/_evaluate.py
@@ -41,6 +41,7 @@ _REPO_ROOT = Path(__file__).parent.parent.parent
 _MAX91D_MASKS_DIR = (
     _REPO_ROOT / "data" / "imputation" / "masks" / "sharable_users_seed42_2026_max91d"
 )
+_XS_MASKS_DIR = _REPO_ROOT / "data" / "imputation" / "masks" / "sharable_users_seed42_2026_xs"
 
 
 _SPLIT_FILENAMES: dict[str, str] = {
@@ -751,7 +752,25 @@ def evaluate_imputation(
                 "excluded by a sparse-checkout or .gitignore rule."
             )
         masking_cfg.masks_file = str(_MAX91D_MASKS_DIR)
-    # xs: masks_file stays None → runner generates masks on the fly
+    elif (
+        paths.version == "xs"
+        and seed == 42
+        and n_days == 1
+        and max_samples is None
+        and _XS_MASKS_DIR.exists()
+    ):
+        # XS ships precomputed masks too (mirrors `full`), but only for the
+        # canonical full-split config they were generated for: seed 42,
+        # single-day windows, all XS val+test samples. A scenario subset still
+        # loads fine (the cache holds all six). Other seed / n_days, or a
+        # max_samples-bounded run, fall through to on-the-fly generation below:
+        # the cache spans the full split, so its applicable indices would
+        # overrun a max_samples-limited dataset — and bounded generation is
+        # cheap anyway (it only masks the small subset). On-the-fly over the
+        # full split is the slow case (~20 min) this cache exists to avoid.
+        masking_cfg.masks_file = str(_XS_MASKS_DIR)
+    # else (xs with a non-canonical config, max_samples set, or cache absent):
+    # masks_file stays None → runner generates masks on the fly.
 
     data_cfg = DataConfig(
         daily_hf_dir=str(paths.daily_hf),

--- a/src/openmhc/_evaluate.py
+++ b/src/openmhc/_evaluate.py
@@ -610,6 +610,9 @@ def evaluate_imputation(
     n_days: int = 1,
     bootstrap: bool | dict = False,
     max_samples: int | None = None,
+    num_workers: int = 0,
+    num_eval_workers: int = 1,
+    pin_memory: bool = False,
 ) -> ImputationResults:
     """Run imputation evaluation with a custom imputer.
 
@@ -655,6 +658,23 @@ def evaluate_imputation(
         max_samples: Limit samples per split for testing/debugging (None =
             no limit). Mirrors ``evaluate_forecasting``. Plumbs into
             ``DataConfig.max_samples_per_split``.
+        num_workers: DataLoader worker processes for loading, mask generation,
+            and the one train pass that computes metric-normalization stats.
+            Defaults to ``0`` (synchronous; notebook-safe). Raise toward your
+            CPU count to overlap I/O with compute. Plumbs into
+            ``DataConfig.num_workers``.
+        num_eval_workers: Parallel processes for the evaluation loop. Defaults
+            to ``1`` (sequential). With ``> 1`` the harness evaluates batches
+            concurrently via ``ProcessPoolExecutor`` (batch-level, all
+            scenarios per worker) — dramatically faster on the full split, with
+            results numerically identical to the sequential path. Caveat: the
+            imputer is pickled to each worker, so it must be importable; a class
+            defined in a notebook cell can fail under the ``spawn`` start method
+            (works under Linux ``fork``). Plumbs into
+            ``DataConfig.num_eval_workers``.
+        pin_memory: DataLoader ``pin_memory`` flag. Defaults to ``False``; set
+            ``True`` to speed host→GPU transfer for a GPU imputer. Plumbs into
+            ``DataConfig.pin_memory``.
 
     Returns:
         An ImputationResults instance with per-scenario, per-split metrics.
@@ -738,9 +758,9 @@ def evaluate_imputation(
         split_file=str(paths.splits_file),
         split_seed=seed,
         batch_size=5000,
-        num_workers=0,
-        num_eval_workers=1,
-        pin_memory=False,
+        num_workers=num_workers,
+        num_eval_workers=num_eval_workers,
+        pin_memory=pin_memory,
         n_days=n_days,
         max_samples_per_split=max_samples,
     )
@@ -948,6 +968,8 @@ def evaluate_forecasting(
     data_dir: str | Path | None = None,
     seed: int = 42,
     max_samples: int | None = None,
+    *,
+    num_workers: int = 4,
 ) -> ForecastingResults:
     """Run forecasting evaluation (Track 3) with a custom forecaster.
 
@@ -966,6 +988,11 @@ def evaluate_forecasting(
             ``MHC_DATA_DIR`` must be set.
         seed: Random seed.
         max_samples: Limit prediction samples per user (debugging).
+        num_workers: DataLoader worker processes for loading trajectories.
+            Defaults to ``4``. The forecasting evaluator is sequential-only
+            (no parallel-eval mode), so this only affects data loading;
+            ``max_samples`` remains the main lever for keeping a run fast.
+            Plumbs into ``DataConfig.num_workers``.
 
     Returns:
         :class:`ForecastingResults` with per-channel metrics.
@@ -1005,6 +1032,7 @@ def evaluate_forecasting(
         day_remain_mask=str(paths.forecasting_sample_index_dir / "day_remain_mask.json"),
         sample_index_file=str(sample_index_file),
         split_seed=seed,
+        num_workers=num_workers,
         max_samples=max_samples,
     )
     forecasting_cfg = ForecastingConfig(forecasting_length=forecasting_length)


### PR DESCRIPTION
## What & why

Investigating whether the quickstart notebook works surfaced that the public
evaluation API was effectively unusable on the `xs` subset — an
`evaluate_imputation(version="xs")` call timed out (>20 min) because XS
**regenerated masks on the fly every run**. This PR makes the quickstart work and
the XS imputation path practical, reusing the same machinery the heavy Hydra runs
use.

## Changes (3 commits)

1. **`docs(notebook)`** — fix `notebooks/quickstart.ipynb` markdown: Track 3 forecasting
   got its own "Run forecasting evaluation" heading (was a duplicated/misnumbered
   submission heading), sections renumbered, `~TBD MB` → ~1.9 GB.
2. **`feat(api)` eval knobs** — surface the performance settings the public wrappers
   previously hardcoded, so users can opt into the parallelism the Hydra runs use.
   Defaults unchanged (behavior-preserving):
   - `evaluate_imputation`: `num_workers`, `num_eval_workers`, `pin_memory`
     (`num_eval_workers>1` engages the existing batch-level `ProcessPoolExecutor`).
   - `evaluate_forecasting`: `num_workers` (evaluator stays sequential-only).
3. **`feat(api)` precomputed XS masks** — ship the canonical XS val+test masks
   in-repo (`data/imputation/masks/sharable_users_seed42_2026_xs/`, 12 `.npz`, ~11 MB,
   git-lfs) + `scripts/precompute_xs_masks.py`. `evaluate_imputation` loads them for
   XS when the request matches the cached config (seed 42, `n_days=1`, no `max_samples`);
   otherwise it falls back to on-the-fly generation. Mirrors the existing `full` path.

## Verification

- Parallel imputation eval is **numerically identical** to sequential (parity check); lint + unit tests green.
- Shipped XS masks are **byte-identical** to freshly generated ones (all 6 val scenarios, indices + packed bits).
- A full-split XS imputation eval now **loads** masks and finishes in **~7 min** instead of timing out on generation.

## Known follow-ups (out of scope here)

- Remaining XS cost is the **data layer** (~150s): per-sample `ZeroToNaNTransform` at `num_workers=0` in `iter_train_data` / the adapter train-pass / stats-based imputer `__init__`.
- The **prediction** path (`_extract_encoder_features`: ~151s stats loop + ~111s per-sample encode) is similarly unoptimized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
