### PR TITLE
docs: link the xs dataset release to Harvard Dataverse in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ extras, virtualenv setup, Sherlock setup, and verification commands.
 ## Dataset Setup
 
 The dataset is hosted separately from this code repository. The `xs` release is
-available for quickstarts and smoke tests; the `full` release uses the same
-layout and API contract once available. Download each version into its own root
-directory and pass the version explicitly when evaluating:
+available for quickstarts and smoke tests on
+[Harvard Dataverse](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZYMJF6)
+(`doi:10.7910/DVN/ZYMJF6`); the `full` release uses the same layout and API
+contract once available. Download each version into its own root directory and
+pass the version explicitly when evaluating:
 
 ```python
 import openmhc


### PR DESCRIPTION
## Summary

The README **Dataset Setup** section described the `xs` release but didn't link to it. This points it at the live Harvard Dataverse record so readers can find/download the small (~1.9 GB) dev subset directly.

- Links to https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZYMJF6 and shows the DOI `doi:10.7910/DVN/ZYMJF6`.
- Matches the DOI already listed in `DATASET.md`.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)