### PR TITLE
docs: fix quickstart install command and stale dataset badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Project Page](https://img.shields.io/badge/Project%20Page-MyHeartCounts-1f883d?logo=googlechrome&style=flat-square)](https://myheartcounts.stanford.edu/)
 [![Benchmark](https://img.shields.io/badge/HuggingFace-Benchmark-ffd21e?style=flat-square&logo=huggingface)](https://myheartcounts-openmhc.hf.space)
 [![Models](https://img.shields.io/badge/HuggingFace-Models-ffd21e?style=flat-square&logo=huggingface)](https://huggingface.co/MyHeartCounts/models)
-[![Dataset](https://img.shields.io/badge/Dataset-Coming%20Soon-6c757d?style=flat-square)](#)
+[![Dataset](https://img.shields.io/badge/Dataset-XS%20on%20Dataverse-1f883d?style=flat-square)](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/ZYMJF6)
 [![Paper](https://img.shields.io/badge/Paper-Coming%20Soon-b31b1b?style=flat-square)](#)
 
 ![OpenMHC overview](figures/figure_1_final.png)

--- a/notebooks/quickstart_benchmark.ipynb
+++ b/notebooks/quickstart_benchmark.ipynb
@@ -25,10 +25,10 @@
    "source": [
     "## 1. Install + download the dataset\n",
     "\n",
-    "If you haven't already:\n",
+    "If you haven't already, install from the repo root (the `dev` extra provides Jupyter):\n",
     "\n",
     "```bash\n",
-    "pip install -e ..\n",
+    "pip install -e \".[all,dev]\"\n",
     "```\n",
     "\n",
     "Then download the XS dataset (~1.9 GB)."


### PR DESCRIPTION
## What

Two documentation fixes found while reproducing a **fresh-machine setup** (new `conda create -n … python=3.10` env → documented `pip install -e ".[all,dev]"` → running `notebooks/quickstart_benchmark.ipynb` end-to-end). The install and all three benchmark tracks worked with no hard blockers; these are the two doc inaccuracies that would mislead a new user.

### 1. Quickstart notebook install cell
`notebooks/quickstart_benchmark.ipynb` told users to run `pip install -e ..`, which:
- installs the **base package only** — no `dev` extra, so Jupyter isn't installed and you can't run the very notebook you're reading;
- diverges from the canonical `pip install -e ".[all,dev]"` in `README.md` / `docs/install.md`;
- the bare `..` path silently installs the **parent of the repo** when run from the repo root (the common case).

→ Changed to `pip install -e ".[all,dev]"`, with a note to run it from the repo root.

### 2. Stale README dataset badge
`README.md` showed a gray **`Dataset — Coming Soon`** badge linking to `#`, even though the OpenMHC-XS release is public on Harvard Dataverse (linked in the body and checked off in the release plan).

→ Updated to a green **`Dataset — XS on Dataverse`** badge pointing at the live DOI (`doi:10.7910/DVN/ZYMJF6`).

## Verification
- Notebook still parses as valid JSON; diff is surgical (only the two intended lines in the cell, original formatting/escaping preserved).
- Fresh-env reproduction in this session: clean `.[all,dev]` install, docs verify snippet passes (engines resolve to this repo), full notebook ran end-to-end (exit 0) across all three tracks, and the Dataverse download endpoint responds.

## Not included
`README.md` Paper badge (line 7) is stale in the same way — left out because I don't have the arXiv URL handy; happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)