### PR TITLE
Feature/forecasting fallback and canonical refresh

### DIFF
--- a/configs/paper/sweep_forecasting.yaml
+++ b/configs/paper/sweep_forecasting.yaml
@@ -10,9 +10,9 @@
 #   release_dir- optional bundle path -> model.release_dir= (finetuned / retrained)
 #   overrides  - optional extra Hydra dot-key strings for mhc-forecast-eval
 
-run_label: forecasting_full_20260609
+run_label: forecasting_full_20260622
 runs_root: results/forecasting_eval/simurgh
-output_root: results/forecasting_eval/simurgh/summary/forecasting_full_20260609
+output_root: results/forecasting_eval/simurgh/summary/forecasting_full_20260622
 
 baseline: seasonal_naive
 continuous_metrics: [mae]

--- a/jobs/sc-cluster/forecasting_eval/README.md
+++ b/jobs/sc-cluster/forecasting_eval/README.md
@@ -67,6 +67,15 @@ sbatch jobs/sc-cluster/forecasting_eval/run_autoarima.sbatch
 sbatch --export=ALL,MHC_FORECAST_RUN_LABEL=<label> jobs/sc-cluster/forecasting_eval/skill_rank.sbatch
 ```
 
+**Publish to the HF leaderboard** (substrates + `fallback_rate` sidecars +
+bootstrap-CI reference) — the full recipe, including the bootstrap-draws refresh
+and that `fallback_rate` is auto-filled by default, lives in
+[`tools/leaderboard_docs/forecasting/README.md`](../../../tools/leaderboard_docs/forecasting/README.md)
+("Refreshing"). In short: `produce_forecasting_bootstrap_draws.sbatch` →
+`stage_leaderboard_substrates.py` (emits the per-method
+`upload_leaderboard_substrate.py … --results-json …` commands) →
+`upload_leaderboard_bootstrap.py --track forecasting`.
+
 ## Environment
 
 | Variable | Meaning | Default |

--- a/jobs/sc-cluster/forecasting_eval/submit_models.sh
+++ b/jobs/sc-cluster/forecasting_eval/submit_models.sh
@@ -20,8 +20,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 cd "${REPO_DIR}"
 
-# Join the existing baseline run so all models aggregate together.
-RUN_LABEL="${MHC_FORECAST_RUN_LABEL:-forecasting_20260605_184121}"
+# To aggregate GPU models together with the CPU baselines, export the SAME
+# MHC_FORECAST_RUN_LABEL you used for submit_all.sh (or just use submit_pipeline.sh,
+# which fans out everything under one label). Standalone, this defaults to a FRESH
+# date label — never a pinned historical run — so a bare invocation can't silently
+# append to / overwrite an old (pre-fix) eval.
+RUN_LABEL="${MHC_FORECAST_RUN_LABEL:-forecasting_$(date +%Y%m%d_%H%M%S)}"
 export MHC_FORECAST_RUN_LABEL="${RUN_LABEL}"
 
 # Local release bundles.

--- a/scripts/paper_results/forecasting/produce_forecasting_bootstrap_draws.py
+++ b/scripts/paper_results/forecasting/produce_forecasting_bootstrap_draws.py
@@ -32,6 +32,7 @@ if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
 import pandas as pd  # noqa: E402
+import yaml  # noqa: E402
 
 from forecasting_evaluation.metrics import metric_spec as _spec  # noqa: E402
 from forecasting_evaluation.metrics.bootstrap_fair_skill_score import (  # noqa: E402
@@ -55,13 +56,26 @@ def _git_commit() -> str:
         return "unknown"
 
 
+def _canonical_summary_dir() -> Path:
+    """Canonical summary dir, read from the sweep config's ``output_root``.
+
+    Single source of truth: the canonical run is pinned in ONE place
+    (``configs/paper/sweep_forecasting.yaml``). This default follows it, so a
+    bootstrap-draws refresh can never silently regenerate the leaderboard CIs
+    from a stale/old substrate (e.g. a legacy per-window-binary run).
+    """
+    out = Path(yaml.safe_load((REPO_ROOT / "configs/paper/sweep_forecasting.yaml").read_text())["output_root"])
+    return out if out.is_absolute() else REPO_ROOT / out
+
+
 def main() -> int:
     """Build + write the unified forecasting bootstrap-draws parquet + meta."""
     p = argparse.ArgumentParser(description="Build forecasting bootstrap draws reference.")
     p.add_argument(
         "--summary-dir",
         type=Path,
-        default=REPO_ROOT / "results/forecasting_eval/simurgh/summary/forecasting_bca_20260618",
+        default=_canonical_summary_dir(),
+        help="Canonical summary dir (default: the sweep config's output_root).",
     )
     p.add_argument("--out-dir", type=Path, default=None, help="default: --summary-dir")
     args = p.parse_args()

--- a/scripts/paper_results/forecasting/stage_leaderboard_substrates.py
+++ b/scripts/paper_results/forecasting/stage_leaderboard_substrates.py
@@ -47,9 +47,10 @@ METHOD_META: dict[str, tuple[str, str]] = {
 }
 DEFAULT_SUBSTRATE = (
     REPO_ROOT
-    / "results/forecasting_eval/simurgh/summary/forecasting_bca_20260618"
+    / "results/forecasting_eval/simurgh/summary/forecasting_full_20260622"
     / "forecasting_per_user_errors.parquet"
 )
+DEFAULT_RUNS_ROOT = REPO_ROOT / "results/forecasting_eval/simurgh"
 
 
 def main() -> int:
@@ -58,6 +59,13 @@ def main() -> int:
     p.add_argument("--substrate", type=Path, default=DEFAULT_SUBSTRATE)
     p.add_argument("--out", type=Path, default=DEFAULT_SUBSTRATE.parent / "leaderboard_substrates")
     p.add_argument("--submitter", default="OpenMHC team")
+    p.add_argument(
+        "--runs-root",
+        type=Path,
+        default=DEFAULT_RUNS_ROOT,
+        help="Per-model runs root; results.json at <runs-root>/<method>/hydra/results.json is "
+        "passed as --results-json so the uploader auto-fills the fallback_rate sidecar key.",
+    )
     args = p.parse_args()
 
     df, _ = read_per_user_metrics_parquet(args.substrate)
@@ -72,9 +80,11 @@ def main() -> int:
         dest = args.out / f"{method}.parquet"
         write_per_user_metrics_parquet(sub, dest)
         name, mtype = METHOD_META.get(method, (method, "—"))
+        results_json = args.runs_root / method / "hydra" / "results.json"
         cmds.append(
             f'python {upload} --dir {args.out} --method {method} --track forecasting '
-            f'--name "{name}" --type "{mtype}" --submitter "{args.submitter}"'
+            f'--name "{name}" --type "{mtype}" --submitter "{args.submitter}" '
+            f"--results-json {results_json}"
         )
         print(f"  {method}: {len(sub)} rows -> {dest}")
 

--- a/scripts/paper_results/forecasting/stage_leaderboard_substrates.py
+++ b/scripts/paper_results/forecasting/stage_leaderboard_substrates.py
@@ -22,6 +22,8 @@ import argparse
 import sys
 from pathlib import Path
 
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SRC_ROOT = REPO_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
@@ -45,11 +47,18 @@ METHOD_META: dict[str, tuple[str, str]] = {
     "mixlinear": ("MixLinear", "Deep Learning"),
     "segrnn": ("SegRNN", "Deep Learning"),
 }
-DEFAULT_SUBSTRATE = (
-    REPO_ROOT
-    / "results/forecasting_eval/simurgh/summary/forecasting_full_20260622"
-    / "forecasting_per_user_errors.parquet"
-)
+def _canonical_output_root() -> Path:
+    """Canonical summary dir, read from the sweep config's ``output_root``.
+
+    Single source of truth: the canonical run is pinned only in
+    ``configs/paper/sweep_forecasting.yaml``, so staging always splits the
+    current canonical substrate and never a stale/old one.
+    """
+    out = Path(yaml.safe_load((REPO_ROOT / "configs/paper/sweep_forecasting.yaml").read_text())["output_root"])
+    return out if out.is_absolute() else REPO_ROOT / out
+
+
+DEFAULT_SUBSTRATE = _canonical_output_root() / "forecasting_per_user_errors.parquet"
 DEFAULT_RUNS_ROOT = REPO_ROOT / "results/forecasting_eval/simurgh"
 
 

--- a/src/forecasting_evaluation/models/foundational_model/chronos2.py
+++ b/src/forecasting_evaluation/models/foundational_model/chronos2.py
@@ -49,6 +49,12 @@ class Chronos2Model(BasePredictionModel):
             torch_dtype=torch_dtype,
             **kwargs,
         )
+        # Chronos-2 truncates context to its configured length internally and
+        # derives its instance-norm scaling from the truncated window, so feeding
+        # a longer history is wasted work with no effect on the output. Read the
+        # model's true context length and slice to it in predict() (the harness
+        # now hands models the full prefix; each model self-windows, like Toto).
+        self.context_length: int = int(self.pipeline.model_context_length)
         self.logger = logging.getLogger(__name__)
         self.logger.info(
             "Loaded Chronos-2 pipeline from %s (device=%s, dtype=%s)",
@@ -59,6 +65,13 @@ class Chronos2Model(BasePredictionModel):
 
     def _resolve_device_map(self) -> str:
         device = self.config.device
+        if device == "auto":
+            # Place the whole model on a single CUDA device explicitly. HF's
+            # device_map="auto" runs accelerate's memory probe, which on these
+            # nodes intermittently reports "Device 0 seems unavailable" and
+            # silently falls back to CPU (≈100x slower). An explicit "cuda"
+            # skips that probe; fall back to cpu only when CUDA is truly absent.
+            return "cuda" if torch.cuda.is_available() else "cpu"
         if device == "cuda" and not torch.cuda.is_available():
             logging.getLogger(__name__).warning(
                 "model.chronos2.device is cuda but CUDA is unavailable; falling back to cpu"
@@ -182,7 +195,22 @@ class Chronos2Model(BasePredictionModel):
             - quantiles_result: Quantile predictions of shape (n_features, prediction_length, n_quantiles)
               or None if quantiles cannot be computed
         """
+        # Trim to the model's context window before handing the array to the
+        # pipeline. Chronos-2 truncates to ``context_length`` and derives its
+        # instance-norm scaling from that window internally, so this is
+        # output-identical to passing the full prefix — but avoids preprocessing
+        # multi-year arrays on every window (the post-7939848 harness passes the
+        # full prefix; models self-window, as Toto does). Gated on no covariates
+        # so target/covariate alignment stays trivially correct (the current eval
+        # passes none); with covariates present we hand over the full prefix and
+        # let the pipeline truncate target+covariates consistently.
         target = history
+        if (
+            past_covariates is None
+            and future_covariates is None
+            and history.shape[1] > self.context_length
+        ):
+            target = history[:, -self.context_length :]
         prediction_length = horizon
 
         # Construct input in the format expected by Chronos2Pipeline

--- a/src/forecasting_evaluation/models/foundational_model/toto.py
+++ b/src/forecasting_evaluation/models/foundational_model/toto.py
@@ -92,6 +92,8 @@ class TotoModel(BasePredictionModel):
 
     def _resolve_device(self) -> str:
         device = self.config.device
+        if device == "auto":
+            return "cuda" if torch.cuda.is_available() else "cpu"
         if device == "cuda" and not torch.cuda.is_available():
             logger.warning("model.toto.device is cuda but CUDA is unavailable; falling back to cpu")
             return "cpu"

--- a/src/openmhc/_evaluate.py
+++ b/src/openmhc/_evaluate.py
@@ -1139,6 +1139,10 @@ def evaluate_forecasting(
                     "continuous_metrics": list(_fc_spec.PAPER_CONTINUOUS_METRICS),
                     "binary_metrics": list(_fc_spec.PAPER_BINARY_METRICS),
                     "baseline": _fc_spec.PAPER_BASELINE,
+                    # Carry the invalid-prediction rate in the substrate meta too
+                    # (mirrors the downstream track), so the rate travels with the
+                    # parquet even when results.json isn't alongside it.
+                    "overall_fallback_rate": float(result.get("overall_fallback_rate", 0.0)),
                 },
             )
             if skill_df is not None:

--- a/src/openmhc/_results.py
+++ b/src/openmhc/_results.py
@@ -377,8 +377,23 @@ class ForecastingResults:
         logger.info("Forecasting results saved to %s", path)
 
     def to_json(self, path: str | Path) -> None:
-        """Export full results dict to JSON."""
-        Path(path).write_text(json.dumps(self.per_channel, indent=2, default=_json_default))
+        """Export the full results dict to JSON.
+
+        Emits ``overall_fallback_rate`` / ``fallback_rate`` at the top level
+        alongside ``per_channel`` (matching the harness ``results.json`` shape),
+        so the invalid-prediction rate survives the round-trip and the
+        leaderboard upload tool can extract it via ``--results-json``. Mirrors
+        ``ImputationResults.to_json``, which preserves the rate by dumping the
+        ``scenarios`` dict it lives inside.
+        """
+        payload = {
+            "run_dir": self.run_dir,
+            "n_samples": self.n_samples,
+            "overall_fallback_rate": self.overall_fallback_rate,
+            "fallback_rate": self.fallback_rate,
+            "per_channel": self.per_channel,
+        }
+        Path(path).write_text(json.dumps(payload, indent=2, default=_json_default))
         logger.info("Forecasting results saved to %s", path)
 
     def summary(self) -> pd.DataFrame:

--- a/tests/test_forecasting_fallback.py
+++ b/tests/test_forecasting_fallback.py
@@ -1,0 +1,44 @@
+"""Forecasting fallback rate: to_json preserves it and the uploader extracts it."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from openmhc import ForecastingResults
+
+_TOOLS = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+
+import upload_leaderboard_substrate as uploader  # noqa: E402
+
+
+def test_to_json_preserves_fallback_rate(tmp_path):
+    res = ForecastingResults(
+        per_channel={"ch_0": {"mae": 1.0}},
+        run_dir="/x",
+        n_samples=10,
+        overall_fallback_rate=0.0123,
+        fallback_rate={"ch_0": 0.0},
+    )
+    p = tmp_path / "results.json"
+    res.to_json(p)
+    d = json.loads(p.read_text())
+    # The rate survives the round-trip at the top level (unlike the old
+    # behaviour, which dumped only per_channel and dropped it).
+    assert d["overall_fallback_rate"] == pytest.approx(0.0123)
+    assert d["fallback_rate"] == {"ch_0": 0.0}
+    assert d["per_channel"] == {"ch_0": {"mae": 1.0}}
+    # And the uploader extracts it from the exported file (the leaderboard path).
+    assert uploader._worst_case_fallback_rate(p) == pytest.approx(0.0123)
+
+
+def test_to_json_default_zero(tmp_path):
+    res = ForecastingResults(per_channel={})
+    p = tmp_path / "results.json"
+    res.to_json(p)
+    assert json.loads(p.read_text())["overall_fallback_rate"] == 0.0

--- a/tests/test_upload_leaderboard_fallback.py
+++ b/tests/test_upload_leaderboard_fallback.py
@@ -1,7 +1,8 @@
-"""Uploader downstream method-column guard."""
+"""Uploader downstream method-column guard + fallback-rate extraction."""
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -27,3 +28,44 @@ def test_validate_method_column_mismatch_raises(tmp_path):
     pd.DataFrame({"method": ["custom"], "y_true": [0]}).to_parquet(pq)
     with pytest.raises(SystemExit):
         uploader.validate_method_column(pq, "linear")
+
+
+def _write_results(tmp_path, payload):
+    p = tmp_path / "results.json"
+    p.write_text(json.dumps(payload))
+    return p
+
+
+def test_worst_case_fallback_rate_forecasting_top_level(tmp_path):
+    # Forecasting / downstream shape: a single top-level scalar.
+    p = _write_results(
+        tmp_path,
+        {"per_channel": {"ch_0": {"mae": 1.0}}, "overall_fallback_rate": 0.0123},
+    )
+    assert uploader._worst_case_fallback_rate(p) == pytest.approx(0.0123)
+
+
+def test_worst_case_fallback_rate_forecasting_zero(tmp_path):
+    p = _write_results(tmp_path, {"per_channel": {}, "overall_fallback_rate": 0.0})
+    assert uploader._worst_case_fallback_rate(p) == 0.0
+
+
+def test_worst_case_fallback_rate_imputation_nested_max(tmp_path):
+    # Imputation shape: max across all scenarios[*][*].overall_fallback_rate cells.
+    p = _write_results(
+        tmp_path,
+        {
+            "random_noise": {"test": {"overall_fallback_rate": 0.01}},
+            "sleep_gap": {
+                "test": {"overall_fallback_rate": 0.05},
+                "val": {"overall_fallback_rate": 0.20},
+            },
+        },
+    )
+    assert uploader._worst_case_fallback_rate(p) == pytest.approx(0.20)
+
+
+def test_worst_case_fallback_rate_legacy_absent_returns_none(tmp_path):
+    # Legacy run with no fallback field anywhere -> None (not 0.0).
+    p = _write_results(tmp_path, {"per_channel": {"ch_0": {"mae": 1.0}}})
+    assert uploader._worst_case_fallback_rate(p) is None

--- a/tools/leaderboard_docs/forecasting/README.md
+++ b/tools/leaderboard_docs/forecasting/README.md
@@ -81,10 +81,19 @@ performance on the substituted cells and should be read with caution.
 
 ## Refreshing (full paper-results reproduction)
 
-The canonical run label is `forecasting_full_20260622` (see
-`configs/paper/sweep_forecasting.yaml`). All steps run from the OpenMHC code repo
-on Simurgh (SC); see `jobs/sc-cluster/forecasting_eval/README.md` for cluster
-details.
+**Single source of truth — avoid regressing to an old run.** The canonical run
+is pinned in exactly one place: `run_label` / `output_root` in
+`configs/paper/sweep_forecasting.yaml` (currently `forecasting_full_20260622`).
+The substrate-staging and bootstrap-draws scripts **default to it** (they read
+`output_root` from that file), so a bare `stage_leaderboard_substrates.py` or
+`produce_forecasting_bootstrap_draws.py` cannot silently rebuild the leaderboard
+from a stale substrate. To re-point the canonical run, edit **only** the sweep
+config. Likewise the **methodology is fixed in the sweep + code**:
+`within_user_aggregation: micro` (binary AUROC is **pooled per user** over all
+the user's horizon cells — the eval emits one pooled row/user; the legacy
+per-window "macro" path is *not* used for the leaderboard). All steps run from
+the OpenMHC code repo on Simurgh (SC); see
+`jobs/sc-cluster/forecasting_eval/README.md` for cluster details.
 
 ```bash
 LABEL=forecasting_full_20260622

--- a/tools/leaderboard_docs/forecasting/README.md
+++ b/tools/leaderboard_docs/forecasting/README.md
@@ -1,0 +1,136 @@
+# Forecasting track — leaderboard substrate
+
+This directory holds the **per-method substrate** for the OpenMHC Track-3
+(forecasting) leaderboard. Each method ships two files:
+
+```
+forecasting/<method>.parquet         # per-(user × channel × metric) raw values
+forecasting/<method>.meta.json       # display + diagnostic sidecar
+```
+
+See `SCHEMA.md` for the exact column / field schema (including the
+`fallback_rate` diagnostic).
+
+## What's it for
+
+The substrate parquets are the canonical inputs for:
+
+- The OpenMHC HF Space (`MyHeartCounts/OpenMHC`) — it downloads these parquets +
+  the sidecars and runs the canonical forecasting reducers to produce the live
+  leaderboard table (skill / fair-skill / mean-rank vs `seasonal_naive`).
+- Independent re-aggregation (skill / rank / fairness reducers in
+  `src/forecasting_evaluation/metrics/`).
+- The cluster-bootstrap reference at `forecasting/bootstrap/` (per-draw CIs) is
+  reduced from these substrates, so any change here must be matched by a
+  bootstrap refresh (see "Refreshing" below) or the CIs drift off the points.
+
+## Loading
+
+```python
+from huggingface_hub import hf_hub_download
+import pandas as pd, json
+
+parquet = hf_hub_download(
+    "MyHeartCounts/OpenMHC-leaderboard-data",
+    "forecasting/chronos2_zeroshot.parquet",
+    repo_type="dataset",
+)
+df = pd.read_parquet(parquet)
+print(df.shape, df.columns.tolist())
+
+# Display + diagnostic sidecar (incl. fallback_rate)
+meta_p = hf_hub_download(
+    "MyHeartCounts/OpenMHC-leaderboard-data",
+    "forecasting/chronos2_zeroshot.meta.json",
+    repo_type="dataset",
+)
+print(json.loads(open(meta_p).read()))
+# -> {"display_name": "Chronos-2 (zero-shot)", "type": "Foundation Model", ...,
+#     "fallback_rate": 0.0}
+```
+
+## Pooled substrate
+
+The pooled per-user frame across all methods is the concatenation of the
+per-method parquets (~7,370 rows/method × 10 methods for the canonical config):
+
+```python
+import glob, pandas as pd
+pooled = pd.concat(
+    [pd.read_parquet(p) for p in glob.glob("forecasting/*.parquet")],
+    ignore_index=True,
+)
+```
+
+## `fallback_rate` is on by default
+
+The invalid-prediction rate is **always** produced and **always** threaded into
+the sidecar — there is no opt-in flag:
+
+- The eval harness always records `overall_fallback_rate` (fraction of forecast
+  cells the model emitted as NaN, which the harness substituted with
+  Seasonal-Naive before scoring) at the top level of each run's `results.json`,
+  and `evaluate_forecasting` carries it in the substrate parquet's `meta`.
+- `stage_leaderboard_substrates.py` emits each upload command **with**
+  `--results-json <runs>/<method>/hydra/results.json`, so
+  `upload_leaderboard_substrate.py` auto-extracts the rate and writes the
+  `fallback_rate` sidecar key by default. Existing display fields are preserved.
+
+A `fallback_rate > ~5%` means the headline scores are inflated with baseline
+performance on the substituted cells and should be read with caution.
+
+## Refreshing (full paper-results reproduction)
+
+The canonical run label is `forecasting_full_20260622` (see
+`configs/paper/sweep_forecasting.yaml`). All steps run from the OpenMHC code repo
+on Simurgh (SC); see `jobs/sc-cluster/forecasting_eval/README.md` for cluster
+details.
+
+```bash
+LABEL=forecasting_full_20260622
+
+# (1) Eval + aggregate — fan out all 10 model jobs under one label, then chain
+#     the paper pipeline (substrate + skill/rank + bootstrap CIs + fairness).
+#     Each run writes results.json with the top-level overall_fallback_rate.
+MHC_FORECAST_RUN_LABEL=$LABEL jobs/sc-cluster/forecasting_eval/submit_pipeline.sh
+#   re-aggregate only (metrics already on disk):
+#   sbatch --export=ALL,MHC_FORECAST_RUN_LABEL=$LABEL \
+#     jobs/sc-cluster/forecasting_eval/run_paper_pipeline.sbatch
+# -> results/forecasting_eval/simurgh/summary/$LABEL/
+#      {forecasting_per_user_errors.parquet, skill_rank_models.json,
+#       forecasting_skill_score*.csv, forecasting_grouped_metric_rank*.csv,
+#       forecasting_fairness_skill_score*.csv}
+
+# (2) Bootstrap-draws reference for the leaderboard CIs (n_boot=1000; CPU ~30 min).
+sbatch scripts/paper_results/forecasting/produce_forecasting_bootstrap_draws.sbatch \
+    --summary-dir results/forecasting_eval/simurgh/summary/$LABEL
+# -> $LABEL/bootstrap_draws.parquet (+ .meta.json)
+
+# (3) Stage per-method substrates + emit the upload commands (each already
+#     carries --results-json so fallback_rate is auto-filled).
+python scripts/paper_results/forecasting/stage_leaderboard_substrates.py
+#   ^ prints one `upload_leaderboard_substrate.py ... --track forecasting
+#     --results-json <runs>/<method>/hydra/results.json` per method; run them
+#     (HF auth required: HF_TOKEN or `huggingface-cli login`). This writes
+#     forecasting/<method>.{parquet,meta.json} with fallback_rate.
+
+# (4) Upload the bootstrap-draws reference (overwrites forecasting/bootstrap/).
+python tools/upload_leaderboard_bootstrap.py \
+    --dir results/forecasting_eval/simurgh/summary/$LABEL --track forecasting
+
+# (5) Docs — keep this README + SCHEMA.md in sync on the dataset repo:
+python - <<'PY'
+from huggingface_hub import HfApi
+api = HfApi()
+for src, dst in [
+    ("tools/leaderboard_docs/forecasting/SCHEMA.md", "forecasting/SCHEMA.md"),
+    ("tools/leaderboard_docs/forecasting/README.md", "forecasting/README.md"),
+]:
+    api.upload_file(path_or_fileobj=src, path_in_repo=dst,
+                    repo_id="MyHeartCounts/OpenMHC-leaderboard-data", repo_type="dataset",
+                    commit_message=f"docs(forecasting): sync {dst}")
+PY
+```
+
+Steps (2) and (4) keep the bootstrap CIs on the same canonical substrate as the
+point numbers — always run them together when the substrates change.

--- a/tools/leaderboard_docs/forecasting/SCHEMA.md
+++ b/tools/leaderboard_docs/forecasting/SCHEMA.md
@@ -82,9 +82,33 @@ Tiny display sidecar the leaderboard reads to render the row:
   "display_name": "My Forecaster",   // shown in the leaderboard
   "type": "Deep Learning",           // category label
   "submitter": "Stanford CS",        // lab / team
-  "subtrack": "other"                // Track 3 has no single-day/long-context split
+  "subtrack": "other",               // Track 3 has no single-day/long-context split
+  "fallback_rate": 0.0               // Seasonal-Naive substitution fraction (see below)
 }
 ```
+
+### `fallback_rate`
+
+Scalar in `[0, 1]`. The run's `overall_fallback_rate` (mirrors
+`openmhc._results.ForecastingResults.overall_fallback_rate`): the fraction of
+forecast cells the model emitted as non-finite (NaN), which the harness then
+substituted with the **Seasonal-Naive** baseline before scoring.
+
+- **`0.0`** — every forecast cell was finite; the harness never substituted.
+- **`>0`** — the model returned NaN at that fraction of forecast cells and the
+  harness filled them with Seasonal-Naive. Treat headline scores cautiously when
+  `fallback_rate > ~5%`, since the metric is inflated with baseline performance
+  on the substituted positions.
+
+The field is added to the sidecar by `tools/upload_leaderboard_substrate.py` in
+one of two ways:
+
+1. Explicit: `--fallback-rate FLOAT`
+2. Auto: `--results-json PATH` — the tool reads the run's `results.json` and
+   extracts the top-level `overall_fallback_rate`.
+
+Existing sidecar fields are preserved on update (the tool fetches the current
+sidecar from HF and merges only the provided fields).
 
 ## Conventions
 

--- a/tools/upload_leaderboard_substrate.py
+++ b/tools/upload_leaderboard_substrate.py
@@ -61,15 +61,28 @@ DEFAULT_REPO_ID = "MyHeartCounts/OpenMHC-leaderboard-data"
 
 
 def _worst_case_fallback_rate(results_json: Path) -> float | None:
-    """Return ``max(overall_fallback_rate)`` across (scenario, split) in results.json.
+    """Return the worst-case ``overall_fallback_rate`` from a ``results.json``.
 
-    Mirrors :attr:`openmhc._results.ImputationResults.overall_fallback_rate`.
+    Handles both result shapes:
+
+    - **Forecasting / downstream** — a single top-level ``overall_fallback_rate``
+      scalar (the harness pools one rate over the whole run).
+    - **Imputation** — nested ``scenarios[*][*].overall_fallback_rate``; the
+      worst case is the max across every ``(scenario, split)`` cell (mirrors
+      :attr:`openmhc._results.ImputationResults.overall_fallback_rate`).
+
     Returns ``None`` when the field is absent everywhere (legacy runs that
-    predate the fallback-tracking feature); ``0.0`` when the field is present
-    and every cell reports 0 (modern runs where the harness never had to
-    substitute a fallback).
+    predate the fallback-tracking feature); ``0.0`` when present and every
+    measured cell reports 0 (the harness never had to substitute a fallback).
     """
     d = json.loads(results_json.read_text())
+    # Forecasting / downstream: a single top-level scalar. Imputation's
+    # results.json has scenario names at the top level (no such key), so this
+    # only fires for the flat shape.
+    top = d.get("overall_fallback_rate")
+    if isinstance(top, (int, float)):
+        return float(top)
+    # Imputation: max across nested scenarios[*][*].
     scenarios = d.get("scenarios", d)
     worst = 0.0
     found = False


### PR DESCRIPTION
## Summary

Brings forecasting (Track 3) **fallback-rate handling** onto the same standardized leaderboard path as imputation (PR #43), and refreshes the canonical forecasting leaderboard on a fresh 10-model re-eval (`forecasting_full_20260622`). Along the way it fixes two real foundation-model eval bugs and removes stale defaults that could silently regress future runs. All changes are forecasting-only (no imputation/downstream code touched).

## What's in here

**Fallback-rate handling (match imputation)**
- `upload_leaderboard_substrate._worst_case_fallback_rate` also reads forecasting's top-level `overall_fallback_rate`, so `upload … --track forecasting --results-json <rj>` auto-writes the `fallback_rate` meta key — same flow as imputation (imputation's nested-scenario path unchanged).
- `ForecastingResults.to_json` now preserves `overall_fallback_rate`/`fallback_rate` (was dropping them; mirrors `ImputationResults`).
- `evaluate_forecasting` carries `overall_fallback_rate` in the `per_user_errors` substrate meta (mirrors downstream).
- `forecasting/SCHEMA.md` documents the `fallback_rate` key; new `forecasting/README.md` with the full reproduction recipe.

**Foundation-model eval fixes**
- chronos2: resolve device `auto`→`cuda` (HF `device_map="auto"` silently fell back to CPU on a flaky-GPU node → ~100× slower); slice history to the model's `context_length` (8192) before the pipeline call — provably output-identical (the model truncates + re-scales on the last 8192 internally) but avoids feeding multi-year arrays per window.
- toto: resolve device `auto`→`cuda` (was passed verbatim to torch `.to()` → crash).

**Canonical refresh**
- Re-pointed `sweep_forecasting.yaml` to `forecasting_full_20260622` (fresh 10-model re-eval; old `_full` preserved on disk).
- `stage_leaderboard_substrates.py` / `produce_forecasting_bootstrap_draws.py` derive their canonical path from the sweep config (single source of truth, no hardcoded labels); staging emits `--results-json` so `fallback_rate` is filled by default.
- `submit_models.sh` no longer defaults to the old buggy run label.

**Tests**
- `tests/test_forecasting_fallback.py` (to_json round-trip + uploader extraction); forecasting/imputation/legacy cases in `tests/test_upload_leaderboard_fallback.py`. Forecasting contract suite green; `ruff` clean on `src/`+`tools/`.

## Leaderboard (HF dataset repo) — already applied
`MyHeartCounts/OpenMHC-leaderboard-data` refreshed to this canonical: 10 per-method substrates + `meta.json` (with `fallback_rate`, all 0.0), regenerated `bootstrap/draws.parquet` (n_boot=1000), and `forecasting/{SCHEMA,README}.md`. Points and CIs are on one consistent run.

## Notes
- Every forecasting model reported `fallback_rate = 0.0` on this run (no invalid predictions).
- Binary metrics are micro/pooled (current/intended); the macro/per-window path is legacy, not used, this is why leaderboard numbers changed.
