### PR TITLE
fix(forecasting): guard method_name==baseline; fix Gate D self-check …

### DIFF
--- a/scripts/paper_results/forecasting/parity/gate_d_public_api.py
+++ b/scripts/paper_results/forecasting/parity/gate_d_public_api.py
@@ -34,8 +34,13 @@ from forecasting_evaluation.models.naive.seasonal_naive import SeasonalNaiveMode
 
 def main() -> int:
     """Run the public-API path for seasonal_naive and assert self-skill ~0."""
+    # Distinct from the baseline model name ("seasonal_naive") so the paired skill
+    # score has two distinct models; the forecaster IS seasonal_naive, so self-skill
+    # should be ~0.
     model = SeasonalNaiveModel(seed=42)
-    res = openmhc.evaluate_forecasting(model, version="full", method_name="seasonal_naive")
+    res = openmhc.evaluate_forecasting(
+        model, version="full", method_name="seasonal_naive_selfcheck"
+    )
 
     print(f"n_samples={res.n_samples}  overall_fallback_rate={res.overall_fallback_rate:.4f}")
     if res.per_user_errors is None or res.per_user_errors.empty:
@@ -46,7 +51,7 @@ def main() -> int:
         return 1
 
     sk = res.skill_scores
-    row = sk[sk["model"].astype(str) == "seasonal_naive"]
+    row = sk[sk["model"].astype(str) == "seasonal_naive_selfcheck"]
     score_cols = [c for c in sk.columns if c.endswith("_score")]
     overall = float(row["overall_score"].iloc[0])
     max_abs = float(np.nanmax(np.abs(row[score_cols].to_numpy(dtype=float))))

--- a/src/openmhc/_evaluate.py
+++ b/src/openmhc/_evaluate.py
@@ -992,6 +992,11 @@ def evaluate_forecasting(
     baseline_path = Path(baseline_errors) if baseline_errors is not None else shipped_baseline
     if baseline_errors is not None and not baseline_path.exists():
         raise FileNotFoundError(f"baseline_errors not found: {baseline_path}")
+    if method_name == _fc_spec.PAPER_BASELINE and baseline_path.exists():
+        raise ValueError(
+            f"method_name={method_name!r} collides with the skill baseline model name; "
+            "pass a distinct method_name (a paired skill score needs two distinct models)."
+        )
 
     if output_dir is not None:
         results_dir = str(Path(output_dir).resolve())


### PR DESCRIPTION
Follow-up to #35. evaluate_forecasting now raises a clear error early when method_name equals the skill baseline (seasonal_naive) instead of failing deep in the skill pivot with cannot reindex on an axis with duplicate labels (a paired skill score needs two distinct models). Gate D's self-check uses a distinct method_name; verified end-to-end self-skill overall_score == 0.0 (public-API substrate byte-identical to the shipped baseline) on the canonical forecasting_bca_20260618 substrate.