### PR TITLE
Code review fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Transform tasks into verifiable goals:
 ## Project Overview
 
 **OpenMHC** is a public evaluation API and leaderboard for the MyHeartCounts wearable health benchmark (NeurIPS 2026). It evaluates models across three tracks:
-- **Track 1 — Outcome Prediction**: Health classification/regression from weekly (168h) sensor embeddings (33 tasks)
+- **Track 1 — Outcome Prediction**: Health classification/regression from weekly (168h) sensor embeddings (32 tasks)
 - **Track 2 — Imputation**: Reconstructing masked daily (1440-min) sensor data across 6 masking scenarios
 - **Track 3 — Forecasting**: Time-series forecasting of hourly sensor values
 
@@ -60,7 +60,7 @@ ruff format src/
 python -c "import openmhc; openmhc.download_dataset(version='xs')"  # ~1.9 GB dev subset
 ```
 
-Ruff config: 100-char line length, Google docstrings, targets Python 3.10+. Line-length check (E501) is disabled for docstrings.
+Ruff config: 100-char line length, Google docstrings, targets Python 3.10+. The line-length check (E501) is disabled repo-wide.
 
 ## Architecture
 
@@ -81,12 +81,12 @@ src/
 ├── downstream_evaluation/    # Track 1 internals (sklearn classifiers, feature extraction)
 ├── imputation_evaluation/    # Track 2 internals (masking, metrics, W&B logging)
 ├── forecasting_evaluation/   # Track 3 internals (Chronos2, AutoARIMA, etc.)
-└── labels/                   # Label registry (33 task names, types, validity criteria)
+└── labels/                   # Label registry (32 task names, types, validity criteria)
 ```
 
 ### Hydra CLI (Track 2)
 
-Reproducible Track 2 runs are dispatched via the `mhc-impute-eval` console script (declared in `pyproject.toml`). The CLI composes YAML configs at `configs/imputation/` (repo root), validates against the dataclass schema in `src/imputation_evaluation/config.py`, builds the imputer via the registry in `src/imputation_evaluation/hydra/registry.py`, and forwards to the same `run_eval` library entry point as `openmhc.evaluate_imputation`. Public-API users never touch Hydra. See `src/imputation_evaluation/README.md` Part 1.5 for usage. Tracks 1 and 3 have their own CLI surfaces (`scripts/downstream_eval/`, `scripts/run_forecasting_eval.py`).
+Reproducible Track 2 runs are dispatched via the `mhc-impute-eval` console script (declared in `pyproject.toml`). The CLI composes YAML configs at `configs/imputation/` (repo root), validates against the dataclass schema in `src/imputation_evaluation/config.py`, builds the imputer via the registry in `src/imputation_evaluation/hydra/registry.py`, and forwards to the same `run_eval` library entry point as `openmhc.evaluate_imputation`. Public-API users never touch Hydra. See `src/imputation_evaluation/README.md` Part 1.5 for usage. Track 1 runs via `scripts/run_eval.py` (and the `mhc-downstream-eval` console script); Track 3 via the `mhc-forecast-eval` console script.
 
 ### Protocol Pattern (Critical)
 
@@ -99,7 +99,9 @@ Example: an `Imputer.impute(data, observed_mask, target_mask)` method may option
 All evaluate/download functions resolve the dataset root in this priority order:
 1. Explicit `data_dir=` argument
 2. `MHC_DATA_DIR` environment variable
-3. Default: `~/.cache/openmhc/data`
+
+If neither is provided, OpenMHC raises rather than silently falling back to a default
+location (`~/.cache/openmhc/data` is only the suggested path in that error message).
 
 ### Data Formats
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,8 +112,7 @@ All evaluate/download functions resolve the dataset root in this priority order:
 ### Splits & Label Validity
 
 - Canonical split: `sharable_users_seed42_2026.json` (user-level, no leakage)
-- Two validity criteria: C1 (`single_day`) = broader, C2 (`weekly_5of7`) = ~55% smaller/stricter
-- Default criterion: C1
+- Label validity: the `single_day` rule (≥1 filtered day in the window), baked into the shipped lookups; the engine has no runtime validity-criterion toggle
 
 ### Result Objects
 

--- a/DATASET.md
+++ b/DATASET.md
@@ -104,12 +104,7 @@ with values being participant IDs (strings).
 
 ## Label validity
 
-A (user, label) pair is "valid" if the user has sufficient wearable data in the label's time window:
-
-- **C1 / `single_day`** — at least 1 filtered day in the window. Default; maximises participant pool.
-- **C2 / `weekly_5of7`** — at least one contiguous 7-day subwindow with ≥ 5 filtered days. Stricter; ~55% smaller.
-
-Submissions to the leaderboard use **C1** by default. Switch with the `data.label_validity_criterion` config.
+A (user, label) pair is "valid" if the user has at least one filtered day of wearable data in the label's time window (the `single_day` rule — it maximises the participant pool, and every Track 1 method shares it).
 
 Validity is **baked into the shipped labels lookups** — a non-sentinel cell in `daily_labels_lookup.parquet` / `weekly_labels_lookup_stride7_windowed.parquet` already marks a valid `(user, day/week)` inside the task window, so the downstream eval reads validity straight from the lookups. (The standalone `label_validity.json` still ships under `labels/` and is consumed separately by the LabelsAPI's `get_labels(return_valid_only=True)`; `label_validity.parquet` is a convenience mirror and `validity_config.json` holds the validity-window thresholds.)
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ at `configs/downstream/`:
 
 ```bash
 mhc-downstream-eval method=xgboost
-mhc-downstream-eval --multirun method=linear,mae,xgboost
+mhc-downstream-eval --multirun method=linear,lsm2,xgboost
 ```
 
 The full Track-1 guide (data contract, baselines, CLI, paper reproduction) is in

--- a/jobs/imperial/pbs/run_downstream_eval.pbs
+++ b/jobs/imperial/pbs/run_downstream_eval.pbs
@@ -39,8 +39,8 @@ mkdir -p logs
 echo "=== downstream eval (PBS/CPU, Hydra CLI): METHOD=${METHOD:-linear} ==="
 echo "Node: $(hostname) | Job: ${PBS_JOBID:-local} | PWD: $(pwd) | Date: $(date)"
 
-# -- conda env (py310; no GPU needed for these CPU methods) --
-source "$HOME/miniforge3/bin/activate" py310
+# -- conda env (openmhc = the pinned paper env; no GPU needed for these CPU methods) --
+source "$HOME/miniforge3/bin/activate" "${CONDA_ENV:-openmhc}"
 python -V
 
 export PYTHONNOUSERSITE=1

--- a/jobs/imperial/pbs/run_downstream_eval_gpu.pbs
+++ b/jobs/imperial/pbs/run_downstream_eval_gpu.pbs
@@ -32,7 +32,7 @@ echo "=== downstream eval (PBS/GPU, Hydra CLI): METHOD=${METHOD:-mae} ==="
 echo "Node: $(hostname) | Job: ${PBS_JOBID:-local} | PWD: $(pwd) | Date: $(date)"
 nvidia-smi --query-gpu=name,memory.total --format=csv,noheader || true
 
-source "$HOME/miniforge3/bin/activate" py310
+source "$HOME/miniforge3/bin/activate" "${CONDA_ENV:-openmhc}"
 python -V
 
 export PYTHONNOUSERSITE=1

--- a/jobs/imperial/pbs/run_eval.pbs
+++ b/jobs/imperial/pbs/run_eval.pbs
@@ -23,8 +23,8 @@ mkdir -p logs
 echo "=== downstream eval (PBS/CPU): METHOD=${METHOD:-linear} ==="
 echo "Node: $(hostname) | Job: ${PBS_JOBID:-local} | PWD: $(pwd) | Date: $(date)"
 
-# -- conda env (py310; no GPU needed for xgboost/linear/multirocket) --
-source "$HOME/miniforge3/bin/activate" py310
+# -- conda env (defaults to openmhc; no GPU needed for xgboost/linear/multirocket) --
+source "$HOME/miniforge3/bin/activate" "${CONDA_ENV:-openmhc}"
 python -V
 
 export PYTHONNOUSERSITE=1

--- a/jobs/imperial/pbs/run_eval_gpu.pbs
+++ b/jobs/imperial/pbs/run_eval_gpu.pbs
@@ -28,7 +28,7 @@ echo "=== downstream eval (PBS/GPU): METHOD=${METHOD:-mae} ==="
 echo "Node: $(hostname) | Job: ${PBS_JOBID:-local} | PWD: $(pwd) | Date: $(date)"
 nvidia-smi --query-gpu=name,memory.total --format=csv,noheader || true
 
-source "$HOME/miniforge3/bin/activate" py310
+source "$HOME/miniforge3/bin/activate" "${CONDA_ENV:-openmhc}"
 python -V
 
 export PYTHONNOUSERSITE=1

--- a/jobs/imperial/slurm/run_eval.slurm
+++ b/jobs/imperial/slurm/run_eval.slurm
@@ -38,7 +38,7 @@ echo "Node: $(hostname) | Job: ${SLURM_JOB_ID:-local} | Date: $(date)"
 set +u
 [ -f "$HOME/.bashrc" ] && source "$HOME/.bashrc"
 source "$HOME/miniconda3/etc/profile.d/conda.sh"
-conda activate py310
+conda activate "${CONDA_ENV:-openmhc}"
 set -u
 
 export PYTHONNOUSERSITE=1

--- a/src/downstream_evaluation/demo_covariates.py
+++ b/src/downstream_evaluation/demo_covariates.py
@@ -73,15 +73,26 @@ def build_demo_user_lookup_from_labels_df(
 ) -> dict[str, np.ndarray]:
     """Build ``{user_id: np.array([cov, ...])}`` from the labels lookup.
 
-    Takes the first non-sentinel value per user, fills missing with 0.0. The
-    labels lookup carries the demographic columns (``age``/``BiologicalSex``/
-    ``BMI_values``), so no separate data source is needed.
+    Takes the first value per user, with sentinels treated as missing. A user missing a
+    covariate is imputed with 0.0 and the per-covariate count is logged, since 0.0 is out
+    of distribution for age/BMI and collides with an encoded sex category. The labels
+    lookup carries the demographic columns (``age``/``BiologicalSex``/``BMI_values``), so
+    no separate data source is needed.
     """
     _demo_df = labels_df[["user_id"] + demo_covariates].copy()
     for c in demo_covariates:
         sentinel = -1.0 if _demo_df[c].dtype in (np.float64, np.float32) else -1
         _demo_df.loc[_demo_df[c] == sentinel, c] = np.nan
-    _user_demo = _demo_df.groupby("user_id")[demo_covariates].first().fillna(0.0)
+    _user_demo = _demo_df.groupby("user_id")[demo_covariates].first()
+    n_missing = _user_demo.isna().sum()
+    if int(n_missing.sum()) > 0:
+        per_cov = ", ".join(f"{c}={int(n_missing[c])}" for c in demo_covariates if n_missing[c])
+        log.warning(
+            "demographic covariates imputed with 0.0 for users missing a value (%s of %d "
+            "users); 0.0 is out of distribution for age/BMI — treat these as imputed.",
+            per_cov, len(_user_demo),
+        )
+    _user_demo = _user_demo.fillna(0.0)
     return {uid: row.values.astype(np.float32) for uid, row in _user_demo.iterrows()}
 
 
@@ -108,20 +119,23 @@ def apply_demographics(
 ) -> np.ndarray:
     """Append the non-excluded demographic covariates to feature matrix ``X``.
 
-    Covariates matching ``task_name`` (self) or listed in ``DEMO_ALIAS`` are
-    excluded to prevent label leakage. Returns ``X`` unchanged when no lookup
-    or covariate list is provided, or when all covariates are excluded.
+    Covariates matching ``task_name`` (self) or listed in ``DEMO_ALIAS`` are excluded to
+    prevent label leakage. Returns ``X`` unchanged when no lookup or covariate list is
+    provided, or when all covariates are excluded. A cohort user absent from the lookup
+    fails loud rather than being appended a fabricated all-zero demographic row.
     """
     if demo_user_lookup is None or not demo_covariates:
         return X
     cov_indices = _kept_cov_indices(task_name, demo_covariates)
     if not cov_indices:
         return X
+    from downstream_evaluation.models._feature_align import raise_if_missing
+
+    missing = [uid for uid in uids if demo_user_lookup.get(uid) is None]
+    raise_if_missing("Linear demographics", missing, "demographics lookup")
     demo_matrix = np.zeros((len(uids), len(cov_indices)), dtype=np.float32)
     for row_idx, uid in enumerate(uids):
-        vec = demo_user_lookup.get(uid)
-        if vec is not None:
-            demo_matrix[row_idx] = vec[cov_indices]
+        demo_matrix[row_idx] = demo_user_lookup[uid][cov_indices]
     return np.hstack([X, demo_matrix])
 
 

--- a/src/downstream_evaluation/evaluation/evaluator.py
+++ b/src/downstream_evaluation/evaluation/evaluator.py
@@ -18,6 +18,7 @@ from downstream_evaluation.evaluation.metrics import (
     compute_ordinal_metrics,
     compute_regression_metrics,
     get_task_type,
+    prepare_predictions,
 )
 
 logger = logging.getLogger(__name__)
@@ -25,19 +26,17 @@ logger = logging.getLogger(__name__)
 
 def _metrics_for(task: str, y_true, y_pred, seed: int = 42) -> dict[str, float]:
     ttype = get_task_type(task)
+    # Binary AUPRC reads the probability; multiclass accuracy the rounded class; ordinal
+    # Spearman and regression Pearson the continuous score. prepare_predictions is the one
+    # place that policy lives, shared with the persisted substrate.
+    y_pred_col, y_proba = prepare_predictions(ttype, y_pred)
     if ttype == "binary":
-        return compute_binary_metrics(y_true, y_pred, seed=seed)
-    # Multiclass accuracy scores discrete class predictions: the uniform probe already
-    # predicts ints, but an end-to-end method may hand back raw floats, so round to int
-    # (a no-op when predictions are already discrete).
+        return compute_binary_metrics(y_true, y_proba, seed=seed)
     if ttype == "multiclass":
-        return compute_multiclass_metrics(y_true, np.round(y_pred).astype(int), seed=seed)
-    # Ordinal uses Spearman's rho, which depends only on rank order. Rounding to int
-    # would collapse the rank-merged fallback scores (percentile-ranked into (0, 1]) to
-    # {0, 1} and destroy the ordering, so score the raw prediction.
+        return compute_multiclass_metrics(y_true, y_pred_col, seed=seed)
     if ttype == "ordinal":
-        return compute_ordinal_metrics(y_true, y_pred, seed=seed)
-    return compute_regression_metrics(y_true, y_pred, seed=seed)
+        return compute_ordinal_metrics(y_true, y_pred_col, seed=seed)
+    return compute_regression_metrics(y_true, y_pred_col, seed=seed)
 
 
 def _combine_with_fallback(y_pred, fb, ttype: str):
@@ -220,52 +219,42 @@ class DownstreamEvaluator:
         non_finite = ~np.isfinite(y_pred)
         n_fallback = 0
         if non_finite.any():
-            y_pred, n_fallback = self._apply_fallback(
-                task, ttype, y_pred, train_td, test_td, train_data, test_data, spec
-            )
+            y_pred, n_fallback = self._apply_fallback(task, ttype, y_pred, train_td, test_td)
         return test_td.labels, y_pred, n_fallback
 
-    def _apply_fallback(self, task, ttype, y_pred, train_td, test_td, train_data, test_data, spec):
+    def _fallback_loader(self, spec):
+        """The DataLoader that feeds the Linear baseline its daily segments (built once)."""
+        if getattr(self, "_fb_loader", None) is None:
+            from downstream_evaluation.data.loader import DataLoader
+
+            self._fb_loader = DataLoader(
+                self.data_dir, granularity="daily", resolution=spec.loader_resolution
+            )
+        return self._fb_loader
+
+    def _apply_fallback(self, task, ttype, y_pred, train_td, test_td):
         """Substitute the Linear baseline for non-finite per-user predictions.
 
-        Reproduces the routing the WBM model used to do internally before #38:
-        participants the model could predict keep its output; participants it
-        left non-finite are scored with a Linear baseline fit on the train
-        cohort. For ranking metrics (binary / ordinal) each cohort is
-        percentile-ranked to ``[0, 1]`` independently before merging, so the two
-        independently-fit predictors sit on a common scale; regression merges
-        raw (Pearson r is scale-invariant). Returns ``(y_pred, n_substituted)``.
+        Participants the model could predict keep its output; participants it left
+        non-finite are scored with a Linear baseline fit on the train cohort. For ranking
+        metrics (binary / ordinal) each cohort is percentile-ranked to ``[0, 1]``
+        independently before merging, so the two independently-fit predictors sit on a
+        common scale; regression merges raw (Pearson r is scale-invariant). Returns
+        ``(y_pred, n_substituted)``.
 
-        Only the legacy daily-segment path supplies the ``(n, 24, 38)`` arrays
-        the Linear baseline needs, which is the path WBM uses; a ``data_spec``
-        model that emits non-finite predictions is an unsupported combination.
+        The baseline builds its own daily segments from the data root, so the fallback
+        applies to any model — cache-backed, streaming, or predict-only — not only models
+        that hand the harness raw segments.
         """
-        if spec is not None:
-            raise NotImplementedError(
-                f"Missing-prediction fallback for task {task!r} requires the legacy "
-                "daily-segment path, but the model declares a data_spec. Only the "
-                "WBM (daily) model currently exercises the fallback."
-            )
-        if train_data is None:
-            raise NotImplementedError(
-                f"Missing-prediction fallback for task {task!r} needs train segments to "
-                "fit the Linear baseline, but the model omitted fit()."
-            )
-        from openmhc._protocols import EvalContext
-
         from downstream_evaluation.models.linear import Linear
 
         fb_model = Linear(data_dir=self.data_dir, seed=self.seed)
-        fb_model.set_context(
-            EvalContext(
-                task=task, split=train_td.split, user_ids=train_td.user_ids, dates=train_td.dates
-            )
-        )
-        fb_model.fit(train_data, train_td.labels, ttype)
-        fb_model.set_context(
-            EvalContext(
-                task=task, split=test_td.split, user_ids=test_td.user_ids, dates=test_td.dates
-            )
-        )
-        fb = np.asarray(fb_model.predict(test_data), dtype=np.float64)
+        spec = fb_model.data_spec
+        loader = self._fallback_loader(spec)
+        fb_train = _spec_inputs(loader, spec, train_td, ttype, streaming=False, with_labels=True)
+        fb_test = _spec_inputs(loader, spec, test_td, ttype, streaming=False, with_labels=False)
+        _set_context(fb_model, train_td)
+        fb_model.fit(fb_train, train_td.labels, ttype)
+        _set_context(fb_model, test_td)
+        fb = np.asarray(fb_model.predict(fb_test), dtype=np.float64)
         return _combine_with_fallback(y_pred, fb, ttype)

--- a/src/downstream_evaluation/evaluation/evaluator.py
+++ b/src/downstream_evaluation/evaluation/evaluator.py
@@ -27,14 +27,16 @@ def _metrics_for(task: str, y_true, y_pred, seed: int = 42) -> dict[str, float]:
     ttype = get_task_type(task)
     if ttype == "binary":
         return compute_binary_metrics(y_true, y_pred, seed=seed)
-    # multiclass/ordinal scores discrete class predictions. The uniform ordinal probe
-    # already predicts ints; an end-to-end method may hand back raw floats (e.g. the
-    # hybrid's rank-combined scores, GRU-D's ordinal expected level), so round to int
-    # before scoring (a no-op when predictions are already discrete).
+    # Multiclass accuracy scores discrete class predictions: the uniform probe already
+    # predicts ints, but an end-to-end method may hand back raw floats, so round to int
+    # (a no-op when predictions are already discrete).
     if ttype == "multiclass":
         return compute_multiclass_metrics(y_true, np.round(y_pred).astype(int), seed=seed)
+    # Ordinal uses Spearman's rho, which depends only on rank order. Rounding to int
+    # would collapse the rank-merged fallback scores (percentile-ranked into (0, 1]) to
+    # {0, 1} and destroy the ordering, so score the raw prediction.
     if ttype == "ordinal":
-        return compute_ordinal_metrics(y_true, np.round(y_pred).astype(int), seed=seed)
+        return compute_ordinal_metrics(y_true, y_pred, seed=seed)
     return compute_regression_metrics(y_true, y_pred, seed=seed)
 
 

--- a/src/downstream_evaluation/evaluation/metrics.py
+++ b/src/downstream_evaluation/evaluation/metrics.py
@@ -106,7 +106,6 @@ def compute_binary_metrics(
     """
     if len(np.unique(y_true)) < 2 or np.isnan(y_prob).any() or np.isinf(y_prob).any():
         return {"auprc": float("nan"), "auprc_se": float("nan")}
-    y_prob = np.clip(y_prob, 1e-10, 1.0 - 1e-10)
 
     def _auprc(yt, yp):
         if len(np.unique(yt)) < 2:

--- a/src/downstream_evaluation/evaluation/metrics.py
+++ b/src/downstream_evaluation/evaluation/metrics.py
@@ -94,6 +94,29 @@ def get_task_type(task_name: str) -> str:
         raise ValueError(f"Unknown label type '{label_type}' for task '{task_name}'")
 
 
+def prepare_predictions(task_type: str, raw: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Split a model's raw test output into the ``(y_pred, y_proba)`` a task type needs.
+
+    ``raw`` is the evaluator's per-user output: the positive-class probability for binary
+    tasks, the point prediction otherwise. Returns the prediction the primary metric scores
+    (``y_pred``) and the continuous score (``y_proba``):
+
+    - binary: ``y_pred`` is the 0.5-thresholded class, ``y_proba`` the probability.
+    - multiclass: ``y_pred`` is the rounded integer class.
+    - ordinal / regression: ``y_pred`` stays the continuous score, so rank-based Spearman
+      and Pearson score the raw prediction rather than a class.
+
+    Both the persisted substrate (``write_task_predictions``) and the live metrics
+    (``_metrics_for``) derive their columns here, so the two cannot diverge on this policy.
+    """
+    raw = np.asarray(raw, dtype=np.float64)
+    if task_type == "binary":
+        return (raw >= 0.5).astype(np.int64), raw
+    if task_type == "multiclass":
+        return np.round(raw).astype(np.int64), raw
+    return raw, raw
+
+
 def compute_binary_metrics(
     y_true: np.ndarray, y_prob: np.ndarray, seed: int = _BOOTSTRAP_SEED
 ) -> dict[str, float]:

--- a/src/downstream_evaluation/evaluation/predictions_io.py
+++ b/src/downstream_evaluation/evaluation/predictions_io.py
@@ -55,10 +55,12 @@ def write_task_predictions(
     """Write ``<predictions_dir>/<method>/<task>/test.parquet``.
 
     ``y_pred`` is the evaluator's raw test output: the class-1 probability for
-    binary tasks, the point prediction otherwise. Both the discrete ``y_pred`` and
-    continuous ``y_proba`` columns are derived from it so the bootstrap can read the
-    probability (binary AUPRC) and the point prediction (ordinal Spearman /
-    regression Pearson) it needs per task type.
+    binary tasks, the point prediction otherwise. The ``y_pred`` / ``y_proba``
+    columns are derived from it so the bootstrap can read the probability (binary
+    AUPRC) and the point prediction (ordinal Spearman / regression Pearson) it needs
+    per task type. Binary ``y_pred`` is thresholded and multiclass ``y_pred`` is
+    rounded to an int class; ordinal and regression ``y_pred`` stay continuous so the
+    rank / linear metric scores the raw prediction.
     """
     ttype = get_task_type(task)
     y_true = np.asarray(y_true)
@@ -66,7 +68,12 @@ def write_task_predictions(
     if ttype == "binary":
         y_proba = raw
         y_pred_col = (raw >= 0.5).astype(np.int64)
-    elif ttype in ("ordinal", "multiclass"):
+    elif ttype == "ordinal":
+        # Spearman is rank-based; keep the raw prediction so rank-merged fallback
+        # scores are not collapsed to {0, 1} by an int cast.
+        y_pred_col = raw
+        y_proba = raw
+    elif ttype == "multiclass":
         y_pred_col = np.round(raw).astype(np.int64)
         y_proba = raw
     else:  # regression

--- a/src/downstream_evaluation/evaluation/predictions_io.py
+++ b/src/downstream_evaluation/evaluation/predictions_io.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from downstream_evaluation.evaluation.metrics import get_task_type
+from downstream_evaluation.evaluation.metrics import get_task_type, prepare_predictions
 
 # Five age bands (plus ``unknown``) — the subgroups the fairness analysis slices on.
 _AGE_GROUP_BINS: tuple[tuple[float, float, str], ...] = (
@@ -54,31 +54,15 @@ def write_task_predictions(
 ) -> None:
     """Write ``<predictions_dir>/<method>/<task>/test.parquet``.
 
-    ``y_pred`` is the evaluator's raw test output: the class-1 probability for
-    binary tasks, the point prediction otherwise. The ``y_pred`` / ``y_proba``
-    columns are derived from it so the bootstrap can read the probability (binary
-    AUPRC) and the point prediction (ordinal Spearman / regression Pearson) it needs
-    per task type. Binary ``y_pred`` is thresholded and multiclass ``y_pred`` is
-    rounded to an int class; ordinal and regression ``y_pred`` stay continuous so the
-    rank / linear metric scores the raw prediction.
+    ``y_pred`` is the evaluator's raw test output: the class-1 probability for binary
+    tasks, the point prediction otherwise. The ``y_pred`` / ``y_proba`` columns are derived
+    from it so the bootstrap can read the probability (binary AUPRC) and the point
+    prediction (ordinal Spearman / regression Pearson) it needs per task type. The
+    per-task-type policy lives in ``prepare_predictions``, shared with the live metrics.
     """
     ttype = get_task_type(task)
     y_true = np.asarray(y_true)
-    raw = np.asarray(y_pred, dtype=np.float64)
-    if ttype == "binary":
-        y_proba = raw
-        y_pred_col = (raw >= 0.5).astype(np.int64)
-    elif ttype == "ordinal":
-        # Spearman is rank-based; keep the raw prediction so rank-merged fallback
-        # scores are not collapsed to {0, 1} by an int cast.
-        y_pred_col = raw
-        y_proba = raw
-    elif ttype == "multiclass":
-        y_pred_col = np.round(raw).astype(np.int64)
-        y_proba = raw
-    else:  # regression
-        y_pred_col = raw
-        y_proba = raw
+    y_pred_col, y_proba = prepare_predictions(ttype, y_pred)
 
     df = (
         pd.DataFrame(

--- a/src/downstream_evaluation/models/_feature_align.py
+++ b/src/downstream_evaluation/models/_feature_align.py
@@ -1,0 +1,40 @@
+"""Fail-loud alignment of per-user features to a cohort.
+
+Each embedding/feature model aligns a ``{user_id: vector}`` store to the cohort's
+``user_ids``. A cohort user absent from the store would otherwise be scored from a
+zero-filled row — a fabricated prediction that bypasses the Linear fallback — so the
+models stop instead. This is the single tested implementation of that guard.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def raise_if_missing(model_name: str, missing, store_desc: str) -> None:
+    """Raise if ``missing`` is non-empty, naming the model, the count, and the store.
+
+    ``missing`` is the list of cohort user ids that have no entry in the feature store;
+    ``store_desc`` names that store for the message (e.g. ``"embedding cache"``).
+    """
+    if missing:
+        raise ValueError(
+            f"{model_name}: {len(missing)} cohort user(s) are missing from the {store_desc} "
+            f"(e.g. {list(missing)[:5]}); the cohort lookup and the {store_desc} are out of "
+            "sync."
+        )
+
+
+def aligned_feature_matrix(model_name: str, user_ids, by_user, store_desc: str) -> np.ndarray:
+    """Per-user feature matrix aligned to ``user_ids``; fails loud on a missing user.
+
+    ``by_user`` maps ``str(user_id) -> feature vector`` (all the same length). Returns a
+    ``(len(user_ids), dim)`` float32 matrix whose rows follow ``user_ids``.
+    """
+    missing = [str(u) for u in user_ids if str(u) not in by_user]
+    raise_if_missing(model_name, missing, store_desc)
+    dim = len(next(iter(by_user.values()))) if by_user else 0
+    X = np.zeros((len(user_ids), dim), dtype=np.float32)
+    for i, uid in enumerate(user_ids):
+        X[i] = by_user[str(uid)]
+    return X

--- a/src/downstream_evaluation/models/grud.py
+++ b/src/downstream_evaluation/models/grud.py
@@ -51,7 +51,7 @@ def _scatter_mean(src, index, n_groups):
 class _UserDataset:
     """Torch Dataset of per-user segment groups (one item = one user)."""
 
-    def __init__(self, X, y_by_task, uids, task_names):
+    def __init__(self, X, y_by_task, uids, task_names, empirical_mean=None):
         import torch
         from pypots.data.utils import _parse_delta_torch
         from pypots.imputation.locf import locf_torch
@@ -63,11 +63,18 @@ class _UserDataset:
         self.values = torch.nan_to_num(X_t, nan=0.0)
         self.deltas = _parse_delta_torch(self.missing_mask)
         obs = self.missing_mask
-        self.empirical_mean = torch.nan_to_num(
-            (self.values * obs).reshape(-1, X.shape[2]).sum(0)
-            / obs.reshape(-1, X.shape[2]).sum(0),
-            nan=0.0,
-        )
+        # GRU-D decays long-missing channels toward this per-channel mean — a fitted
+        # statistic, so it must come from the train cohort only. Validation and predict
+        # pass the cached train mean rather than recomputing it on their own (test)
+        # cohort, which would leak test-set statistics into every prediction.
+        if empirical_mean is not None:
+            self.empirical_mean = empirical_mean
+        else:
+            self.empirical_mean = torch.nan_to_num(
+                (self.values * obs).reshape(-1, X.shape[2]).sum(0)
+                / obs.reshape(-1, X.shape[2]).sum(0),
+                nan=0.0,
+            )
         # group segment indices by user (preserve first-seen order)
         order, seen = [], {}
         for i, u in enumerate(uids):
@@ -322,6 +329,7 @@ class GRUD:
         self.seed = seed
         self._trainer = None
         self._segments = None  # {uid: (n_segs, 24, 19)} with NaN at missing
+        self._empirical_mean = None  # train-cohort GRU-D decay target, cached on fit
         self._task_types: dict[str, str] = {}
         self._reg_stats: dict[str, tuple[float, float]] = {}  # task -> (mean, std)
         self._ctx = None  # EvalContext (active task + cohort user_ids), injected per call
@@ -351,15 +359,15 @@ class GRUD:
         self._segments = {u: values[np.asarray(idx)] for u, idx in by_user.items()}
 
     def _provider(self):
-        from downstream_evaluation.data.provider import LOOKUP_BY_GRANULARITY, TaskDataProvider
+        from downstream_evaluation.data.provider import TaskDataProvider, lookup_filename
         from downstream_evaluation.data.splits import load_split_file
         from openmhc._evaluate import _DatasetPaths
 
         paths = _DatasetPaths.from_root(self._data_dir)
-        lookup = str(paths.root / "processed" / LOOKUP_BY_GRANULARITY["daily"])
+        lookup = str(paths.root / "processed" / lookup_filename("daily", full_history=True))
         return TaskDataProvider(lookup, load_split_file(paths.splits_file), granularity="daily")
 
-    def _build_split(self, provider, split, cls_n, reg_tasks, ord_n):
+    def _build_split(self, provider, split, cls_n, reg_tasks, ord_n, empirical_mean=None):
         """Flatten the cohort's per-user segments + per-(task) labels for one split."""
         labels: dict[str, dict[str, float]] = {}
         cohort: set[str] = set()
@@ -386,7 +394,9 @@ class GRUD:
                     y_by_task[t].extend([int(val)] * len(segs))
         X = np.concatenate(Xs, axis=0)
         y_by_task = {t: np.asarray(v) for t, v in y_by_task.items()}
-        return _UserDataset(X, y_by_task, np.asarray(uids, dtype=object), self._tasks)
+        return _UserDataset(
+            X, y_by_task, np.asarray(uids, dtype=object), self._tasks, empirical_mean=empirical_mean
+        )
 
     def fit(self, data, labels, task_type) -> None:
         """Train the shared multi-task model once on the first call.
@@ -437,15 +447,30 @@ class GRUD:
             self._reg_stats[t] = (mu, sd)
 
         train_ds = self._build_split(provider, "train", cls_n, reg_tasks, ord_n)
-        val_ds = self._build_split(provider, "validation", cls_n, reg_tasks, ord_n)
+        self._empirical_mean = train_ds.empirical_mean
+        val_ds = self._build_split(
+            provider, "validation", cls_n, reg_tasks, ord_n, empirical_mean=self._empirical_mean
+        )
         device = "cuda" if torch.cuda.is_available() else "cpu"
         logger.info("GRU-D training: %d train users, device=%s", len(train_ds), device)
         self._trainer = _Trainer(cls_n, reg_tasks, ord_n, device, seed=self.seed)
         self._trainer.fit(train_ds, val_ds, n_steps=24, n_features=N_SENSOR_CHANNELS)
 
     def predict(self, data) -> np.ndarray:
-        """Per-user predictions for the active task, aligned to the cohort ``user_ids``."""
+        """Per-user predictions for the active task, aligned to the cohort ``user_ids``.
+
+        Every cohort user must have a daily segment: a missing one would be silently
+        predicted as 0.0 and scored as a fabricated prediction (bypassing the
+        NaN->Linear fallback), so fail loudly instead.
+        """
         task = self._ctx.task
+        missing = [str(u) for u in self._ctx.user_ids if str(u) not in self._segments]
+        if missing:
+            raise ValueError(
+                f"{self.name}: {len(missing)} cohort user(s) have no daily segment and would "
+                f"be silently zero-filled (e.g. {missing[:5]}); the cohort lookup and the "
+                "segment store are out of sync."
+            )
         users = [str(u) for u in self._ctx.user_ids if str(u) in self._segments]
         # one-user-per-item dataset, in user_ids order, dummy labels.
         Xs, uids = [], []
@@ -460,11 +485,12 @@ class GRUD:
             for t in self._tasks
         }
         ds = _UserDataset(
-            np.concatenate(Xs, axis=0), dummy, np.asarray(uids, dtype=object), self._tasks
+            np.concatenate(Xs, axis=0), dummy, np.asarray(uids, dtype=object), self._tasks,
+            empirical_mean=self._empirical_mean,
         )
         preds = self._trainer.predict(ds, task, self._task_types[task])
         if self._task_types[task] == "regression" and task in self._reg_stats:
             mu, sd = self._reg_stats[task]
             preds = preds * sd + mu  # reverse the train-split z-score
         pred_by_user = dict(zip(ds.user_ids, preds))
-        return np.array([pred_by_user.get(str(u), 0.0) for u in self._ctx.user_ids], dtype=np.float64)
+        return np.array([pred_by_user[str(u)] for u in self._ctx.user_ids], dtype=np.float64)

--- a/src/downstream_evaluation/models/grud.py
+++ b/src/downstream_evaluation/models/grud.py
@@ -23,6 +23,8 @@ import logging
 
 import numpy as np
 
+from downstream_evaluation.models._feature_align import raise_if_missing
+
 logger = logging.getLogger(__name__)
 
 N_SENSOR_CHANNELS = 19
@@ -51,7 +53,7 @@ def _scatter_mean(src, index, n_groups):
 class _UserDataset:
     """Torch Dataset of per-user segment groups (one item = one user)."""
 
-    def __init__(self, X, y_by_task, uids, task_names, empirical_mean=None):
+    def __init__(self, X, y_by_task, uids, task_names, empirical_mean):
         import torch
         from pypots.data.utils import _parse_delta_torch
         from pypots.imputation.locf import locf_torch
@@ -364,18 +366,29 @@ class GRUD:
         from openmhc._evaluate import _DatasetPaths
 
         paths = _DatasetPaths.from_root(self._data_dir)
+        # GRU-D always evaluates on the full-history daily lookup, matching the other daily
+        # models. It is not wired for the forward-windowed ablation, where it would train on
+        # full-history cohorts while being scored on windowed test cohorts; use a different
+        # model for that ablation.
         lookup = str(paths.root / "processed" / lookup_filename("daily", full_history=True))
         return TaskDataProvider(lookup, load_split_file(paths.splits_file), granularity="daily")
 
-    def _build_split(self, provider, split, cls_n, reg_tasks, ord_n, empirical_mean=None):
-        """Flatten the cohort's per-user segments + per-(task) labels for one split."""
+    def _build_split(self, provider, split, cls_n, reg_tasks, ord_n, empirical_mean):
+        """Flatten the cohort's per-user segments + per-(task) labels for one split.
+
+        ``empirical_mean`` is the per-channel decay target: pass ``None`` on the train
+        split to compute it from those users, and the cached train mean on validation and
+        predict so test-set statistics never influence the decay.
+        """
         labels: dict[str, dict[str, float]] = {}
         cohort: set[str] = set()
         for t in self._tasks:
             td = provider.task_data(t, split)
             labels[t] = {str(u): lab for u, lab in zip(td.user_ids, td.labels)}
             cohort.update(labels[t])
-        users = [u for u in sorted(cohort) if u in self._segments]
+        missing = [u for u in sorted(cohort) if u not in self._segments]
+        raise_if_missing(self.name, missing, "segment store")
+        users = sorted(cohort)
         Xs, uids = [], []
         y_by_task = {t: [] for t in self._tasks}
         for u in users:
@@ -446,7 +459,9 @@ class GRUD:
             sd = float(y.std()) if len(y) and y.std() > 1e-8 else 1.0
             self._reg_stats[t] = (mu, sd)
 
-        train_ds = self._build_split(provider, "train", cls_n, reg_tasks, ord_n)
+        train_ds = self._build_split(
+            provider, "train", cls_n, reg_tasks, ord_n, empirical_mean=None
+        )
         self._empirical_mean = train_ds.empirical_mean
         val_ds = self._build_split(
             provider, "validation", cls_n, reg_tasks, ord_n, empirical_mean=self._empirical_mean
@@ -465,13 +480,8 @@ class GRUD:
         """
         task = self._ctx.task
         missing = [str(u) for u in self._ctx.user_ids if str(u) not in self._segments]
-        if missing:
-            raise ValueError(
-                f"{self.name}: {len(missing)} cohort user(s) have no daily segment and would "
-                f"be silently zero-filled (e.g. {missing[:5]}); the cohort lookup and the "
-                "segment store are out of sync."
-            )
-        users = [str(u) for u in self._ctx.user_ids if str(u) in self._segments]
+        raise_if_missing(self.name, missing, "segment store")
+        users = [str(u) for u in self._ctx.user_ids]
         # one-user-per-item dataset, in user_ids order, dummy labels.
         Xs, uids = [], []
         for u in users:

--- a/src/downstream_evaluation/models/lsm2/model.py
+++ b/src/downstream_evaluation/models/lsm2/model.py
@@ -25,6 +25,8 @@ from pathlib import Path
 
 import numpy as np
 
+from downstream_evaluation.models._feature_align import raise_if_missing
+
 logger = logging.getLogger(__name__)
 
 N_CHANNELS = 19
@@ -293,12 +295,7 @@ class LSM2:
                 X[i] = np.mean(vecs, axis=0)
             else:
                 missing.append(str(uid))
-        if missing:
-            raise ValueError(
-                f"LSM2: {len(missing)} cohort user(s) have no cached embedding for any "
-                f"eligible day and would be silently zero-filled (e.g. {missing[:5]}); the "
-                "cohort lookup and the embedding cache are out of sync."
-            )
+        raise_if_missing("LSM2", missing, "embedding cache")
         return X
 
     def fit(self, data, labels, task_type) -> None:

--- a/src/downstream_evaluation/models/lsm2/model.py
+++ b/src/downstream_evaluation/models/lsm2/model.py
@@ -278,13 +278,27 @@ class LSM2:
         logger.info("LSM2 embeddings ready: %d day-embeddings, dim=%d", len(emb), self._dim)
 
     def _encode(self, user_ids, dates) -> np.ndarray:
-        """Per-user mean-pool of the cached LSM2 day-embeddings over each user's eligible days."""
+        """Per-user mean-pool of the cached LSM2 day-embeddings over each user's eligible days.
+
+        A cohort user with no cached embedding for any eligible day would be
+        silently zero-filled and scored as a fabricated prediction (bypassing the
+        NaN->Linear fallback), so fail loudly instead.
+        """
         self._ensure_embeddings()
         X = np.zeros((len(user_ids), self._dim), dtype=np.float32)
+        missing = []
         for i, (uid, ds) in enumerate(zip(user_ids, dates)):
             vecs = [self._by_key[k] for d in ds if (k := (str(uid), str(d)[:10])) in self._by_key]
             if vecs:
                 X[i] = np.mean(vecs, axis=0)
+            else:
+                missing.append(str(uid))
+        if missing:
+            raise ValueError(
+                f"LSM2: {len(missing)} cohort user(s) have no cached embedding for any "
+                f"eligible day and would be silently zero-filled (e.g. {missing[:5]}); the "
+                "cohort lookup and the embedding cache are out of sync."
+            )
         return X
 
     def fit(self, data, labels, task_type) -> None:

--- a/src/downstream_evaluation/models/multirocket.py
+++ b/src/downstream_evaluation/models/multirocket.py
@@ -21,6 +21,8 @@ import logging
 
 import numpy as np
 
+from downstream_evaluation.models._feature_align import aligned_feature_matrix
+
 logger = logging.getLogger(__name__)
 
 N_SENSOR_CHANNELS = 19
@@ -159,24 +161,8 @@ class MultiRocket:
         logger.info("MultiRocket pooled per-user features: %d users, dim=%d", len(self._pooled), dim)
 
     def _features(self, user_ids) -> np.ndarray:
-        """Per-user pooled features aligned to ``user_ids``.
-
-        Every cohort user must have a pooled feature: a missing one would be
-        silently zero-filled and scored as a fabricated prediction (bypassing the
-        NaN->Linear fallback), so fail loudly instead.
-        """
-        missing = [str(u) for u in user_ids if str(u) not in self._pooled]
-        if missing:
-            raise ValueError(
-                f"MultiRocket: {len(missing)} cohort user(s) lack a pooled feature and "
-                f"would be silently zero-filled (e.g. {missing[:5]}); the cohort lookup and "
-                "the segment store are out of sync."
-            )
-        dim = next(iter(self._pooled.values())).shape[0] if self._pooled else 0
-        X = np.zeros((len(user_ids), dim), dtype=np.float32)
-        for i, uid in enumerate(user_ids):
-            X[i] = self._pooled[str(uid)]
-        return X
+        """Per-user pooled features aligned to ``user_ids`` (fails loud on a missing user)."""
+        return aligned_feature_matrix("MultiRocket", user_ids, self._pooled, "segment store")
 
     def fit(self, data, labels, task_type) -> None:
         # ``data`` is unused: MultiRocket pools per user from its own self-loaded

--- a/src/downstream_evaluation/models/multirocket.py
+++ b/src/downstream_evaluation/models/multirocket.py
@@ -159,13 +159,23 @@ class MultiRocket:
         logger.info("MultiRocket pooled per-user features: %d users, dim=%d", len(self._pooled), dim)
 
     def _features(self, user_ids) -> np.ndarray:
-        """Per-user pooled features aligned to ``user_ids`` (missing users → zeros)."""
+        """Per-user pooled features aligned to ``user_ids``.
+
+        Every cohort user must have a pooled feature: a missing one would be
+        silently zero-filled and scored as a fabricated prediction (bypassing the
+        NaN->Linear fallback), so fail loudly instead.
+        """
+        missing = [str(u) for u in user_ids if str(u) not in self._pooled]
+        if missing:
+            raise ValueError(
+                f"MultiRocket: {len(missing)} cohort user(s) lack a pooled feature and "
+                f"would be silently zero-filled (e.g. {missing[:5]}); the cohort lookup and "
+                "the segment store are out of sync."
+            )
         dim = next(iter(self._pooled.values())).shape[0] if self._pooled else 0
         X = np.zeros((len(user_ids), dim), dtype=np.float32)
         for i, uid in enumerate(user_ids):
-            vec = self._pooled.get(str(uid))
-            if vec is not None:
-                X[i] = vec
+            X[i] = self._pooled[str(uid)]
         return X
 
     def fit(self, data, labels, task_type) -> None:

--- a/src/downstream_evaluation/models/tsfm.py
+++ b/src/downstream_evaluation/models/tsfm.py
@@ -32,6 +32,8 @@ from urllib.parse import quote
 
 import numpy as np
 
+from downstream_evaluation.models._feature_align import aligned_feature_matrix
+
 logger = logging.getLogger(__name__)
 
 HOURS_PER_DAY = 24
@@ -453,26 +455,13 @@ class TSFMEncoder:
         return out
 
     def _encode(self, task: str, split: str, user_ids) -> np.ndarray:
-        """Per-user channel-pooled TSFM embedding, aligned to ``user_ids``.
+        """Per-user channel-pooled TSFM embedding aligned to ``user_ids``.
 
-        Every cohort user must have a feature: a missing one would be silently
-        zero-filled and scored as a fabricated prediction (bypassing the
-        NaN->Linear fallback), so fail loudly instead.
+        Fails loud on a cohort user with no cached feature.
         """
         self._ensure_split(split)
         by_user = self._load_task(split, task)
-        missing = [str(u) for u in user_ids if str(u) not in by_user]
-        if missing:
-            raise ValueError(
-                f"{self.name}: {len(missing)} cohort user(s) lack a {task!r} feature and "
-                f"would be silently zero-filled (e.g. {missing[:5]}); the cohort lookup and "
-                "the feature cache are out of sync."
-            )
-        dim = len(next(iter(by_user.values()))) if by_user else 0
-        X = np.zeros((len(user_ids), dim), dtype=np.float32)
-        for i, uid in enumerate(user_ids):
-            X[i] = by_user[str(uid)]
-        return X
+        return aligned_feature_matrix(self.name, user_ids, by_user, "feature cache")
 
     def fit(self, data, labels, task_type) -> None:
         # ``data`` is unused: TSFM self-serves its build-on-miss embedding cache,

--- a/src/downstream_evaluation/models/tsfm.py
+++ b/src/downstream_evaluation/models/tsfm.py
@@ -453,15 +453,25 @@ class TSFMEncoder:
         return out
 
     def _encode(self, task: str, split: str, user_ids) -> np.ndarray:
-        """Per-user channel-pooled TSFM embedding, aligned to ``user_ids``."""
+        """Per-user channel-pooled TSFM embedding, aligned to ``user_ids``.
+
+        Every cohort user must have a feature: a missing one would be silently
+        zero-filled and scored as a fabricated prediction (bypassing the
+        NaN->Linear fallback), so fail loudly instead.
+        """
         self._ensure_split(split)
         by_user = self._load_task(split, task)
+        missing = [str(u) for u in user_ids if str(u) not in by_user]
+        if missing:
+            raise ValueError(
+                f"{self.name}: {len(missing)} cohort user(s) lack a {task!r} feature and "
+                f"would be silently zero-filled (e.g. {missing[:5]}); the cohort lookup and "
+                "the feature cache are out of sync."
+            )
         dim = len(next(iter(by_user.values()))) if by_user else 0
         X = np.zeros((len(user_ids), dim), dtype=np.float32)
         for i, uid in enumerate(user_ids):
-            vec = by_user.get(str(uid))
-            if vec is not None:
-                X[i] = vec
+            X[i] = by_user[str(uid)]
         return X
 
     def fit(self, data, labels, task_type) -> None:

--- a/src/downstream_evaluation/models/wbm/model.py
+++ b/src/downstream_evaluation/models/wbm/model.py
@@ -260,30 +260,40 @@ class WBM:
         self._dim = int(emb.shape[1])
         logger.info("WBM embeddings ready: %d segments, dim=%d", len(emb), self._dim)
 
-    def encode_cohort(self, task: str, td) -> np.ndarray:
+    def encode_cohort(self, task: str, td) -> tuple[np.ndarray, np.ndarray]:
         """Per-user mean-pool of the WBM embeddings over each user's eligible weeks.
 
-        ``td`` is the weekly cohort (the encoder's own cohort); daily users without a
-        weekly embedding are handled by ``WBMProbe.predict`` via the NaN->Linear fallback
-        and never reach here. A weekly-cohort user with no embedding for any eligible week
-        would be silently zero-filled and scored as a fabricated prediction, so fail loudly.
+        ``td`` is the weekly cohort. Returns the pooled embeddings for the users that have
+        at least one weekly embedding, together with a boolean mask (over ``td.user_ids``)
+        marking which users those are. A weekly-cohort user with no embedding for any
+        eligible week is left out; the caller leaves that user's prediction unset so the
+        harness scores it with the Linear baseline — the same path taken by daily users
+        without any weekly embedding.
         """
         self._ensure_embeddings()
-        X = np.zeros((len(td.user_ids), self._dim), dtype=np.float32)
+        rows = []
+        kept = np.zeros(len(td.user_ids), dtype=bool)
         missing = []
         for i, (uid, weeks) in enumerate(zip(td.user_ids, td.dates)):
             vecs = [self._by_key[k] for w in weeks if (k := (str(uid), str(w))) in self._by_key]
             if vecs:
-                X[i] = np.mean(vecs, axis=0)
+                rows.append(np.mean(vecs, axis=0))
+                kept[i] = True
             else:
                 missing.append(str(uid))
         if missing:
-            raise ValueError(
-                f"WBM: {len(missing)} weekly-cohort user(s) have no embedding for any "
-                f"eligible week and would be silently zero-filled (e.g. {missing[:5]}); the "
-                "weekly lookup and the embedding cache are out of sync."
+            logger.warning(
+                "WBM: %d weekly-cohort user(s) have no embedding for any eligible week and "
+                "will be scored with the Linear fallback (e.g. %s); check the weekly lookup "
+                "and the embedding cache if this count is unexpected.",
+                len(missing), missing[:5],
             )
-        return X
+        X = (
+            np.asarray(rows, dtype=np.float32)
+            if rows
+            else np.zeros((0, self._dim), dtype=np.float32)
+        )
+        return X, kept
 
 
 class WBMProbe:
@@ -371,16 +381,25 @@ class WBMProbe:
         import openmhc
 
         wtd = self._weekly_td(self._ctx.task, "train")
-        X = self._wbm.encode_cohort(self._ctx.task, wtd)
-        self._probe = openmhc.LinearProbe(task_type, seed=self.seed).fit(X, wtd.labels)
+        X, kept = self._wbm.encode_cohort(self._ctx.task, wtd)
+        if not kept.any():
+            raise ValueError(
+                f"WBM: no training user in the weekly cohort for task {self._ctx.task!r} has "
+                "an embedding, so the probe cannot be fit; check the weekly lookup and the "
+                "embedding cache."
+            )
+        y = np.asarray(wtd.labels)[kept]
+        self._probe = openmhc.LinearProbe(task_type, seed=self.seed).fit(X, y)
 
     def predict(self, data) -> np.ndarray:
         """Per-user SSL-probe predictions aligned to the daily cohort; NaN for users
         without a weekly embedding (the harness substitutes the Linear baseline)."""
         daily_users = [str(u) for u in self._ctx.user_ids]
         wtd = self._weekly_td(self._ctx.task, self._ctx.split)
-        preds = self._probe.predict(self._wbm.encode_cohort(self._ctx.task, wtd))
-        by_user = dict(zip((str(u) for u in wtd.user_ids), preds))
+        X, kept = self._wbm.encode_cohort(self._ctx.task, wtd)
+        preds = self._probe.predict(X)
+        kept_uids = [str(u) for u, k in zip(wtd.user_ids, kept) if k]
+        by_user = dict(zip(kept_uids, preds))
         out = np.full(len(daily_users), np.nan, dtype=np.float64)
         for i, u in enumerate(daily_users):
             if u in by_user:

--- a/src/downstream_evaluation/models/wbm/model.py
+++ b/src/downstream_evaluation/models/wbm/model.py
@@ -261,13 +261,28 @@ class WBM:
         logger.info("WBM embeddings ready: %d segments, dim=%d", len(emb), self._dim)
 
     def encode_cohort(self, task: str, td) -> np.ndarray:
-        """Per-user mean-pool of the WBM embeddings over each user's eligible weeks."""
+        """Per-user mean-pool of the WBM embeddings over each user's eligible weeks.
+
+        ``td`` is the weekly cohort (the encoder's own cohort); daily users without a
+        weekly embedding are handled by ``WBMProbe.predict`` via the NaN->Linear fallback
+        and never reach here. A weekly-cohort user with no embedding for any eligible week
+        would be silently zero-filled and scored as a fabricated prediction, so fail loudly.
+        """
         self._ensure_embeddings()
         X = np.zeros((len(td.user_ids), self._dim), dtype=np.float32)
+        missing = []
         for i, (uid, weeks) in enumerate(zip(td.user_ids, td.dates)):
             vecs = [self._by_key[k] for w in weeks if (k := (str(uid), str(w))) in self._by_key]
             if vecs:
                 X[i] = np.mean(vecs, axis=0)
+            else:
+                missing.append(str(uid))
+        if missing:
+            raise ValueError(
+                f"WBM: {len(missing)} weekly-cohort user(s) have no embedding for any "
+                f"eligible week and would be silently zero-filled (e.g. {missing[:5]}); the "
+                "weekly lookup and the embedding cache are out of sync."
+            )
         return X
 
 

--- a/src/downstream_evaluation/models/xgboost/model.py
+++ b/src/downstream_evaluation/models/xgboost/model.py
@@ -21,6 +21,7 @@ directory to load it directly instead of rebuilding.
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 
@@ -73,6 +74,11 @@ _PARQUET_NAMES = [
     "pipeline_curve_analysis_user_features.parquet",
     "pipeline_day_dynamics_user_features.parquet",
 ]
+# The curve-analysis features are only valid when their FPCA basis and per-minute
+# imputation means are fit on the training split alone. This sidecar records that a table
+# was built that way; a curve table without it has unknown fit provenance and is rebuilt
+# rather than loaded, so held-out users can never influence their own features.
+_CURVE_FIT_MARKER = "pipeline_curve_analysis_user_features.fitmeta.json"
 # Diagnostic/metadata columns to drop (they would leak coverage info).
 _METADATA_PREFIXES = ("n_", "total_")
 
@@ -209,7 +215,10 @@ def extract_xgboost_features(
         #    is fit on the train split only (transform-all), so test-split curves never
         #    leak into any user's features.
         ca_out = out / "pipeline_curve_analysis_user_features.parquet"
-        if force or not ca_out.exists():
+        ca_marker = out / _CURVE_FIT_MARKER
+        # Rebuild when the table is missing, or when its train-fit marker is absent, so a
+        # table of unknown fit provenance is refit on the training split rather than reused.
+        if force or not ca_out.exists() or not ca_marker.exists():
             from downstream_evaluation.data.splits import load_split_file
 
             train_users = load_split_file(paths.splits_file)["train"]
@@ -219,6 +228,9 @@ def extract_xgboost_features(
                 max_nonwear_minutes=max_nonwear_minutes, variance_filter=variance_filter,
                 cutoff_dates=cutoff_dates, eligible_keys=eligible_keys,
                 fit_user_ids=train_users,
+            )
+            ca_marker.write_text(
+                json.dumps({"fpca_fit_scope": "train", "n_train_users": len(train_users)})
             )
     logger.info("xgboost features written -> %s", out)
 
@@ -300,8 +312,12 @@ class XGBoost:
         if self._index is not None:
             return
         fd = self._resolve_features_dir()
-        if not all((fd / n).exists() for n in _PARQUET_NAMES):
-            logger.info("xgboost feature cache miss at %s — building from raw (CPU)", fd)
+        # A complete cache has every feature table plus the marker showing the curve
+        # features were fit on the training split. Missing either one triggers a rebuild,
+        # so a curve table of unknown fit provenance is never loaded as-is.
+        have_tables = all((fd / n).exists() for n in _PARQUET_NAMES)
+        if not (have_tables and (fd / _CURVE_FIT_MARKER).exists()):
+            logger.info("xgboost feature cache incomplete at %s — building from raw (CPU)", fd)
             extract_xgboost_features(
                 output_dir=str(fd),
                 data_dir=self._data_dir,

--- a/src/downstream_evaluation/models/xgboost/model.py
+++ b/src/downstream_evaluation/models/xgboost/model.py
@@ -204,14 +204,21 @@ def extract_xgboost_features(
                 checkpoint_dir=ckpt_dir, output_path=dd_out, cutoff_dates=cutoff_dates,
             )
 
-        # 3. Curve analysis — independent of the timeseries pipeline.
+        # 3. Curve analysis — independent of the timeseries pipeline. Its cross-user
+        #    preprocessing (FPCA basis, population-mean imputation, basis-mean fallback)
+        #    is fit on the train split only (transform-all), so test-split curves never
+        #    leak into any user's features.
         ca_out = out / "pipeline_curve_analysis_user_features.parquet"
         if force or not ca_out.exists():
+            from downstream_evaluation.data.splits import load_split_file
+
+            train_users = load_split_file(paths.splits_file)["train"]
             build_curve_analysis_features(
                 arrow_dir=arrow_dir, output_path=ca_out,
                 checkpoint_path=out / f"curve_analysis_avg_curves{suffix}.parquet",
                 max_nonwear_minutes=max_nonwear_minutes, variance_filter=variance_filter,
                 cutoff_dates=cutoff_dates, eligible_keys=eligible_keys,
+                fit_user_ids=train_users,
             )
     logger.info("xgboost features written -> %s", out)
 

--- a/src/downstream_evaluation/models/xgboost/pipeline_curve_analysis.py
+++ b/src/downstream_evaluation/models/xgboost/pipeline_curve_analysis.py
@@ -229,9 +229,9 @@ def _compute_averaged_curves(
 # ── Phase B helpers ──────────────────────────────────────────────────────────
 
 
-def _impute_population_mean(matrix: np.ndarray) -> np.ndarray:
-    """Fill NaN values with population mean at each minute position."""
-    col_means = np.nanmean(matrix, axis=0)
+def _impute_population_mean(matrix: np.ndarray, fit_mask: np.ndarray) -> np.ndarray:
+    """Fill NaN values with the train-cohort population mean at each minute position."""
+    col_means = np.nanmean(matrix[fit_mask], axis=0)
     # If entire minute column is NaN, fill with 0
     col_means = np.where(np.isfinite(col_means), col_means, 0.0)
     nan_mask = np.isnan(matrix)
@@ -244,6 +244,7 @@ def _build_sparse_basis_representation(
     n_basis: int = 24,
     smoothing_parameter: float = 1e5,
     min_obs: int = 10,
+    fit_mask: np.ndarray | None = None,
 ) -> FDataBasis:
     """Convert sparse averaged curves to a smooth B-spline basis representation.
 
@@ -257,13 +258,15 @@ def _build_sparse_basis_representation(
     large (~1e5) because the penalty matrix scales with domain range.
 
     Users with fewer than `min_obs` valid points get the population-mean basis
-    representation (fitted from the mean of all valid users' basis coefficients).
+    representation (fitted from the mean of the valid train users' basis coefficients).
 
     Args:
         matrix: (n_users, 1440) array with NaN for missing minutes.
         n_basis: Number of B-spline basis functions (default 24 = ~1 per hour).
         smoothing_parameter: Regularization strength for curvature penalty (default 1e5).
         min_obs: Minimum non-NaN observations to attempt basis fitting.
+        fit_mask: Boolean mask over users selecting the train cohort; the insufficient-obs
+            mean-coefficient fallback is computed from these users only. ``None`` uses all.
 
     Returns:
         FDataBasis with shape (n_users, n_basis).
@@ -325,8 +328,13 @@ def _build_sparse_basis_representation(
         regularization=reg,
     )
 
-    # Compute mean coefficients from valid users for fallback
-    mean_coefficients = fd_valid.coefficients.mean(axis=0, keepdims=True)
+    # Compute mean coefficients from the valid TRAIN users for the fallback, so the
+    # insufficient-obs users' representation does not depend on test-split curves.
+    if fit_mask is None:
+        train_pos = list(range(len(valid_user_indices)))
+    else:
+        train_pos = [j for j, ui in enumerate(valid_user_indices) if fit_mask[ui]]
+    mean_coefficients = fd_valid.coefficients[train_pos].mean(axis=0, keepdims=True)
 
     # Assemble full coefficient matrix (all users, in original order)
     all_coefficients = np.zeros((n_users, n_basis), dtype=np.float64)
@@ -494,6 +502,7 @@ def build_curve_analysis_features(
     variance_filter: bool = True,
     cutoff_dates: dict[str, str] | None = None,
     eligible_keys: set[tuple[str, str]] | None = None,
+    fit_user_ids: set[str] | None = None,
 ) -> pl.DataFrame:
     """Build curve analysis user-level features from Arrow files.
 
@@ -521,6 +530,10 @@ def build_curve_analysis_features(
                          has near-zero variance (flat signal = sensor malfunction).
         cutoff_dates: Optional ``{user_id: "YYYY-MM-DD"}`` per-user data cutoff.
                       Rows with ``date > cutoff_dates[user_id]`` are excluded.
+        fit_user_ids: Train-split user IDs. The cross-user preprocessing (population-mean
+                      imputation, the FPCA eigenbasis, the basis-mean fallback) is fit on
+                      these users only and applied to all, so a held-out user's features do
+                      not depend on test-split data. ``None`` fits on every user (legacy).
 
     Returns:
         DataFrame with user_id + (n_components x 4 channels) FPCA score columns
@@ -599,6 +612,13 @@ def build_curve_analysis_features(
     print("Phase B: Assembling matrices and processing channels...")
     user_ids = curves_df["user_id"].to_list()
     n_users = len(user_ids)
+    # Cross-user preprocessing (imputation means, FPCA eigenbasis, basis-mean fallback)
+    # is fit on the train cohort only; a missing split fits on every user (legacy path).
+    fit_mask = (
+        np.ones(n_users, dtype=bool)
+        if fit_user_ids is None
+        else np.array([str(u) in fit_user_ids for u in user_ids])
+    )
     channel_matrices: dict[str, np.ndarray] = {}  # non-sparse channels (FDataGrid path)
     channel_basis: dict[str, object] = {}  # sparse channels (FDataBasis path)
 
@@ -621,11 +641,12 @@ def build_curve_analysis_features(
                 n_basis=n_basis,
                 smoothing_parameter=smoothing_parameter,
                 min_obs=min_obs,
+                fit_mask=fit_mask,
             )
             channel_basis[ch_info["name"]] = fd_basis
         else:
-            # Non-sparse channel: population-mean imputation (unchanged)
-            matrix = _impute_population_mean(matrix)
+            # Non-sparse channel: train-cohort population-mean imputation
+            matrix = _impute_population_mean(matrix, fit_mask)
             n_nan_after = np.isnan(matrix).sum()
             print(
                 f"  {ch_info['name']}: {n_users}x{MINUTES_PER_DAY}, "
@@ -651,11 +672,13 @@ def build_curve_analysis_features(
         if ch_name in channel_basis:
             # Sparse channel: FPCA on FDataBasis (B-spline smoothed)
             fd = channel_basis[ch_name]
-            scores = fpca.fit_transform(fd)
         else:
             # Non-sparse channel: FPCA on FDataGrid (population-mean imputed)
             fd = FDataGrid(channel_matrices[ch_name], grid_points=grid_points)
-            scores = fpca.fit_transform(fd)
+        # Fit the eigenbasis on the train cohort only, then project every user onto it,
+        # so a held-out user's scores don't depend on a basis fitted with test curves.
+        fpca.fit(fd[fit_mask])
+        scores = fpca.transform(fd)
 
         # Canonicalize component signs. FPCA eigenfunctions are defined only up to sign,
         # and skfda leaves the sign machine/library-version dependent, so the same data can

--- a/src/downstream_evaluation/models/xgboost/pipeline_curve_analysis.py
+++ b/src/downstream_evaluation/models/xgboost/pipeline_curve_analysis.py
@@ -231,6 +231,12 @@ def _compute_averaged_curves(
 
 def _impute_population_mean(matrix: np.ndarray, fit_mask: np.ndarray) -> np.ndarray:
     """Fill NaN values with the train-cohort population mean at each minute position."""
+    if not fit_mask.any():
+        raise ValueError(
+            "no training users are present in the curve cohort, so the per-minute "
+            "population mean cannot be estimated; the split file and the curve data are "
+            "out of sync."
+        )
     col_means = np.nanmean(matrix[fit_mask], axis=0)
     # If entire minute column is NaN, fill with 0
     col_means = np.where(np.isfinite(col_means), col_means, 0.0)
@@ -334,6 +340,11 @@ def _build_sparse_basis_representation(
         train_pos = list(range(len(valid_user_indices)))
     else:
         train_pos = [j for j, ui in enumerate(valid_user_indices) if fit_mask[ui]]
+    if not train_pos:
+        raise ValueError(
+            "no training user has enough observations to fit the basis-mean fallback for "
+            "insufficient-observation users; the split file and the curve data are out of sync."
+        )
     mean_coefficients = fd_valid.coefficients[train_pos].mean(axis=0, keepdims=True)
 
     # Assemble full coefficient matrix (all users, in original order)
@@ -502,7 +513,8 @@ def build_curve_analysis_features(
     variance_filter: bool = True,
     cutoff_dates: dict[str, str] | None = None,
     eligible_keys: set[tuple[str, str]] | None = None,
-    fit_user_ids: set[str] | None = None,
+    *,
+    fit_user_ids: set[str],
 ) -> pl.DataFrame:
     """Build curve analysis user-level features from Arrow files.
 
@@ -530,10 +542,10 @@ def build_curve_analysis_features(
                          has near-zero variance (flat signal = sensor malfunction).
         cutoff_dates: Optional ``{user_id: "YYYY-MM-DD"}`` per-user data cutoff.
                       Rows with ``date > cutoff_dates[user_id]`` are excluded.
-        fit_user_ids: Train-split user IDs. The cross-user preprocessing (population-mean
-                      imputation, the FPCA eigenbasis, the basis-mean fallback) is fit on
-                      these users only and applied to all, so a held-out user's features do
-                      not depend on test-split data. ``None`` fits on every user (legacy).
+        fit_user_ids: Train-split user IDs (required, non-empty). The cross-user
+                      preprocessing (population-mean imputation, the FPCA eigenbasis, the
+                      basis-mean fallback) is fit on these users only and applied to all,
+                      so a held-out user's features do not depend on test-split data.
 
     Returns:
         DataFrame with user_id + (n_components x 4 channels) FPCA score columns
@@ -545,6 +557,12 @@ def build_curve_analysis_features(
     arrow_dir = Path(arrow_dir)
     if not arrow_dir.exists():
         raise FileNotFoundError(f"Directory not found: {arrow_dir}")
+
+    if not fit_user_ids:
+        raise ValueError(
+            "build_curve_analysis_features requires a non-empty fit_user_ids (the training "
+            "split); the FPCA basis and imputation means must be fit on training users only."
+        )
 
     if splits is None:
         splits = ["train", "test", "val"]
@@ -612,13 +630,9 @@ def build_curve_analysis_features(
     print("Phase B: Assembling matrices and processing channels...")
     user_ids = curves_df["user_id"].to_list()
     n_users = len(user_ids)
-    # Cross-user preprocessing (imputation means, FPCA eigenbasis, basis-mean fallback)
-    # is fit on the train cohort only; a missing split fits on every user (legacy path).
-    fit_mask = (
-        np.ones(n_users, dtype=bool)
-        if fit_user_ids is None
-        else np.array([str(u) in fit_user_ids for u in user_ids])
-    )
+    # Cross-user preprocessing (imputation means, FPCA eigenbasis, basis-mean fallback) is
+    # fit on the train cohort only, so a held-out user's features never depend on test curves.
+    fit_mask = np.array([str(u) in fit_user_ids for u in user_ids])
     channel_matrices: dict[str, np.ndarray] = {}  # non-sparse channels (FDataGrid path)
     channel_basis: dict[str, object] = {}  # sparse channels (FDataBasis path)
 

--- a/src/openmhc/_evaluate.py
+++ b/src/openmhc/_evaluate.py
@@ -311,7 +311,9 @@ def evaluate_prediction(
             ``download_dataset`` writes to). If omitted, ``MHC_DATA_DIR`` must
             be set. All sub-paths (`processed/daily_hourly_hf/`, `splits/`,
             `labels/`, etc.) are derived from this root.
-        seed: Random seed for classifiers and splits.
+        seed: Random seed for the per-task bootstrap standard errors and the Linear
+            fallback baseline. The bundled models pin their own classifier seed, so this
+            does not change their point predictions.
         predictions_dir: when set, write per-(method, task) test predictions +
             a shared ``_subgroups.json`` here — the input the paper-metrics
             bootstrap paired-resamples for skill / rank / fairness CIs.

--- a/src/openmhc/_probe.py
+++ b/src/openmhc/_probe.py
@@ -56,24 +56,40 @@ class LinearProbe:
         self._clf = create_model(config, random_state=seed, task_type=task_type)
 
     @staticmethod
-    def _as_features(emb: np.ndarray) -> np.ndarray:
-        """Float32 feature matrix with non-finite values zero-filled (NaN/±inf → 0)."""
+    def _finite_rows(emb: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Return the float32 matrix and a mask of the rows that are entirely finite.
+
+        A row with any NaN/±inf marks a participant the encoder could not represent. Such
+        rows are excluded from fitting and predicted as NaN, so the harness can substitute
+        the Linear baseline for them — the same "emit NaN where you cannot predict"
+        convention the Forecaster protocol uses.
+        """
         x = np.asarray(emb, dtype=np.float32)
-        np.nan_to_num(x, copy=False, nan=0.0, posinf=0.0, neginf=0.0)
-        return x
+        return x, np.isfinite(x).all(axis=1)
 
     def fit(self, embeddings: np.ndarray, labels: np.ndarray) -> LinearProbe:
-        """Fit the probe on training embeddings ``(n, D)`` and their labels ``(n,)``."""
-        self._clf.fit(self._as_features(embeddings), labels)
+        """Fit the probe on training embeddings ``(n, D)`` and their labels ``(n,)``.
+
+        Participants whose embedding is non-finite are dropped from the fit.
+        """
+        x, finite = self._finite_rows(embeddings)
+        self._clf.fit(x[finite], np.asarray(labels)[finite])
         return self
 
     def predict(self, embeddings: np.ndarray) -> np.ndarray:
         """Predict for ``(n, D)`` embeddings.
 
         Returns the class-1 probability for binary tasks and the point prediction
-        otherwise (ordinal labels are integer-valued; regression is continuous).
+        otherwise (ordinal labels are integer-valued; regression is continuous). A
+        participant whose embedding is non-finite is returned as NaN, so the harness scores
+        it with the fallback rather than a fabricated value.
         """
-        x = self._as_features(embeddings)
-        if self.task_type == "binary":
-            return self._clf.predict_proba(x)[:, 1]
-        return self._clf.predict(x)
+        x, finite = self._finite_rows(embeddings)
+        out = np.full(len(x), np.nan, dtype=np.float64)
+        if finite.any():
+            xv = x[finite]
+            if self.task_type == "binary":
+                out[finite] = self._clf.predict_proba(xv)[:, 1]
+            else:
+                out[finite] = self._clf.predict(xv)
+        return out

--- a/src/openmhc/_protocols.py
+++ b/src/openmhc/_protocols.py
@@ -146,6 +146,11 @@ class Method(Protocol):
     def predict(self, data: ParticipantData) -> np.ndarray:
         """Return one prediction per participant, in ``data`` order (the only required method).
 
+        Return ``NaN`` for a participant you cannot score. The harness substitutes the
+        Linear baseline for those participants rather than dropping them, and reports the
+        substituted share as the fallback rate — so a partial-coverage model is scored
+        fairly instead of penalized.
+
         The optional ``fit(data, labels, task_type)`` / ``set_context(ctx)`` hooks are
         documented in the class docstring above; the engine calls each only if defined.
         """

--- a/src/openmhc/models/lsm2/blocks.py
+++ b/src/openmhc/models/lsm2/blocks.py
@@ -100,9 +100,12 @@ class MultiHeadAttention(nn.Module):
 
         Args:
             x: Input tensor of shape (B, N, C)
-            attn_mask: Optional attention mask. Can be:
-                - (B, N) where True/1 is "keep" and False/0 is "mask"
-                - (B, 1, 1, N) additive mask with -inf for masked positions
+            attn_mask: Optional additive attention mask, added to the attention logits
+                (``0`` keeps a key, ``-inf`` masks it). Either:
+                - (B, N): a per-key bias broadcast across queries and heads
+                - (B, 1, 1, N): the same bias in SDPA's 4-D broadcast shape
+                A 0/1 boolean "keep" array is NOT a mask here — it would be added as a small
+                logit bias, not applied as masking.
             rope_fn: Optional callable (q, k) -> (q_rot, k_rot) for rotary pos emb.
 
         Returns:

--- a/tests/test_downstream_fallback.py
+++ b/tests/test_downstream_fallback.py
@@ -99,7 +99,13 @@ def test_wbmprobe_predict_aligns_and_nans_missing():
     m._ctx = types.SimpleNamespace(task="Diabetes", split="test", user_ids=["u0", "u1", "u2", "u3"])
     weekly = types.SimpleNamespace(user_ids=["u1", "u3"])
     m._weekly_td = lambda task, split: weekly
-    m._wbm = types.SimpleNamespace(encode_cohort=lambda task, td: np.zeros((len(td.user_ids), 4)))
+    # encode_cohort returns (embeddings, kept_mask); both weekly users encodable here.
+    m._wbm = types.SimpleNamespace(
+        encode_cohort=lambda task, td: (
+            np.zeros((len(td.user_ids), 4)),
+            np.ones(len(td.user_ids), dtype=bool),
+        )
+    )
     m._probe = types.SimpleNamespace(predict=lambda X: np.array([0.7, 0.9]))
 
     out = m.predict(None)
@@ -109,12 +115,80 @@ def test_wbmprobe_predict_aligns_and_nans_missing():
     assert out[1] == 0.7 and out[3] == 0.9  # weekly users keep the SSL probe output
 
 
+def test_wbmprobe_predict_nans_unencodable_weekly_user():
+    """A weekly-cohort user with no embedding is left NaN (→ Linear fallback), not raised.
+
+    ``encode_cohort`` drops the un-encodable user (mask False) and returns only the rows it
+    could pool, so the corresponding daily prediction stays NaN for the harness to fill.
+    """
+    import types
+
+    from downstream_evaluation.models.wbm import WBMProbe
+
+    m = WBMProbe("/tmp/x")
+    m._ctx = types.SimpleNamespace(task="Diabetes", split="test", user_ids=["u1", "u3"])
+    weekly = types.SimpleNamespace(user_ids=["u1", "u3"])
+    m._weekly_td = lambda task, split: weekly
+    # u1 has an embedding (kept), u3 has none (dropped) → one row of X, mask [True, False].
+    m._wbm = types.SimpleNamespace(
+        encode_cohort=lambda task, td: (np.zeros((1, 4)), np.array([True, False]))
+    )
+    m._probe = types.SimpleNamespace(predict=lambda X: np.array([0.7]))
+
+    out = m.predict(None)
+
+    assert out.shape == (2,)
+    assert out[0] == 0.7  # encodable weekly user keeps its probe output
+    assert np.isnan(out[1])  # un-encodable weekly user → NaN → harness fallback
+
+
+def test_linear_probe_propagates_nan_for_unencodable_rows():
+    """A non-finite embedding row predicts NaN (→ harness fallback) and is dropped from fit."""
+    import openmhc
+
+    rng = np.random.default_rng(0)
+    x = rng.normal(size=(20, 8)).astype(np.float32)
+    y = rng.integers(0, 2, size=20)
+    x_fit = x.copy()
+    x_fit[3] = np.nan  # a training participant the encoder could not represent
+
+    probe = openmhc.LinearProbe("binary", n_components=5, seed=0).fit(x_fit, y)
+
+    x_test = x[:4].copy()
+    x_test[1] = np.nan
+    out = probe.predict(x_test)
+
+    assert np.isnan(out[1])  # non-finite embedding → NaN, so the harness scores it via fallback
+    assert np.all(np.isfinite(np.delete(out, 1)))  # finite rows still score
+
+
+def test_apply_demographics_fails_loud_on_absent_user():
+    """A cohort user absent from the demographic lookup raises, not an all-zero row."""
+    from downstream_evaluation.demo_covariates import apply_demographics
+
+    covs = ["age", "BiologicalSex", "BMI_values"]
+    lookup = {
+        "u0": np.array([40.0, 1.0, 22.0], dtype=np.float32),
+        "u1": np.array([55.0, 0.0, 28.0], dtype=np.float32),
+    }
+    x = np.zeros((2, 3), dtype=np.float32)
+
+    # Fully covered cohort → covariates appended, no error.
+    out = apply_demographics(x, ["u0", "u1"], "Diabetes", lookup, covs)
+    assert out.shape == (2, 6)
+
+    # An absent cohort user → loud failure, not a fabricated all-zero demographic row.
+    with pytest.raises(ValueError, match="out of sync"):
+        apply_demographics(x, ["u0", "u2"], "Diabetes", lookup, covs)
+
+
 def test_missing_feature_fails_loud_not_zero_filled():
     """A cohort user with no extractable feature raises, rather than being scored as zeros.
 
     The silent zero-fill produced a finite prediction that bypassed the NaN->Linear
     fallback and under-counted ``n_fallback``; the guard now fails loudly instead.
-    MultiRocket stands in for the shared pattern (tsfm/lsm2/grud/wbm guard identically).
+    MultiRocket stands in for the shared pattern (tsfm/lsm2/grud guard identically; WBM
+    instead leaves un-encodable users NaN so the harness fallback scores them).
     """
     from downstream_evaluation.models.multirocket import MultiRocket
 

--- a/tests/test_downstream_fallback.py
+++ b/tests/test_downstream_fallback.py
@@ -109,6 +109,28 @@ def test_wbmprobe_predict_aligns_and_nans_missing():
     assert out[1] == 0.7 and out[3] == 0.9  # weekly users keep the SSL probe output
 
 
+def test_missing_feature_fails_loud_not_zero_filled():
+    """A cohort user with no extractable feature raises, rather than being scored as zeros.
+
+    The silent zero-fill produced a finite prediction that bypassed the NaN->Linear
+    fallback and under-counted ``n_fallback``; the guard now fails loudly instead.
+    MultiRocket stands in for the shared pattern (tsfm/lsm2/grud/wbm guard identically).
+    """
+    from downstream_evaluation.models.multirocket import MultiRocket
+
+    m = MultiRocket()
+    m._pooled = {"u0": np.arange(5, dtype=np.float32), "u1": np.ones(5, dtype=np.float32)}
+
+    # Fully covered cohort → aligned feature matrix, no error.
+    x = m._features(["u0", "u1"])
+    assert x.shape == (2, 5)
+    assert np.array_equal(x[0], np.arange(5))
+
+    # An uncovered cohort user → loud failure naming the gap, not a silent zero row.
+    with pytest.raises(ValueError, match="zero-filled|out of sync"):
+        m._features(["u0", "u2"])
+
+
 def test_prediction_results_fallback_fields_default():
     """PredictionResults stays constructible from records alone (additive fields)."""
     pr = PredictionResults(records=[{"task": "t", "metric": "auprc", "value": 0.5}])

--- a/tests/test_ordinal_scoring_and_auprc_clip.py
+++ b/tests/test_ordinal_scoring_and_auprc_clip.py
@@ -69,6 +69,27 @@ def test_ordinal_predictions_persisted_raw(tmp_path):
     assert len(np.unique(stored)) > 2
 
 
+def test_prepare_predictions_policy_per_task_type():
+    """The single source both ladders use to split raw output into (y_pred, y_proba)."""
+    from downstream_evaluation.evaluation.metrics import prepare_predictions
+
+    raw = np.array([-2.0, 0.2, 0.7, 3.5])
+
+    y_pred, y_proba = prepare_predictions("binary", raw)
+    assert np.array_equal(y_pred, (raw >= 0.5).astype(np.int64))
+    assert np.array_equal(y_proba, raw)
+
+    y_pred, y_proba = prepare_predictions("multiclass", np.array([0.4, 1.6, 2.2]))
+    assert np.array_equal(y_pred, np.array([0, 2, 2]))
+    assert y_pred.dtype == np.int64
+    assert np.array_equal(y_proba, np.array([0.4, 1.6, 2.2]))
+
+    for ttype in ("ordinal", "regression"):
+        y_pred, y_proba = prepare_predictions(ttype, raw)
+        assert np.array_equal(y_pred, raw) and np.array_equal(y_proba, raw)
+        assert np.issubdtype(y_pred.dtype, np.floating)
+
+
 def test_binary_auprc_not_clipped_for_score_submissions():
     """AUPRC uses raw scores; out-of-``(0, 1)`` logits are not clamped to a bound."""
     rng = np.random.default_rng(2)

--- a/tests/test_ordinal_scoring_and_auprc_clip.py
+++ b/tests/test_ordinal_scoring_and_auprc_clip.py
@@ -1,0 +1,83 @@
+"""Regression tests for two Track 1 scoring-correctness fixes.
+
+B1 — ordinal predictions must be scored (and persisted) on their RAW rank order, not
+     rounded to int. The rank-merge fallback produces values in ``(0, 1]``; ``np.round``
+     would collapse them to ``{0, 1}`` and turn Spearman's rho into a median-split binary.
+B5 — ``compute_binary_metrics`` must not clip scores into ``[1e-10, 1 - 1e-10]`` before
+     AUPRC. ``average_precision_score`` is rank-based, so clipping ties every out-of-``(0, 1)``
+     score at a bound and distorts the metric for score-valued (logit) submissions.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from scipy.stats import rankdata, spearmanr
+from sklearn.metrics import average_precision_score
+
+from downstream_evaluation.evaluation.evaluator import _metrics_for
+from downstream_evaluation.evaluation.metrics import compute_binary_metrics, get_task_type
+from downstream_evaluation.evaluation.predictions_io import write_task_predictions
+from labels.api import LABEL_NAMES
+
+
+def _an_ordinal_task() -> str:
+    return next(t for t in sorted(LABEL_NAMES) if get_task_type(t) == "ordinal")
+
+
+def test_ordinal_metric_scores_raw_ranks_not_rounded():
+    """Ordinal Spearman is computed on the raw prediction, not ``np.round(pred)``."""
+    task = _an_ordinal_task()
+    rng = np.random.default_rng(0)
+    n = 200
+    y_true = rng.integers(0, 4, size=n)  # ordinal levels 0..3
+    # Simulate a fallback-merged ordinal prediction: distinct percentile ranks in (0, 1].
+    y_pred = rankdata(rng.normal(size=n)) / n
+
+    out = _metrics_for(task, y_true, y_pred, seed=0)
+    expected_raw, _ = spearmanr(y_true, y_pred)
+    collapsed, _ = spearmanr(y_true, np.round(y_pred).astype(int))
+
+    assert out["spearman_r"] == float(expected_raw)
+    # Rounding collapses (0, 1] to {0, 1}; the fix must NOT reproduce that value.
+    assert not np.isclose(out["spearman_r"], collapsed)
+    # np.round(y_pred) would leave <=2 distinct values; the raw prediction keeps its ranks.
+    assert len(np.unique(np.round(y_pred).astype(int))) <= 2
+    assert len(np.unique(y_pred)) > 2
+
+
+def test_ordinal_predictions_persisted_raw(tmp_path):
+    """``write_task_predictions`` stores the raw ordinal ``y_pred`` (the bootstrap reads it)."""
+    task = _an_ordinal_task()
+    rng = np.random.default_rng(1)
+    n = 50
+    uids = [f"u{i}" for i in range(n)]
+    y_true = rng.integers(0, 4, size=n)
+    raw = rankdata(rng.normal(size=n)) / n  # in (0, 1]
+
+    write_task_predictions(tmp_path, "m", task, uids, y_true, raw)
+    safe = task.replace("/", "_").replace(" ", "_")
+    df = pd.read_parquet(tmp_path / "m" / safe / "test.parquet")
+
+    stored = df["y_pred"].to_numpy()
+    raw_by_uid = dict(zip(uids, raw))
+    expected = np.array([raw_by_uid[u] for u in df["uid"]])
+
+    # y_pred keeps the continuous prediction (float), not a {0, 1} int collapse.
+    assert np.issubdtype(stored.dtype, np.floating)
+    assert np.allclose(stored, expected)
+    assert len(np.unique(stored)) > 2
+
+
+def test_binary_auprc_not_clipped_for_score_submissions():
+    """AUPRC uses raw scores; out-of-``(0, 1)`` logits are not clamped to a bound."""
+    rng = np.random.default_rng(2)
+    n = 300
+    y_true = rng.integers(0, 2, size=n)
+    scores = rng.normal(size=n) * 5.0  # logit-scale, many values outside (0, 1)
+
+    out = compute_binary_metrics(y_true, scores, seed=0)
+    assert out["auprc"] == float(average_precision_score(y_true, scores))
+    # The removed clip would have tied every out-of-range score at a bound and moved AUPRC.
+    clipped = np.clip(scores, 1e-10, 1.0 - 1e-10)
+    assert not np.isclose(out["auprc"], average_precision_score(y_true, clipped))

--- a/tools/leaderboard_docs/SCHEMA.md
+++ b/tools/leaderboard_docs/SCHEMA.md
@@ -17,7 +17,7 @@ One row per `(method, task, task_type, subgroup_attr, subgroup_value, user_id)`.
 | `subgroup_value` | string (dict) | `all` for the global cell; otherwise the subgroup level (an age bucket, or a sex value) |
 | `user_id` | string (dict) | pseudonymous participant id — the bootstrap cluster unit |
 | `y_true` | float32 | ground-truth label for the `(task, user)` cell |
-| `y_pred` | float32 | the model's discrete prediction (class for binary/ordinal; point value for regression) |
+| `y_pred` | float32 | the model's prediction, by task type: a thresholded class for binary, and the continuous score for ordinal and regression (ordinal is scored with rank-based Spearman, so the raw score is kept rather than rounded to a class) |
 | `y_proba` | float32 | the model's continuous score — class-1 probability for binary, point prediction otherwise (the column the ranking/correlation metrics read) |
 
 ### Why pairs, not an error

--- a/tools/leaderboard_docs/downstream/SCHEMA.md
+++ b/tools/leaderboard_docs/downstream/SCHEMA.md
@@ -49,7 +49,7 @@ compression.
 | `subgroup_value` | string (dict) | `all` for the global cell; otherwise the subgroup level (age bucket, sex value, or `unknown`) |
 | `user_id` | string (dict) | participant id from the canonical split |
 | `y_true` | float32 | ground-truth label for this `(task, user)` |
-| `y_pred` | float32 | the model's discrete prediction (class for binary/ordinal/multiclass; point value for regression) |
+| `y_pred` | float32 | the model's prediction, by task type: a thresholded class for binary, a rounded class for multiclass, and the continuous score for ordinal and regression (ordinal is scored with rank-based Spearman, so the raw score is kept rather than rounded to a class) |
 | `y_proba` | float32 | the model's continuous score — class-1 probability for binary, point prediction otherwise (the column the ranking/correlation metrics read) |
 
 ### Value semantics


### PR DESCRIPTION
Fixes the 6 correctness issues from the Track 1 review. Bug-for-bug below;
1. **Ordinal preds rounded to {0,1}** — `_combine_with_fallback` rank-merges ordinal
   predictions into (0,1], then the metric + the persisted `y_pred` both did
   `np.round().astype(int)`, collapsing every rank to a binary median-split (incl. the
   model's own finite preds) and propagating into the paper bootstrap + leaderboard.
   **Fix:** score & persist the raw ordinal prediction (Spearman is rank-based; the int
   cast now applies only to multiclass). `evaluator.py`, `predictions_io.py`.
2. **XGBoost FPCA/imputation fit on train+val+test** (transductive). **Fix:** fit on the
   train split only, transform all users (version-aware split lookup).
3. **GRU-D uses the test cohort + wrong lookup** — (a) the decay-to-mean `empirical_mean`
   was recomputed from the test cohort at predict; (b) it read the *windowed* label lookup
   while the engine evaluates full-history. **Fix:** cache the train-split mean and reuse it
   at val/predict; switch to the full-history lookup (matches the other models).
4. **5 models silently zero-fill missing features** → scored as real, bypassing the
   NaN→Linear fallback. **Fix:** the zero-fill is never triggered on the shipped cohort
   (verified: cohort ⊆ feature store for all), but replaced it with a fail-loud `ValueError`
   guard in each model so a future data mismatch can't silently score fabricated predictions.
5. **`np.clip` corrupts AUPRC for score/logit submissions** (ties everything at the bound;
   AUPRC is rank-based and finiteness is already guaranteed). **Fix:** delete the clip.
6. **C2 (`weekly_5of7`) / `label_validity_criterion` documented but unimplemented.**
   **Fix:** dropped C2 + the config promise from the docs; document only the shipped C1 rule.

Closes #78.

Addresses part of #97: fixes the CLAUDE.md task count/default-path/CLI/E501/validity docs, the README downstream multirun example, the `evaluate_prediction(seed=...)` wording, and the LSM2 attention-mask docstring. Does not close #97 because the umbrella still includes unresolved documentation-drift items outside this PR.
