### PR TITLE
Regenerate Track-2 (imputation + forecasting) arXiv tables from the HF substrate

### DIFF
--- a/scripts/paper_results/forecasting/build_forecasting_bootstrap_from_hf.py
+++ b/scripts/paper_results/forecasting/build_forecasting_bootstrap_from_hf.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Reduce the HF forecasting substrate into the paper bootstrap CSVs.
+
+The OpenMHC leaderboard HF dataset (``MyHeartCounts/OpenMHC-leaderboard-data``)
+is the single source of truth.
+
+* **Skill + rank** are reduced directly from the pre-computed per-draw reference
+  ``forecasting/bootstrap/draws.parquet`` (long frame
+  ``(reduction, model, scope, metric, draw, value)``) via the same ``_summarize``
+  helper the pipeline uses — this avoids the ``bootstrap_skill_rank`` rank kernel,
+  which requires pandas >= 2.1 (``DataFrame.stack(future_stack=...)``).
+* **Fairness** (deterministic point + BCa) is computed by
+  ``bootstrap_fair_skill_score`` over the per-method substrate
+  (``forecasting/<model>.parquet``), exactly as ``run_paper_pipeline.py`` does —
+  the BCa acceleration needs the leave-one-user-out jackknife, which is not in the
+  draws reference.
+
+Writes the three CSVs the arXiv forecasting table generator consumes:
+    forecasting_skill_score_bootstrap.csv
+    forecasting_grouped_metric_rank_bootstrap.csv
+    forecasting_fairness_skill_score_bootstrap.csv
+
+Demographics for the fairness BCa are resolved via the labels API; set
+``MHC_DATA_DIR`` (e.g. ``~/.cache/openmhc/data-full``) so
+``<root>/labels/{last_labels,enrollment_info}.json`` resolve.
+
+Usage:
+    MHC_DATA_DIR=~/.cache/openmhc/data-full python \
+        scripts/paper_results/forecasting/build_forecasting_bootstrap_from_hf.py \
+        --out-dir /tmp/forecasting_hf_csvs
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+import pandas as pd  # noqa: E402
+from huggingface_hub import hf_hub_download  # noqa: E402
+
+from forecasting_evaluation.metrics import metric_spec as _spec  # noqa: E402
+from forecasting_evaluation.metrics.bootstrap_fair_skill_score import (  # noqa: E402
+    bootstrap_fair_skill_score,
+)
+from forecasting_evaluation.metrics.bootstrap_skill_rank import _summarize  # noqa: E402
+from forecasting_evaluation.metrics.per_user_errors import (  # noqa: E402
+    PER_USER_METRICS_PARQUET_COLUMNS,
+)
+
+DEFAULT_REPO_ID = "MyHeartCounts/OpenMHC-leaderboard-data"
+DRAWS_PATH = "forecasting/bootstrap/draws.parquet"
+N_BOOT, SEED, CI_LEVEL = 1000, 42, 0.95
+AGE_BINS = (18, 30, 40, 50, 60)
+
+
+def _reduce_draws(draws: pd.DataFrame, reduction: str, key_cols: list[str]) -> pd.DataFrame:
+    """Reduce per-draw values to {mean, se, ci_lo, ci_hi, n_boot} per key.
+
+    Mirrors the pipeline's percentile-CI reduction (``_summarize``) so the CSVs
+    are interchangeable with a from-substrate ``bootstrap_skill_rank`` run.
+    """
+    sub = draws[draws["reduction"] == reduction]
+    rows = []
+    for key, grp in sub.groupby(key_cols, observed=True):
+        key = key if isinstance(key, tuple) else (key,)
+        rec = dict(zip(key_cols, (str(k) for k in key)))
+        rec.update(_summarize(grp["value"].to_numpy(), CI_LEVEL))
+        rows.append(rec)
+    return pd.DataFrame(rows)
+# The 10 paper models (matches forecasting/bootstrap/draws.meta.json).
+MODELS = [
+    "seasonal_naive",
+    "autoARIMA",
+    "autoETS",
+    "mixlinear",
+    "dlinear",
+    "segrnn",
+    "toto_zeroshot_ctx4096",
+    "toto_finetuned_ctx4096",
+    "chronos2_zeroshot",
+    "chronos2_finetuned",
+]
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--repo-id", default=DEFAULT_REPO_ID)
+    p.add_argument("--revision", default=None)
+    p.add_argument("--out-dir", type=Path, required=True)
+    args = p.parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    t0 = time.time()
+    frames = []
+    for name in MODELS:
+        path = hf_hub_download(
+            repo_id=args.repo_id,
+            filename=f"forecasting/{name}.parquet",
+            repo_type="dataset",
+            revision=args.revision,
+        )
+        frames.append(pd.read_parquet(path)[PER_USER_METRICS_PARQUET_COLUMNS])
+    substrate = pd.concat(frames, ignore_index=True)
+    print(f"substrate: {len(substrate)} rows, {substrate['user_id'].nunique()} users "
+          f"({time.time() - t0:.0f}s)")
+
+    models = {name: {"path": "", "display_name": name} for name in MODELS}
+
+    # --- Skill + rank: reduce directly from the pre-computed HF draws reference ---
+    draws_path = hf_hub_download(
+        repo_id=args.repo_id, filename=DRAWS_PATH, repo_type="dataset", revision=args.revision
+    )
+    draws = pd.read_parquet(draws_path)
+    _reduce_draws(draws, "skill", ["model", "scope"]).to_csv(
+        args.out_dir / "forecasting_skill_score_bootstrap.csv", index=False
+    )
+    _reduce_draws(draws, "rank", ["model", "scope", "metric"]).to_csv(
+        args.out_dir / "forecasting_grouped_metric_rank_bootstrap.csv", index=False
+    )
+    print(f"skill/rank reduced from draws ({time.time() - t0:.0f}s)")
+
+    from labels.api import ENROLLMENT_PATH, LABELS_PATH
+
+    if not LABELS_PATH or not ENROLLMENT_PATH:
+        raise SystemExit("labels/enrollment unresolved — set MHC_DATA_DIR.")
+    ftables = bootstrap_fair_skill_score(
+        models=models,
+        baseline_model=_spec.PAPER_BASELINE,
+        continuous_metrics=list(_spec.PAPER_CONTINUOUS_METRICS),
+        binary_metrics=list(_spec.PAPER_BINARY_METRICS),
+        continuous_channel_indices=_spec.CONTINUOUS_CHANNELS,
+        binary_channel_indices=_spec.BINARY_CHANNELS,
+        labels_path=str(LABELS_PATH),
+        enrollment_path=str(ENROLLMENT_PATH),
+        age_bins=AGE_BINS,
+        n_boot=N_BOOT,
+        seed=SEED,
+        ci_level=CI_LEVEL,
+        within_user_aggregation="micro",
+        bca=True,
+        per_user_metrics=substrate,
+    )
+    ftables["fairness_skill_scores_point"].to_csv(
+        args.out_dir / "forecasting_fairness_skill_score.csv", index=False
+    )
+    ftables["fairness_skill_scores"].to_csv(
+        args.out_dir / "forecasting_fairness_skill_score_bootstrap.csv", index=False
+    )
+    print(f"fairness done ({time.time() - t0:.0f}s). Wrote CSVs -> {args.out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/paper_results/forecasting/make_forecasting_latex_tables.py
+++ b/scripts/paper_results/forecasting/make_forecasting_latex_tables.py
@@ -66,9 +66,9 @@ MODELS: dict[str, tuple[str, str]] = {
 
 GROUP_ORDER = ("stat", "neural", "foundation")
 GROUP_TITLE = {
-    "stat": r"\cellcolor[HTML]{EFEFEF}\textit{Statistical Methods}",
-    "neural": r"\cellcolor[HTML]{EFEFEF}\textit{Neural Models}",
-    "foundation": r"\cellcolor[HTML]{EFEFEF}\textit{Time-Series Foundation Models}",
+    "stat": "Statistical Methods",
+    "neural": "Neural Models",
+    "foundation": "Time-Series Foundation Models",
 }
 
 # Column spec: (header, csv, scope, center, lo, hi, scale100, lower_better, ref_zero, metric)
@@ -89,41 +89,49 @@ COLUMNS: list[tuple[str, str, str, str, str, str, bool, bool, bool, str | None]]
 
 NCOL = len(COLUMNS) + 1  # + method column
 
-HEADER = r"""\begin{table}[ht!]
-\renewcommand{\arraystretch}{1.05}
+HEADER = r"""\begin{table*}[t]
 \centering
-\captionsetup{width=\textwidth}
+\captionsetup{width=0.98\textwidth}
 \caption{
 \textbf{Forecasting Results.}
 We report Average Rank $R$, Aggregate Skill Score $S$
-(in \%; $0=\mathrm{\textsc{Seasonal Naive}}$ reference),
-Fairness-adjusted $S_{\text{fair}}$, and category-specific Skill Scores for the
-sensor categories \textit{Activity, Physiology, Sleep, Workout}.
-FT denotes fine-tuned. Sub/superscripts give the $95\%$ bootstrap confidence
-interval ($1000$ resamples); $S_{\text{fair}}$ uses the bias-corrected and
-accelerated (BCa) interval about its point estimate, all other columns the
-percentile interval about the bootstrap mean.
+(in \%; $0=\textsc{Seasonal Naive}$ reference),
+Fairness-adjusted Skill Score $S_{\mathrm{fair}}$, and category-specific
+Skill Scores for \textit{Activity}, \textit{Physiology}, \textit{Sleep},
+and \textit{Workout}. FT denotes fine-tuned. Subscripts and superscripts
+indicate the $95\%$ bootstrap confidence interval based on $1000$ resamples.
 }
 \label{tab:forecasting_grouped_model_summary}
+
+\newcommand{\est}[3]{%
+  \ensuremath{#1^{\scriptscriptstyle +#2}_{\scriptscriptstyle -#3}}%
+}
+
 \small
-\setlength{\tabcolsep}{1.5pt}
-\resizebox{\linewidth}{!}{%
-\begin{tabular}{l ccccccc}
-\toprule[1.5pt]
+\renewcommand{\arraystretch}{1.16}
+\setlength{\tabcolsep}{2.2pt}
+
+\begin{tabularx}{\textwidth}{
+    >{\raggedright\arraybackslash}X
+    *{7}{>{\centering\arraybackslash}m{1.35cm}}
+}
+\toprule[1.4pt]
+
 \textbf{Method}
-& $R \downarrow$
-& $S \uparrow$
-& $S_{\text{fair}} \uparrow$
-& Activity\,$\uparrow$
-& Physio.\,$\uparrow$
-& Sleep\,$\uparrow$
-& Workout\,$\uparrow$ \\
+& \mbox{$R\,\downarrow$}
+& \mbox{$S\,\uparrow$}
+& \mbox{$S_{\mathrm{fair}}\,\uparrow$}
+& \mbox{Activity~$\uparrow$}
+& \mbox{Physio.~$\uparrow$}
+& \mbox{Sleep~$\uparrow$}
+& \mbox{Workout~$\uparrow$} \\
+
+\midrule
 """
 
-FOOTER = r"""\bottomrule[1.5pt]
-\end{tabular}%
-}
-\end{table}
+FOOTER = r"""\bottomrule[1.4pt]
+\end{tabularx}
+\end{table*}
 """
 
 
@@ -194,7 +202,7 @@ def fmt_cell(
     n: int,
     is_best: bool,
 ) -> str:
-    """One LaTeX cell: optional color + ``$value^{+upper}_{-lower}$``."""
+    """One LaTeX cell: optional color + ``\\est{value}{upper}{lower}``."""
     if ref_zero and model == REFERENCE:
         return r"$0.0$"  # baseline reference: plain, no CI, no color
     if scale100:
@@ -205,10 +213,16 @@ def fmt_cell(
     down = f"{(center - lo) * s:.1f}" if scale100 else f"{(center - lo):.2f}"
     body = rf"\mathbf{{{num}}}" if is_best else num
     color = rf"\cellcolor{{customblue!{n}}}" if n > 0 else ""
-    return rf"{color}${body}^{{+{up}}}_{{-{down}}}$"
+    return rf"{color}\est{{{body}}}{{{up}}}{{{down}}}"
 
 
 def build_body(cols: list[dict[str, tuple[float, float, float]]]) -> str:
+    """Render the grouped data rows in the arXiv ``\\est``/``tabularx`` layout.
+
+    Each cell sits on its own line (leading ``& ``) and rows are blank-line
+    separated, matching the hand-written table so the diff is numbers/colors
+    only. Groups are separated by ``\\specialrule`` + a ``\\rowcolor`` title row.
+    """
     lines: list[str] = []
 
     # Per-column min/max over ALL models (single section, global gradient).
@@ -217,13 +231,16 @@ def build_body(cols: list[dict[str, tuple[float, float, float]]]) -> str:
         vals = [cols[ci][m][0] for m in MODELS if m in cols[ci]]
         bounds.append((min(vals), max(vals)) if vals else (0.0, 0.0))
 
-    for grp in GROUP_ORDER:
-        lines.append(r"\hline")
-        lines.append(rf"\multicolumn{{{NCOL}}}{{l}}{{{GROUP_TITLE[grp]}}} \\")
+    for gi, grp in enumerate(GROUP_ORDER):
+        if gi > 0:
+            lines.append(r"\specialrule{\lightrulewidth}{0pt}{0pt}")
+        lines.append(r"\rowcolor[HTML]{EFEFEF}")
+        lines.append(rf"\multicolumn{{{NCOL}}}{{l}}{{\textit{{{GROUP_TITLE[grp]}}}}} \\")
+        lines.append("")
         members = [m for m, (_, g) in MODELS.items() if g == grp]  # fixed dict order
         for m in members:
             label = MODELS[m][0]
-            cells = []
+            row = [label]
             for ci, col in enumerate(COLUMNS):
                 _h, _f, _sc, _ctr, _lo, _hi, scale100, lower, ref_zero, _metric = col
                 center, lo, hi = cols[ci][m]
@@ -231,8 +248,10 @@ def build_body(cols: list[dict[str, tuple[float, float, float]]]) -> str:
                 n = intensity(center, vmin, vmax, lower)
                 best_val = vmin if lower else vmax
                 is_best = (center == best_val) and (m != REFERENCE)
-                cells.append(fmt_cell(m, center, lo, hi, scale100, ref_zero, n, is_best))
-            lines.append(rf"{label} & " + " & ".join(cells) + r" \\")
+                row.append("& " + fmt_cell(m, center, lo, hi, scale100, ref_zero, n, is_best))
+            row[-1] = row[-1] + r" \\"
+            lines.append("\n".join(row))
+            lines.append("")
 
     return "\n".join(lines) + "\n"
 

--- a/scripts/paper_results/forecasting/make_forecasting_latex_tables.py
+++ b/scripts/paper_results/forecasting/make_forecasting_latex_tables.py
@@ -103,7 +103,7 @@ indicate the $95\%$ bootstrap confidence interval based on $1000$ resamples.
 }
 \label{tab:forecasting_grouped_model_summary}
 
-\newcommand{\est}[3]{%
+\providecommand{\est}[3]{%
   \ensuremath{#1^{\scriptscriptstyle +#2}_{\scriptscriptstyle -#3}}%
 }
 

--- a/scripts/paper_results/imputation/make_imputation_latex_tables.py
+++ b/scripts/paper_results/imputation/make_imputation_latex_tables.py
@@ -134,8 +134,8 @@ HEADER = r"""\begin{table}[b!]
     \renewcommand{\arraystretch}{1.05}
     \centering
     \captionsetup{width=\textwidth}
-    \caption{\textbf{Imputation Results.} We report Average Rank $R$, Aggregate Skill Score $S$ (in \%; $0=\TN{LOCF}$ reference), Fairness-Adjusted Skill Score $S_{\text{fair}}$, and Channel-Specific Skill Scores for the following channels: \textit{Activity, Physiology, Sleep, Workout}. Finally, we also report performance on all \textit{Semantic} masking approaches (see Appendix \ref{sec:imputation}). Single-day imputation method results are in the upper section of the table; long-context imputation method results ($\geq 7\times 1440$ time steps) are below. %
-    Sub/superscripts give the $95\%$ bootstrap confidence interval ($1000$ resamples); $S_{\text{fair}}$ uses the bias-corrected and accelerated (BCa) interval about its point estimate, all other columns the percentile interval about the bootstrap mean.
+    \caption{\textbf{Imputation Results.} We report Average Rank $R$, Aggregate Skill Score $S$ (in \%; $0=\TN{LOCF}$ reference), Fairness Skill Score $S_{\text{fair}}$, and Channel-Specific Skill Scores for the following channels: \textit{Activity, Physiology, Sleep, Workout}. Finally, we also report performance on all \textit{Semantic} masking approaches (see Appendix \ref{sec:imputation}). Single-day imputation method results are in the upper section of the table; long-context imputation method results ($\geq 7\times 1440$ time steps) are below. %
+    Sub/superscripts give the $95\%$ bootstrap confidence interval ($1000$ resamples); $S_{\text{fair}}$ uses the bias-corrected and accelerated (BCa) interval about its point estimate, all other columns the percentile interval about the bootstrap mean. \kwz{CAPTION}
     }
     \label{tab:imputation_main_results}
     \small

--- a/scripts/paper_results/imputation/make_imputation_raw_tables.py
+++ b/scripts/paper_results/imputation/make_imputation_raw_tables.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Generate the arXiv imputation *raw-metric* appendix tables from HF.
+
+Source of truth: the per-method substrate on the OpenMHC leaderboard HF dataset
+(``MyHeartCounts/OpenMHC-leaderboard-data``, ``imputation/<method>.parquet``).
+Each row is a per-(method, scenario, split, channel, channel_type,
+subgroup_attr, subgroup_value, user) error ``E_per_user`` where ``continuous``
+= per-user MAE and ``binary`` = ``1 - AUC`` (un-floored).
+
+The substrate stores **MAE** (not RMSE — RMSE needs squared errors, which are
+not retained), so these tables report MAE for continuous channels and ROC AUC
+for binary channels:
+
+    MAE(method, scenario)  = mean over the scenario's continuous channels of
+                             [ mean over users of E_per_user ]
+    AUC(method, scenario)  = mean over the scenario's binary channels of
+                             [ 1 - mean over users of E_per_user ]
+
+Only ``random_noise``, ``temporal_slice``, ``signal_slice`` mask binary
+channels, so AUC is reported only for those three; ``sleep_gap``,
+``workout_gap``, ``intensity_failure`` are continuous-only (MAE only).
+
+Emits two ``\\begin{table}...\\end{table}`` blocks (single-day and long-context),
+matching the existing hand-written appendix tables (booktabs rules, per-column
+``customblue!N`` gradient, bold best cell), as point estimates over the test
+cohort.
+
+Usage:
+    python scripts/paper_results/imputation/make_imputation_raw_tables.py \
+        --out-single ~/MHC-benchmark/paper/sections_arxiv/appendix/imputation_raw_single_day_table.tex \
+        --out-long   ~/MHC-benchmark/paper/sections_arxiv/appendix/imputation_raw_long_context_table.tex
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+DEFAULT_REPO_ID = "MyHeartCounts/OpenMHC-leaderboard-data"
+
+# key -> (latex_label, context, model_group). Labels mirror the existing tables
+# (\cite, not \citep). Order within each (context, group) is fixed.
+METHODS: dict[str, tuple[str, str, str]] = {
+    # single-day -- statistical
+    "linear": (r"Linear", "single", "stat"),
+    "temporal_mean": (r"Temporal mean", "single", "stat"),
+    "locf": (r"LOCF \textit{(reference)}", "single", "stat"),
+    "temporal_mode": (r"Temporal mode", "single", "stat"),
+    "mode": (r"Mode", "single", "stat"),
+    "mean": (r"Mean", "single", "stat"),
+    # single-day -- neural
+    "lsm2": (r"LSM-2~\cite{xu2025lsm}", "single", "neural"),
+    "dlinear": (r"DLinear~\cite{zeng2023dlinear}", "single", "neural"),
+    "brits": (r"BRITS~\cite{cao2018brits}", "single", "neural"),
+    "timesnet": (r"TimesNet~\cite{wu2023timesnet}", "single", "neural"),
+    "fedformer": (r"FEDformer~\cite{zhou2022fedformer}", "single", "neural"),
+    # long-context -- statistical
+    "personalized_temporal_mean": (r"Pers.\ temp.\ mean", "long", "stat"),
+    "personalized_mean": (r"Pers.\ mean", "long", "stat"),
+    "personalized_mode": (r"Pers.\ mode", "long", "stat"),
+    # long-context -- neural
+    "lsm2_weekly": (r"LSM-2 (7-day)", "long", "neural"),
+    "lsm2_weekly_sparse": (r"LSM-2-Sparse (7-day)", "long", "neural"),
+    "dlinear_weekly": (r"DLinear (7-day)~\cite{zeng2023dlinear}", "long", "neural"),
+}
+
+# (column prefix, scenario key, has_auc) in table-column order.
+SCENARIOS: list[tuple[str, str, bool]] = [
+    ("Random", "random_noise", True),
+    ("Temporal", "temporal_slice", True),
+    ("Signal", "signal_slice", True),
+    ("Sleep", "sleep_gap", False),
+    ("Workout", "workout_gap", False),
+    ("Intensity", "intensity_failure", False),
+]
+
+GROUP_TITLE = {
+    "stat": r"\cellcolor[HTML]{EFEFEF}\textit{Statistical Models}",
+    "neural": r"\cellcolor[HTML]{EFEFEF}\textit{Neural Models}",
+}
+
+CAPTION = {
+    "single": (
+        r"\textbf{Single-Day Imputation Raw Metrics.} Scenario-level raw metrics on the "
+        r"test split. Each MAE entry is the mean per-channel MAE across applicable "
+        r"continuous channels; each ROC AUC entry is the macro-average across applicable "
+        r"binary channels. Sleep gap, workout gap, and intensity failure mask only "
+        r"continuous channels, so ROC AUC is not reported there. Values are point "
+        r"estimates over the test cohort."
+    ),
+    "long": (
+        r"\textbf{Long-Context Imputation Raw Metrics.} Scenario-level raw metrics on the "
+        r"test split. Each MAE entry is the mean per-channel MAE across applicable "
+        r"continuous channels; each ROC AUC entry is the macro-average across applicable "
+        r"binary channels. Sleep gap, workout gap, and intensity failure mask only "
+        r"continuous channels, so ROC AUC is not reported there. Values are point "
+        r"estimates over the test cohort."
+    ),
+}
+LABEL = {
+    "single": "tab:imputation_appendix_raw_single_day",
+    "long": "tab:imputation_appendix_raw_long_context",
+}
+
+
+def build_columns() -> list[tuple[str, str, str, bool]]:
+    """Flatten SCENARIOS into (header, scenario, metric, lower_better) columns."""
+    cols: list[tuple[str, str, str, bool]] = []
+    for prefix, scen, has_auc in SCENARIOS:
+        cols.append((rf"{prefix} MAE$\downarrow$", scen, "mae", True))
+        if has_auc:
+            cols.append((rf"{prefix} AUC$\uparrow$", scen, "auc", False))
+    return cols
+
+
+def compute_metrics(repo_id: str, revision: str | None) -> dict[str, dict[tuple[str, str], float]]:
+    """Return {method: {(scenario, 'mae'|'auc'): value}} point estimates from HF."""
+    import pandas as pd
+    from huggingface_hub import hf_hub_download
+
+    out: dict[str, dict[tuple[str, str], float]] = {}
+    for method in METHODS:
+        path = hf_hub_download(
+            repo_id=repo_id, filename=f"imputation/{method}.parquet",
+            repo_type="dataset", revision=revision,
+        )
+        df = pd.read_parquet(path)
+        df = df[(df["subgroup_attr"] == "all") & (df["split"] == "test")]
+        vals: dict[tuple[str, str], float] = {}
+        for _prefix, scen, has_auc in SCENARIOS:
+            s = df[df["scenario"] == scen]
+            cont = s[s["channel_type"] == "continuous"]
+            # per-channel macro-mean over users, then mean across channels.
+            per_ch_mae = cont.groupby("channel")["E_per_user"].mean()
+            if len(per_ch_mae):
+                vals[(scen, "mae")] = float(per_ch_mae.mean())
+            if has_auc:
+                binr = s[s["channel_type"] == "binary"]
+                per_ch_err = binr.groupby("channel")["E_per_user"].mean()
+                if len(per_ch_err):
+                    vals[(scen, "auc")] = float((1.0 - per_ch_err).mean())
+        out[method] = vals
+    return out
+
+
+def intensity(value: float, vmin: float, vmax: float, lower_better: bool) -> int:
+    """Per-column min-max intensity in [0, 100]."""
+    if vmax == vmin:
+        return 0
+    frac = (vmax - value) / (vmax - vmin) if lower_better else (value - vmin) / (vmax - vmin)
+    return round(frac * 100)
+
+
+def fmt_cell(value: float | None, metric: str, n: int, is_best: bool) -> str:
+    """One LaTeX cell: optional color + ``$value$`` (MAE 1 dp, AUC 3 dp)."""
+    if value is None:
+        return ""  # scenario has no channels of this type (e.g. AUC for continuous-only)
+    num = f"{value:.1f}" if metric == "mae" else f"{value:.3f}"
+    body = rf"\mathbf{{{num}}}" if is_best else num
+    color = rf"\cellcolor{{customblue!{n}}}" if n > 0 else ""
+    return rf"{color}${body}$"
+
+
+def build_table(
+    ctx: str, metrics: dict[str, dict[tuple[str, str], float]]
+) -> str:
+    columns = build_columns()
+    ndata = len(columns)
+    ncol = ndata + 1
+    members = [m for m, (_, c, _) in METHODS.items() if c == ctx]
+
+    # Per-column min/max over the methods present in this table.
+    bounds = []
+    for _h, scen, metric, _lb in columns:
+        vals = [metrics[m].get((scen, metric)) for m in members]
+        vals = [v for v in vals if v is not None]
+        bounds.append((min(vals), max(vals)) if vals else (0.0, 0.0))
+
+    header_cells = " & ".join(h for h, _s, _m, _lb in columns)
+    lines = [
+        r"\begin{table}[t!]",
+        r"    \renewcommand{\arraystretch}{1.05}",
+        r"    \centering",
+        r"    \captionsetup{width=\textwidth}",
+        rf"    \caption{{{CAPTION[ctx]}}}",
+        rf"    \label{{{LABEL[ctx]}}}",
+        r"    \small",
+        r"    \setlength{\tabcolsep}{1.5pt}",
+        r"    \resizebox{\linewidth}{!}{%",
+        rf"    \begin{{tabular}}{{l {'c' * ndata}}}",
+        r"    \toprule[1.5pt]",
+        rf"    \textbf{{Method}} & {header_cells} \\",
+        r"    \hline",
+    ]
+
+    for gi, grp in enumerate(("stat", "neural")):
+        if gi > 0:
+            lines.append(r"    \hline")
+        lines.append(rf"    \multicolumn{{{ncol}}}{{l}}{{{GROUP_TITLE[grp]}}} \\")
+        for m in [mm for mm in members if METHODS[mm][2] == grp]:
+            cells = []
+            for ci, (_h, scen, metric, lower) in enumerate(columns):
+                v = metrics[m].get((scen, metric))
+                vmin, vmax = bounds[ci]
+                if v is None:
+                    cells.append("")
+                    continue
+                n = intensity(v, vmin, vmax, lower)
+                best_val = vmin if lower else vmax
+                is_best = v == best_val
+                cells.append(fmt_cell(v, metric, n, is_best))
+            lines.append(rf"    {METHODS[m][0]} & " + " & ".join(cells) + r" \\")
+
+    lines += [r"    \bottomrule[1.5pt]", r"    \end{tabular}%", r"    }", r"\end{table}", ""]
+    return "\n".join(lines)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--repo-id", default=DEFAULT_REPO_ID)
+    p.add_argument("--revision", default=None)
+    base = Path.home() / "MHC-benchmark/paper/sections_arxiv/appendix"
+    p.add_argument("--out-single", type=Path, default=base / "imputation_raw_single_day_table.tex")
+    p.add_argument("--out-long", type=Path, default=base / "imputation_raw_long_context_table.tex")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    metrics = compute_metrics(args.repo_id, args.revision)
+    for ctx, out in (("single", args.out_single), ("long", args.out_long)):
+        table = build_table(ctx, metrics)
+        if args.dry_run:
+            print(table)
+            continue
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(table)
+        print(f"Wrote {out} ({len(table)} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/paper_results/imputation/make_imputation_skill_by_scenario_table.py
+++ b/scripts/paper_results/imputation/make_imputation_skill_by_scenario_table.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Generate the arXiv imputation *skill-by-scenario* appendix table from HF.
+
+Source of truth: the OpenMHC leaderboard HF dataset
+(``MyHeartCounts/OpenMHC-leaderboard-data``). This table includes the dense
+``LSM-2 (7-day)`` baseline, so it reduces the **dense-weekly** bootstrap
+reference ``imputation/bootstrap_with_dense_weekly/draws.parquet`` (the main
+16-method draws + the dense ``lsm2_weekly``) plus the matching per-method
+substrate parquets — so all rows are ranked within one consistent 17-method pool.
+
+Columns: Aggregate Skill Score $S$, Average Rank $R$, Fairness Skill Score
+$S_{\\text{fair}}$ (the **disparity-ratio** score used by the main table — the
+deprecated $S-\\lambda\\bar D$ score and its $\\bar D$ column are dropped), and
+per-scenario Skill Scores for the six masking scenarios. Values are bootstrap
+mean $\\pm$ SE ($B{=}1000$); $S_{\\text{fair}}$ is the deterministic point
+estimate $\\pm$ bootstrap SE.
+
+Reductions are the canonical ones (``aggregate_skill_rank_fairness`` for
+skill/rank, ``compute_fairness_skill_scores`` for the disparity-ratio fairness),
+identical to ``make_imputation_latex_tables.py`` but over the dense-weekly
+superset and with ``bca=False`` (the table renders $\\pm$SE, so the BCa jackknife
+is unnecessary).
+
+Usage:
+    python scripts/paper_results/imputation/make_imputation_skill_by_scenario_table.py \
+        --out ~/MHC-benchmark/paper/sections_arxiv/appendix/imputation_skill_by_scenario_table.tex
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+DEFAULT_REPO_ID = "MyHeartCounts/OpenMHC-leaderboard-data"
+DRAWS_PATH = "imputation/bootstrap_with_dense_weekly/draws.parquet"
+REFERENCE = "locf"
+
+# key -> (latex_label, context, model_group). Labels mirror the existing appendix
+# table (plain \cite). lsm2_weekly is the dense 7-day baseline.
+METHODS: dict[str, tuple[str, str, str]] = {
+    "linear": (r"Linear", "single", "stat"),
+    "temporal_mean": (r"Temporal mean", "single", "stat"),
+    "locf": (r"LOCF \textit{(reference)}", "single", "stat"),
+    "temporal_mode": (r"Temporal mode", "single", "stat"),
+    "mode": (r"Mode", "single", "stat"),
+    "mean": (r"Mean", "single", "stat"),
+    "lsm2": (r"LSM-2~\cite{xu2025lsm}", "single", "neural"),
+    "dlinear": (r"DLinear~\cite{zeng2023dlinear}", "single", "neural"),
+    "brits": (r"BRITS~\cite{cao2018brits}", "single", "neural"),
+    "timesnet": (r"TimesNet~\cite{wu2023timesnet}", "single", "neural"),
+    "fedformer": (r"FEDformer~\cite{zhou2022fedformer}", "single", "neural"),
+    "personalized_temporal_mean": (r"Pers.\ temp.\ mean", "long", "stat"),
+    "personalized_mean": (r"Pers.\ mean", "long", "stat"),
+    "personalized_mode": (r"Pers.\ mode", "long", "stat"),
+    "lsm2_weekly": (r"LSM-2 (7-day)", "long", "neural"),
+    "lsm2_weekly_sparse": (r"LSM-2-Sparse (7-day)", "long", "neural"),
+    "dlinear_weekly": (r"DLinear (7-day)~\cite{zeng2023dlinear}", "long", "neural"),
+}
+
+# (header, source, scope, center, scale100, lower_better, ref_zero)
+#   source: "skill" | "rank" | "fair"
+COLUMNS = [
+    (r"$S\uparrow$", "skill", "overall", "mean", True, False, True),
+    (r"$R\downarrow$", "rank", "overall", "mean", False, True, False),
+    (r"$S_{\text{fair}}\uparrow$", "fair", "overall", "point", True, False, True),
+    (r"Random noise\,$\uparrow$", "skill", "random_noise", "mean", True, False, True),
+    (r"Temporal slice\,$\uparrow$", "skill", "temporal_slice", "mean", True, False, True),
+    (r"Signal slice\,$\uparrow$", "skill", "signal_slice", "mean", True, False, True),
+    (r"Sleep gap\,$\uparrow$", "skill", "sleep_gap", "mean", True, False, True),
+    (r"Workout gap\,$\uparrow$", "skill", "workout_gap", "mean", True, False, True),
+    (r"Intensity failure\,$\uparrow$", "skill", "intensity_failure", "mean", True, False, True),
+]
+NCOL = len(COLUMNS) + 1
+
+SECTION_TITLE = {
+    "single": r"\textbf{\emph{Single-day imputation}}",
+    "long": r"\textbf{\emph{Long-context imputation ($\geq 7 \times 1440$ time steps)}}",
+}
+GROUP_TITLE = {
+    "stat": r"\cellcolor[HTML]{EFEFEF}\textit{Statistical Models}",
+    "neural": r"\cellcolor[HTML]{EFEFEF}\textit{Neural Models}",
+}
+
+HEADER_TMPL = r"""\begin{table}[t!]
+    \renewcommand{\arraystretch}{1.05}
+    \centering
+    \captionsetup{width=\textwidth}
+    \caption{\textbf{Imputation Results by Masking Scenario.} Aggregate Skill Score $S$ (in \%; $0=$LOCF reference), Average Rank $R$, Fairness Skill Score $S_{\text{fair}}$ (disparity-ratio; see Appendix~\ref{sec:fairness_adjusted_score}), and per-scenario Skill Scores across all six masking scenarios (lower is better for $R$; higher otherwise). Single-day methods above; long-context methods ($\geq 7\times 1440$ time steps) below. Gradients computed within each track. Values are bootstrap means $\pm$ SE ($B{=}1000$); $S_{\text{fair}}$ is the point estimate $\pm$ bootstrap SE.}
+    \label{tab:imputation_appendix_skill_by_scenario}
+    \small
+    \setlength{\tabcolsep}{1.5pt}
+    \resizebox{\linewidth}{!}{%
+    \begin{tabular}{l ccccccccc}
+    \toprule[1.5pt]
+    \textbf{Method} & $S\uparrow$ & $R\downarrow$ & $S_{\text{fair}}\uparrow$ & Random noise\,$\uparrow$ & Temporal slice\,$\uparrow$ & Signal slice\,$\uparrow$ & Sleep gap\,$\uparrow$ & Workout gap\,$\uparrow$ & Intensity failure\,$\uparrow$ \\
+    \midrule
+"""
+FOOTER = r"""    \bottomrule[1.5pt]
+    \end{tabular}%
+    }
+\end{table}
+"""
+
+
+def reduce_from_hf(repo_id: str, revision: str | None) -> dict[str, dict[tuple[str, str], tuple[float, float]]]:
+    """Return {method: {(source, scope): (center, se)}} from the dense-weekly HF substrate."""
+    import pandas as pd
+    from huggingface_hub import hf_hub_download
+
+    from imputation_evaluation.evaluation.bootstrap_skill_rank import (
+        aggregate_skill_rank_fairness,
+        read_draws_parquet,
+    )
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from aggregate_fairness_skill_score import (  # noqa: E402
+        BCA_HEADLINE_SCOPES,
+        SENSITIVE_ATTRS,
+        _fair_points_by_key,
+        _per_user_to_per_cell_E,
+        compute_fairness_skill_scores,
+    )
+
+    draws_path = hf_hub_download(
+        repo_id=repo_id, filename=DRAWS_PATH, repo_type="dataset", revision=revision
+    )
+    draws_df, _ = read_draws_parquet(Path(draws_path))
+    all_rows = draws_df[draws_df["subgroup_attr"] == "all"]
+    tables = aggregate_skill_rank_fairness(all_rows)
+
+    per_method = [
+        pd.read_parquet(
+            hf_hub_download(
+                repo_id=repo_id, filename=f"imputation/{m}.parquet",
+                repo_type="dataset", revision=revision,
+            )
+        )
+        for m in METHODS
+    ]
+    per_user_df = pd.concat(per_method, ignore_index=True)
+    # Fairness SE from the (cheap) percentile bootstrap; the CENTER is the
+    # deterministic point estimate (matches the main table, which uses point).
+    # We compute the point directly via _fair_points_by_key — the BCa jackknife
+    # (the slow part) is unnecessary since this table renders point +/- SE.
+    fairness = compute_fairness_skill_scores(
+        draws_df, attrs=list(SENSITIVE_ATTRS), baseline_method=REFERENCE, bca=False,
+    )
+    # B.2: drop per-channel binary ch_7..ch_18 (sleep/workouts reach fairness only
+    # via cat_collapsed:*), matching compute_fairness_skill_scores' point flow.
+    pu = per_user_df
+    drop = pu["channel"].astype(str).str.match(r"^ch_(?:[7-9]|1[0-8])$") & (
+        pu["channel_type"].astype(str) == "binary"
+    )
+    per_cell = _per_user_to_per_cell_E(pu[~drop & (pu["split"] == "test")])
+    points = _fair_points_by_key(
+        per_cell, attrs=list(SENSITIVE_ATTRS), baseline_method=REFERENCE,
+        clip_lower=1e-2, clip_upper=100.0, scopes=BCA_HEADLINE_SCOPES,
+    )
+    fair_se = {
+        r["method"]: (float(r["se"]) if r["se"] == r["se"] else 0.0)
+        for _, r in fairness[(fairness["scope"] == "overall") & (fairness["split"] == "test")].iterrows()
+    }
+
+    out: dict[str, dict[tuple[str, str], tuple[float, float]]] = {m: {} for m in METHODS}
+
+    def _ingest(df, source, center_col):
+        sub = df[df["split"] == "test"]
+        for _, r in sub.iterrows():
+            m = r["method"]
+            if m not in out:
+                continue
+            c = r.get(center_col)
+            if c is None or (isinstance(c, float) and c != c):
+                continue
+            se = r.get("se")
+            out[m][(source, str(r["scope"]))] = (float(c), float(se) if se == se else 0.0)
+
+    _ingest(tables["skill_scores"], "skill", "mean")
+    _ingest(tables["avg_rankings"], "rank", "mean")
+    for m in METHODS:
+        pt = points.get((m, "overall"))
+        if pt is not None:
+            out[m][("fair", "overall")] = (float(pt), fair_se.get(m, 0.0))
+    return out
+
+
+def intensity(value: float, vmin: float, vmax: float, lower_better: bool) -> int:
+    if vmax == vmin:
+        return 0
+    frac = (vmax - value) / (vmax - vmin) if lower_better else (value - vmin) / (vmax - vmin)
+    return round(frac * 100)
+
+
+def fmt_cell(method, center, se, scale100, ref_zero, n, is_best) -> str:
+    if ref_zero and method == REFERENCE:
+        return r"$0.0$"
+    s = 100.0 if scale100 else 1.0
+    num = f"{center * s:+.1f}" if scale100 else f"{center * s:.1f}"
+    se_s = f"{se * s:.1f}"
+    body = rf"\mathbf{{{num}}}" if is_best else num
+    color = rf"\cellcolor{{customblue!{n}}}" if n > 0 else ""
+    return rf"{color}${body}{{\scriptstyle \pm {se_s}}}$"
+
+
+def build_body(data) -> str:
+    lines: list[str] = []
+    for ctx in ("single", "long"):
+        if ctx == "long":
+            lines.append(r"    \midrule")
+        lines.append(rf"    \multicolumn{{{NCOL}}}{{l}}{{{SECTION_TITLE[ctx]}}} \\")
+        lines.append(r"    \hline")
+        section = [m for m, (_, c, _) in METHODS.items() if c == ctx]
+        bounds = []
+        for _h, src, scope, _ctr, _s, _lb, _rz in COLUMNS:
+            vals = [data[m][(src, scope)][0] for m in section if (src, scope) in data[m]]
+            bounds.append((min(vals), max(vals)) if vals else (0.0, 0.0))
+        for gi, grp in enumerate(("stat", "neural")):
+            if gi > 0:
+                lines.append(r"    \hline")
+            lines.append(rf"    \multicolumn{{{NCOL}}}{{l}}{{{GROUP_TITLE[grp]}}} \\")
+            members = [m for m in section if METHODS[m][2] == grp]
+            members.sort(key=lambda m: -data[m].get(("skill", "overall"), (0.0, 0.0))[0])
+            for m in members:
+                cells = []
+                for ci, (_h, src, scope, _ctr, scale100, lower, ref_zero) in enumerate(COLUMNS):
+                    center, se = data[m].get((src, scope), (float("nan"), 0.0))
+                    vmin, vmax = bounds[ci]
+                    n = intensity(center, vmin, vmax, lower)
+                    best_val = vmin if lower else vmax
+                    is_best = (center == best_val) and (m != REFERENCE)
+                    cells.append(fmt_cell(m, center, se, scale100, ref_zero, n, is_best))
+                lines.append(rf"    {METHODS[m][0]} & " + " & ".join(cells) + r" \\")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--repo-id", default=DEFAULT_REPO_ID)
+    p.add_argument("--revision", default=None)
+    p.add_argument(
+        "--out", type=Path,
+        default=Path.home()
+        / "MHC-benchmark/paper/sections_arxiv/appendix/imputation_skill_by_scenario_table.tex",
+    )
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    data = reduce_from_hf(args.repo_id, args.revision)
+    missing = [m for m in METHODS if not data[m]]
+    if missing:
+        raise SystemExit(f"Methods missing from reduction: {missing}")
+
+    table = HEADER_TMPL + build_body(data) + FOOTER
+    if args.dry_run:
+        print(table)
+        return
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(table)
+    print(f"Wrote {args.out} ({len(table)} bytes)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds/refreshes the generator scripts that produce the arXiv **imputation** and **forecasting** result tables directly from the canonical HF leaderboard substrate (`MyHeartCounts/OpenMHC-leaderboard-data`) — the single source of truth. The corresponding `.tex` tables + prose were regenerated in the paper (Overleaf) repo separately.

### Scripts
- **`forecasting/build_forecasting_bootstrap_from_hf.py`** *(new)* — reduces the HF forecasting `bootstrap/draws.parquet` (skill + rank, via the shared `_summarize`) and the per-method substrate (fairness point + BCa) into the paper bootstrap CSVs. Deliberately avoids the `bootstrap_skill_rank` rank kernel, which needs `pandas>=2.1` (`future_stack`).
- **`forecasting/make_forecasting_latex_tables.py`** — now emits the existing arXiv `\est{}`/`tabularx` layout (numbers-only refresh) from the HF-reduced CSVs, instead of reading a stale local CSV dir.
- **`imputation/make_imputation_raw_tables.py`** *(new)* — raw per-scenario **MAE** + ROC AUC tables (single-day + long-context). RMSE is not recoverable from the HF substrate (it stores per-user MAE only), so the raw tables report MAE; AUC is dropped for the continuous-only scenarios (sleep / workout / intensity).
- **`imputation/make_imputation_skill_by_scenario_table.py`** *(new)* — per-scenario skill + **disparity-ratio** Fairness Skill Score (deterministic point + bootstrap SE) over the dense-weekly 17-method pool (incl. dense `LSM-2 (7-day)`); drops the deprecated `S − λ·D` mean-disparity column.
- **`imputation/make_imputation_latex_tables.py`** — restores the hand-edited caption ("Fairness Skill Score" + `\kwz` note) so re-rendering is numbers-only.

### Notes
- All numbers sourced from HF; no local results dirs are read.
- Paper-side `.tex` (tables + prose) updates live in the Overleaf repo (already committed/pushed there); this PR is the reproducible generator tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)