### PR TITLE
Report deterministic point estimates in paper tables (not bootstrap means)

### DIFF
--- a/scripts/paper_results/forecasting/build_forecasting_bootstrap_from_hf.py
+++ b/scripts/paper_results/forecasting/build_forecasting_bootstrap_from_hf.py
@@ -74,6 +74,17 @@ def _reduce_draws(draws: pd.DataFrame, reduction: str, key_cols: list[str]) -> p
         rec.update(_summarize(grp["value"].to_numpy(), CI_LEVEL))
         rows.append(rec)
     return pd.DataFrame(rows)
+
+
+def _assert_point_coverage(df: pd.DataFrame, key_cols: list[str], baseline: str) -> None:
+    """Fail loudly if any non-baseline bootstrap row lacks a deterministic point."""
+    gap = df[(df["model"] != baseline) & df["point"].isna() & df["mean"].notna()]
+    if len(gap):
+        examples = gap[key_cols].drop_duplicates().head(10).to_dict("records")
+        raise SystemExit(
+            f"{len(gap)} bootstrap cells have no deterministic point (scope drift). "
+            f"Examples: {examples}"
+        )
 # The 10 paper models (matches forecasting/bootstrap/draws.meta.json).
 MODELS = [
     "seasonal_naive",
@@ -118,13 +129,29 @@ def main() -> int:
         repo_id=args.repo_id, filename=DRAWS_PATH, repo_type="dataset", revision=args.revision
     )
     draws = pd.read_parquet(draws_path)
-    _reduce_draws(draws, "skill", ["model", "scope"]).to_csv(
-        args.out_dir / "forecasting_skill_score_bootstrap.csv", index=False
+
+    # Deterministic point estimate (the reported center) from the per-user
+    # substrate — the same point flow bootstrap_skill_rank anchors its BCa on.
+    # Merged as a ``point`` column alongside the percentile CI reduced from draws.
+    from forecasting_evaluation.metrics.bootstrap_skill_rank import compute_point_skill_rank
+
+    point = compute_point_skill_rank(
+        models=models,
+        baseline_model=_spec.PAPER_BASELINE,
+        binary_groups=[(name, tuple(idx)) for name, idx in _spec.BINARY_GROUPS],
+        per_user_metrics=substrate,
     )
-    _reduce_draws(draws, "rank", ["model", "scope", "metric"]).to_csv(
-        args.out_dir / "forecasting_grouped_metric_rank_bootstrap.csv", index=False
+    skill_df = _reduce_draws(draws, "skill", ["model", "scope"]).merge(
+        point["skill_scores"], on=["model", "scope"], how="left"
     )
-    print(f"skill/rank reduced from draws ({time.time() - t0:.0f}s)")
+    rank_df = _reduce_draws(draws, "rank", ["model", "scope", "metric"]).merge(
+        point["avg_rankings"], on=["model", "scope", "metric"], how="left"
+    )
+    _assert_point_coverage(skill_df, ["model", "scope"], _spec.PAPER_BASELINE)
+    _assert_point_coverage(rank_df, ["model", "scope", "metric"], _spec.PAPER_BASELINE)
+    skill_df.to_csv(args.out_dir / "forecasting_skill_score_bootstrap.csv", index=False)
+    rank_df.to_csv(args.out_dir / "forecasting_grouped_metric_rank_bootstrap.csv", index=False)
+    print(f"skill/rank reduced from draws + point ({time.time() - t0:.0f}s)")
 
     from labels.api import ENROLLMENT_PATH, LABELS_PATH
 

--- a/scripts/paper_results/forecasting/make_forecasting_latex_tables.py
+++ b/scripts/paper_results/forecasting/make_forecasting_latex_tables.py
@@ -78,13 +78,13 @@ RANK = "forecasting_grouped_metric_rank_bootstrap.csv"
 FAIR = "forecasting_fairness_skill_score_bootstrap.csv"
 
 COLUMNS: list[tuple[str, str, str, str, str, str, bool, bool, bool, str | None]] = [
-    (r"$R \downarrow$",            RANK,  "overall",          "mean",  "ci_lo",  "ci_hi",  False, True,  False, "overall"),
-    (r"$S \uparrow$",              SKILL, "overall_score",    "mean",  "ci_lo",  "ci_hi",  True,  False, True,  None),
+    (r"$R \downarrow$",            RANK,  "overall",          "point", "ci_lo",  "ci_hi",  False, True,  False, "overall"),
+    (r"$S \uparrow$",              SKILL, "overall_score",    "point", "ci_lo",  "ci_hi",  True,  False, True,  None),
     (r"$S_{\text{fair}} \uparrow$",FAIR,  "overall",          "point", "bca_lo", "bca_hi", True,  False, True,  None),
-    (r"Activity\,$\uparrow$",      SKILL, "activity_score",   "mean",  "ci_lo",  "ci_hi",  True,  False, True,  None),
-    (r"Physio.\,$\uparrow$",       SKILL, "physiology_score", "mean",  "ci_lo",  "ci_hi",  True,  False, True,  None),
-    (r"Sleep\,$\uparrow$",         SKILL, "sleep_score",      "mean",  "ci_lo",  "ci_hi",  True,  False, True,  None),
-    (r"Workout\,$\uparrow$",       SKILL, "workout_score",    "mean",  "ci_lo",  "ci_hi",  True,  False, True,  None),
+    (r"Activity\,$\uparrow$",      SKILL, "activity_score",   "point", "ci_lo",  "ci_hi",  True,  False, True,  None),
+    (r"Physio.\,$\uparrow$",       SKILL, "physiology_score", "point", "ci_lo",  "ci_hi",  True,  False, True,  None),
+    (r"Sleep\,$\uparrow$",         SKILL, "sleep_score",      "point", "ci_lo",  "ci_hi",  True,  False, True,  None),
+    (r"Workout\,$\uparrow$",       SKILL, "workout_score",    "point", "ci_lo",  "ci_hi",  True,  False, True,  None),
 ]
 
 NCOL = len(COLUMNS) + 1  # + method column
@@ -98,8 +98,10 @@ We report Average Rank $R$, Aggregate Skill Score $S$
 (in \%; $0=\textsc{Seasonal Naive}$ reference),
 Fairness-adjusted Skill Score $S_{\mathrm{fair}}$, and category-specific
 Skill Scores for \textit{Activity}, \textit{Physiology}, \textit{Sleep},
-and \textit{Workout}. FT denotes fine-tuned. Subscripts and superscripts
-indicate the $95\%$ bootstrap confidence interval based on $1000$ resamples.
+and \textit{Workout}. FT denotes fine-tuned. Values are point estimates on the
+held-out test split; subscripts and superscripts indicate the $95\%$ bootstrap
+confidence interval ($1000$ resamples): the percentile interval for every column
+except $S_{\mathrm{fair}}$, which uses the bias-corrected and accelerated (BCa) interval.
 }
 \label{tab:forecasting_grouped_model_summary}
 

--- a/scripts/paper_results/imputation/make_imputation_latex_tables.py
+++ b/scripts/paper_results/imputation/make_imputation_latex_tables.py
@@ -71,6 +71,9 @@ REDUCED_CSVS = (
     "fairness_skill_score_bootstrap.csv",
 )
 CACHE_MANIFEST = "manifest.json"
+# Bump when the reduced-CSV schema changes so stale caches auto-rebuild.
+# v2: skill/rank CSVs carry a deterministic ``point`` column (was bootstrap mean only).
+CACHE_SCHEMA_VERSION = 2
 
 # ---------------------------------------------------------------------------
 # Method registry: key -> (latex_label, context, model_group)
@@ -108,14 +111,14 @@ METHODS: dict[str, tuple[str, str, str]] = {
 #   lower_better: invert the color gradient (best = lowest)
 #   ref_zero  : LOCF renders as a plain "$0.0$" (skill columns; baseline == 0)
 COLUMNS: list[tuple[str, str, str, str, str, str, bool, bool, bool]] = [
-    (r"$R\downarrow$",            "avg_rankings_bootstrap.csv",          "overall",        "mean",  "ci_lo",  "ci_hi",  False, True,  False),
-    (r"$S\uparrow$",              "skill_scores_bootstrap.csv",          "overall",        "mean",  "ci_lo",  "ci_hi",  True,  False, True),
+    (r"$R\downarrow$",            "avg_rankings_bootstrap.csv",          "overall",        "point", "ci_lo",  "ci_hi",  False, True,  False),
+    (r"$S\uparrow$",              "skill_scores_bootstrap.csv",          "overall",        "point", "ci_lo",  "ci_hi",  True,  False, True),
     (r"$S_{\text{fair}}\uparrow$","fairness_skill_score_bootstrap.csv",  "overall",        "point", "bca_lo", "bca_hi", True,  False, True),
-    (r"Activity\,$\uparrow$",     "skill_scores_bootstrap.csv",          "cat:activity",   "mean",  "ci_lo",  "ci_hi",  True,  False, True),
-    (r"Physio.\,$\uparrow$",      "skill_scores_bootstrap.csv",          "cat:physiology", "mean",  "ci_lo",  "ci_hi",  True,  False, True),
-    (r"Sleep\,$\uparrow$",        "skill_scores_bootstrap.csv",          "cat:sleep",      "mean",  "ci_lo",  "ci_hi",  True,  False, True),
-    (r"Workout\,$\uparrow$",      "skill_scores_bootstrap.csv",          "cat:workouts",   "mean",  "ci_lo",  "ci_hi",  True,  False, True),
-    (r"Semantic\,$\uparrow$",     "skill_scores_bootstrap.csv",          "semantic",       "mean",  "ci_lo",  "ci_hi",  True,  False, True),
+    (r"Activity\,$\uparrow$",     "skill_scores_bootstrap.csv",          "cat:activity",   "point", "ci_lo",  "ci_hi",  True,  False, True),
+    (r"Physio.\,$\uparrow$",      "skill_scores_bootstrap.csv",          "cat:physiology", "point", "ci_lo",  "ci_hi",  True,  False, True),
+    (r"Sleep\,$\uparrow$",        "skill_scores_bootstrap.csv",          "cat:sleep",      "point", "ci_lo",  "ci_hi",  True,  False, True),
+    (r"Workout\,$\uparrow$",      "skill_scores_bootstrap.csv",          "cat:workouts",   "point", "ci_lo",  "ci_hi",  True,  False, True),
+    (r"Semantic\,$\uparrow$",     "skill_scores_bootstrap.csv",          "semantic",       "point", "ci_lo",  "ci_hi",  True,  False, True),
 ]
 
 NCOL = len(COLUMNS) + 1  # + method column
@@ -129,13 +132,13 @@ GROUP_TITLE = {
     "neural": r"\cellcolor[HTML]{EFEFEF}\textit{Neural Models}",
 }
 
-HEADER = r"""\begin{table}[b!]
+HEADER = r"""\begin{table}[t!]
     \vspace{-2mm}
     \renewcommand{\arraystretch}{1.05}
     \centering
     \captionsetup{width=\textwidth}
     \caption{\textbf{Imputation Results.} We report Average Rank $R$, Aggregate Skill Score $S$ (in \%; $0=\TN{LOCF}$ reference), Fairness Skill Score $S_{\text{fair}}$, and Channel-Specific Skill Scores for the following channels: \textit{Activity, Physiology, Sleep, Workout}. Finally, we also report performance on all \textit{Semantic} masking approaches (see Appendix \ref{sec:imputation}). Single-day imputation method results are in the upper section of the table; long-context imputation method results ($\geq 7\times 1440$ time steps) are below. %
-    Sub/superscripts give the $95\%$ bootstrap confidence interval ($1000$ resamples); $S_{\text{fair}}$ uses the bias-corrected and accelerated (BCa) interval about its point estimate, all other columns the percentile interval about the bootstrap mean. \kwz{CAPTION}
+    Values are point estimates on the held-out test split; sub/superscripts give the $95\%$ bootstrap confidence interval ($1000$ resamples): the percentile interval for every column except $S_{\text{fair}}$, which uses the bias-corrected and accelerated (BCa) interval. \kwz{CAPTION}
     }
     \label{tab:imputation_main_results}
     \small
@@ -249,14 +252,20 @@ def build_body(cols: list[dict[str, tuple[float, float, float]]]) -> str:
             lines.append(rf"    \multicolumn{{{NCOL}}}{{l}}{{{GROUP_TITLE[grp]}}} \\")
 
             members = [m for m, (_, c, g) in METHODS.items() if c == ctx and g == grp]
-            # order by overall skill (column index 1) descending
-            members.sort(key=lambda m: -cols[1][m][0])
+            # order by overall skill (column index 1) descending; the reference
+            # (LOCF) has no skill point, so fall back to 0 for ordering.
+            members.sort(key=lambda m: -cols[1].get(m, (0.0, 0.0, 0.0))[0])
 
             for m in members:
                 label = METHODS[m][0]
                 cells = []
                 for ci, col in enumerate(COLUMNS):
                     _h, _f, _sc, _ctr, _lo, _hi, scale100, lower, ref_zero = col
+                    # The reference renders as a plain $0.0$ in ref_zero columns and
+                    # carries no point there, so don't require a data cell for it.
+                    if ref_zero and m == REFERENCE:
+                        cells.append(fmt_cell(m, 0.0, 0.0, 0.0, scale100, ref_zero, 0, False))
+                        continue
                     center, lo, hi = cols[ci][m]
                     vmin, vmax = bounds[ci]
                     n = intensity(center, vmin, vmax, lower)
@@ -312,8 +321,15 @@ def _remote_fingerprint(repo_id: str, revision: str | None) -> dict[str, str]:
 
 
 def _cache_key(fingerprint: dict[str, str]) -> str:
-    """md5 over the sorted (path, sha256) pairs — the cache identity."""
-    payload = json.dumps(fingerprint, sort_keys=True).encode()
+    """md5 over the sorted (path, sha256) pairs + schema version — the cache identity.
+
+    ``CACHE_SCHEMA_VERSION`` is folded in so that a change to the reduced-CSV
+    schema (e.g. adding the deterministic ``point`` column) invalidates old
+    caches automatically, without needing ``--force``.
+    """
+    payload = json.dumps(
+        {"schema": CACHE_SCHEMA_VERSION, "files": fingerprint}, sort_keys=True
+    ).encode()
     return hashlib.md5(payload).hexdigest()
 
 
@@ -322,6 +338,27 @@ def _cache_is_valid(cache_dir: Path) -> bool:
     if not (cache_dir / CACHE_MANIFEST).is_file():
         return False
     return all((cache_dir / name).is_file() for name in REDUCED_CSVS)
+
+
+def _attach_point(boot, point, *, reference: str = "locf"):
+    """Left-merge the deterministic ``point`` onto a bootstrap summary table.
+
+    Merges on ``(method, scope)``. Fails loudly if any non-reference bootstrap cell
+    lacks a matching point (a scope-vocabulary drift between the deterministic and
+    bootstrap reducers). The reference method (LOCF) is exempt: it has no skill point
+    (skill vs self is 0 by construction) and renders as ``$0.0$``.
+    """
+    merged = boot.merge(point, on=["method", "scope"], how="left")
+    gap = merged[
+        (merged["method"] != reference) & merged["mean"].notna() & merged["point"].isna()
+    ]
+    if len(gap):
+        examples = gap[["method", "scope"]].drop_duplicates().head(10).to_dict("records")
+        raise ValueError(
+            f"{len(gap)} bootstrap cells have no deterministic point "
+            f"(scope drift between reducers). Examples: {examples}"
+        )
+    return merged
 
 
 def _build_reduced_csvs(
@@ -340,6 +377,7 @@ def _build_reduced_csvs(
 
     from imputation_evaluation.evaluation.bootstrap_skill_rank import (
         aggregate_skill_rank_fairness,
+        compute_point_skill_rank,
         read_draws_parquet,
     )
 
@@ -397,6 +435,25 @@ def _build_reduced_csvs(
         bca=True,
         per_user_df=per_user_df,
     )
+
+    # Deterministic point estimate for skill / rank (the reported center), from the
+    # same leaderboard reducers on the unresampled ``subgroup_attr == "all"`` cohort.
+    # Attached as a ``point`` column alongside the bootstrap percentile CI.
+    # CRITICAL: average rank is a cross-method statistic, so the point must be
+    # computed over the SAME method pool as the bootstrap draws. The per-method
+    # substrate on HF may carry extra methods (e.g. the dense ``lsm2_weekly``) that
+    # are absent from this table's draws; including them would shift every rank.
+    logger.info("Computing deterministic skill / rank point estimates …")
+    draw_methods = set(tables["avg_rankings"]["method"].astype(str)) | set(
+        tables["skill_scores"]["method"].astype(str)
+    )
+    pu_all = per_user_df[
+        (per_user_df["subgroup_attr"] == "all")
+        & (per_user_df["method"].astype(str).isin(draw_methods))
+    ].rename(columns={"E_per_user": "E"})
+    point = compute_point_skill_rank(pu_all, baseline_method="locf")
+    tables["skill_scores"] = _attach_point(tables["skill_scores"], point["skill_scores"])
+    tables["avg_rankings"] = _attach_point(tables["avg_rankings"], point["avg_rankings"])
 
     cache_dir.mkdir(parents=True, exist_ok=True)
     tables["skill_scores"].to_csv(

--- a/scripts/paper_results/imputation/make_imputation_latex_tables.py
+++ b/scripts/paper_results/imputation/make_imputation_latex_tables.py
@@ -340,13 +340,16 @@ def _cache_is_valid(cache_dir: Path) -> bool:
     return all((cache_dir / name).is_file() for name in REDUCED_CSVS)
 
 
-def _attach_point(boot, point, *, reference: str = "locf"):
+def _attach_point(boot, point, *, reference: str):
     """Left-merge the deterministic ``point`` onto a bootstrap summary table.
 
     Merges on ``(method, scope)``. Fails loudly if any non-reference bootstrap cell
     lacks a matching point (a scope-vocabulary drift between the deterministic and
     bootstrap reducers). The reference method (LOCF) is exempt: it has no skill point
     (skill vs self is 0 by construction) and renders as ``$0.0$``.
+
+    ``reference`` is required (not defaulted) so a caller with a different baseline
+    can never silently mis-exempt the wrong method.
     """
     merged = boot.merge(point, on=["method", "scope"], how="left")
     gap = merged[
@@ -359,6 +362,38 @@ def _attach_point(boot, point, *, reference: str = "locf"):
             f"(scope drift between reducers). Examples: {examples}"
         )
     return merged
+
+
+def attach_skill_rank_point(tables, per_user_df, *, baseline):
+    """Attach the deterministic ``point`` column to the skill / rank bootstrap tables.
+
+    Shared by the main and skill-by-scenario table generators. The point is computed
+    by :func:`compute_point_skill_rank` over:
+
+    * the **test** split only — matching the bootstrap draws and the fairness point;
+    * the **same method pool** as the draws — average rank is a cross-method
+      statistic, so an extra method in the per-method substrate (e.g. the dense
+      ``lsm2_weekly`` absent from the main table's draws) would shift every rank.
+
+    Returns ``(skill_scores, avg_rankings)``, each with a ``point`` column
+    left-merged on via :func:`_attach_point`.
+    """
+    from imputation_evaluation.evaluation.bootstrap_skill_rank import (
+        compute_point_skill_rank,
+    )
+
+    draw_methods = set(tables["avg_rankings"]["method"].astype(str)) | set(
+        tables["skill_scores"]["method"].astype(str)
+    )
+    pu_all = per_user_df[
+        (per_user_df["subgroup_attr"] == "all")
+        & (per_user_df["split"] == "test")
+        & (per_user_df["method"].astype(str).isin(draw_methods))
+    ].rename(columns={"E_per_user": "E"})
+    point = compute_point_skill_rank(pu_all, baseline_method=baseline)
+    skill = _attach_point(tables["skill_scores"], point["skill_scores"], reference=baseline)
+    rank = _attach_point(tables["avg_rankings"], point["avg_rankings"], reference=baseline)
+    return skill, rank
 
 
 def _build_reduced_csvs(
@@ -377,7 +412,6 @@ def _build_reduced_csvs(
 
     from imputation_evaluation.evaluation.bootstrap_skill_rank import (
         aggregate_skill_rank_fairness,
-        compute_point_skill_rank,
         read_draws_parquet,
     )
 
@@ -436,24 +470,13 @@ def _build_reduced_csvs(
         per_user_df=per_user_df,
     )
 
-    # Deterministic point estimate for skill / rank (the reported center), from the
-    # same leaderboard reducers on the unresampled ``subgroup_attr == "all"`` cohort.
-    # Attached as a ``point`` column alongside the bootstrap percentile CI.
-    # CRITICAL: average rank is a cross-method statistic, so the point must be
-    # computed over the SAME method pool as the bootstrap draws. The per-method
-    # substrate on HF may carry extra methods (e.g. the dense ``lsm2_weekly``) that
-    # are absent from this table's draws; including them would shift every rank.
+    # Deterministic point estimate for skill / rank (the reported center), attached
+    # as a ``point`` column alongside the bootstrap percentile CI. See
+    # ``attach_skill_rank_point`` for the test-split + method-pool invariants.
     logger.info("Computing deterministic skill / rank point estimates …")
-    draw_methods = set(tables["avg_rankings"]["method"].astype(str)) | set(
-        tables["skill_scores"]["method"].astype(str)
+    tables["skill_scores"], tables["avg_rankings"] = attach_skill_rank_point(
+        tables, per_user_df, baseline="locf"
     )
-    pu_all = per_user_df[
-        (per_user_df["subgroup_attr"] == "all")
-        & (per_user_df["method"].astype(str).isin(draw_methods))
-    ].rename(columns={"E_per_user": "E"})
-    point = compute_point_skill_rank(pu_all, baseline_method="locf")
-    tables["skill_scores"] = _attach_point(tables["skill_scores"], point["skill_scores"])
-    tables["avg_rankings"] = _attach_point(tables["avg_rankings"], point["avg_rankings"])
 
     cache_dir.mkdir(parents=True, exist_ok=True)
     tables["skill_scores"].to_csv(

--- a/scripts/paper_results/imputation/make_imputation_skill_by_scenario_table.py
+++ b/scripts/paper_results/imputation/make_imputation_skill_by_scenario_table.py
@@ -64,17 +64,17 @@ METHODS: dict[str, tuple[str, str, str]] = {
 }
 
 # (header, source, scope, center, scale100, lower_better, ref_zero)
-#   source: "skill" | "rank" | "fair"
+#   source: "skill" | "rank" | "fair"; center is always the deterministic "point".
 COLUMNS = [
-    (r"$S\uparrow$", "skill", "overall", "mean", True, False, True),
-    (r"$R\downarrow$", "rank", "overall", "mean", False, True, False),
+    (r"$S\uparrow$", "skill", "overall", "point", True, False, True),
+    (r"$R\downarrow$", "rank", "overall", "point", False, True, False),
     (r"$S_{\text{fair}}\uparrow$", "fair", "overall", "point", True, False, True),
-    (r"Random noise\,$\uparrow$", "skill", "random_noise", "mean", True, False, True),
-    (r"Temporal slice\,$\uparrow$", "skill", "temporal_slice", "mean", True, False, True),
-    (r"Signal slice\,$\uparrow$", "skill", "signal_slice", "mean", True, False, True),
-    (r"Sleep gap\,$\uparrow$", "skill", "sleep_gap", "mean", True, False, True),
-    (r"Workout gap\,$\uparrow$", "skill", "workout_gap", "mean", True, False, True),
-    (r"Intensity failure\,$\uparrow$", "skill", "intensity_failure", "mean", True, False, True),
+    (r"Random noise\,$\uparrow$", "skill", "random_noise", "point", True, False, True),
+    (r"Temporal slice\,$\uparrow$", "skill", "temporal_slice", "point", True, False, True),
+    (r"Signal slice\,$\uparrow$", "skill", "signal_slice", "point", True, False, True),
+    (r"Sleep gap\,$\uparrow$", "skill", "sleep_gap", "point", True, False, True),
+    (r"Workout gap\,$\uparrow$", "skill", "workout_gap", "point", True, False, True),
+    (r"Intensity failure\,$\uparrow$", "skill", "intensity_failure", "point", True, False, True),
 ]
 NCOL = len(COLUMNS) + 1
 
@@ -91,7 +91,7 @@ HEADER_TMPL = r"""\begin{table}[t!]
     \renewcommand{\arraystretch}{1.05}
     \centering
     \captionsetup{width=\textwidth}
-    \caption{\textbf{Imputation Results by Masking Scenario.} Aggregate Skill Score $S$ (in \%; $0=$LOCF reference), Average Rank $R$, Fairness Skill Score $S_{\text{fair}}$ (disparity-ratio; see Appendix~\ref{sec:fairness_adjusted_score}), and per-scenario Skill Scores across all six masking scenarios (lower is better for $R$; higher otherwise). Single-day methods above; long-context methods ($\geq 7\times 1440$ time steps) below. Gradients computed within each track. Values are bootstrap means $\pm$ SE ($B{=}1000$); $S_{\text{fair}}$ is the point estimate $\pm$ bootstrap SE.}
+    \caption{\textbf{Imputation Results by Masking Scenario.} Aggregate Skill Score $S$ (in \%; $0=$LOCF reference), Average Rank $R$, Fairness Skill Score $S_{\text{fair}}$ (disparity-ratio; see Appendix~\ref{app:fairness_skillscore}), and per-scenario Skill Scores across all six masking scenarios (lower is better for $R$; higher otherwise). Single-day methods above; long-context methods ($\geq 7\times 1440$ time steps) below. Gradients computed within each track. Values are point estimates on the held-out test split; sub/superscripts give the $95\%$ bootstrap confidence interval ($B{=}1000$): the percentile interval for every column except $S_{\text{fair}}$, which uses the bias-corrected and accelerated (BCa) interval.}
     \label{tab:imputation_appendix_skill_by_scenario}
     \small
     \setlength{\tabcolsep}{1.5pt}
@@ -127,17 +127,17 @@ def reduce_from_hf(repo_id: str, revision: str | None) -> dict[str, dict[tuple[s
 
     from imputation_evaluation.evaluation.bootstrap_skill_rank import (
         aggregate_skill_rank_fairness,
+        compute_point_skill_rank,
         read_draws_parquet,
     )
 
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
     from aggregate_fairness_skill_score import (  # noqa: E402
-        BCA_HEADLINE_SCOPES,
         SENSITIVE_ATTRS,
-        _fair_points_by_key,
-        _per_user_to_per_cell_E,
         compute_fairness_skill_scores,
     )
+    from make_imputation_latex_tables import _attach_point  # noqa: E402
 
     draws_path = hf_hub_download(
         repo_id=repo_id, filename=DRAWS_PATH, repo_type="dataset", revision=revision
@@ -156,62 +156,49 @@ def reduce_from_hf(repo_id: str, revision: str | None) -> dict[str, dict[tuple[s
         for m in METHODS
     ]
     per_user_df = pd.concat(per_method, ignore_index=True)
-    # Fairness SE from the (cheap) percentile bootstrap; the CENTER is the
-    # deterministic point estimate (matches the main table, which uses point).
-    # We compute the point directly via _fair_points_by_key — the BCa jackknife
-    # (the slow part) is unnecessary since this table renders point +/- SE.
+
+    # Deterministic point (the reported center) for skill / rank, from the same
+    # leaderboard reducers on the unresampled all/all cohort; percentile CI comes
+    # from the bootstrap summary.
+    # Average rank is cross-method: compute the point over the same method pool as
+    # the bootstrap draws (restrict the substrate to those methods).
+    draw_methods = set(tables["avg_rankings"]["method"].astype(str)) | set(
+        tables["skill_scores"]["method"].astype(str)
+    )
+    pu_all = per_user_df[
+        (per_user_df["subgroup_attr"] == "all")
+        & (per_user_df["method"].astype(str).isin(draw_methods))
+    ].rename(columns={"E_per_user": "E"})
+    point = compute_point_skill_rank(pu_all, baseline_method=REFERENCE)
+    skill_tbl = _attach_point(tables["skill_scores"], point["skill_scores"])
+    rank_tbl = _attach_point(tables["avg_rankings"], point["avg_rankings"])
+
+    # Fairness: deterministic point + BCa interval (matches the main table). The
+    # BCa jackknife needs the per-user substrate.
     fairness = compute_fairness_skill_scores(
-        draws_df, attrs=list(SENSITIVE_ATTRS), baseline_method=REFERENCE, bca=False,
+        draws_df, attrs=list(SENSITIVE_ATTRS), baseline_method=REFERENCE,
+        bca=True, per_user_df=per_user_df,
     )
-    # B.2: drop per-channel binary ch_7..ch_18 (sleep/workouts reach fairness only
-    # via cat_collapsed:*), matching compute_fairness_skill_scores' point flow.
-    pu = per_user_df
-    drop = pu["channel"].astype(str).str.match(r"^ch_(?:[7-9]|1[0-8])$") & (
-        pu["channel_type"].astype(str) == "binary"
-    )
-    per_cell = _per_user_to_per_cell_E(pu[~drop & (pu["split"] == "test")])
-    points = _fair_points_by_key(
-        per_cell, attrs=list(SENSITIVE_ATTRS), baseline_method=REFERENCE,
-        clip_lower=1e-2, clip_upper=100.0, scopes=BCA_HEADLINE_SCOPES,
-    )
+    fairness = fairness[(fairness["scope"] == "overall") & (fairness["split"] == "test")]
 
-    fair_se: dict[str, float] = {}
-    fair_rows = fairness[(fairness["scope"] == "overall") & (fairness["split"] == "test")]
-    for _, r in fair_rows.iterrows():
-        m = r["method"]
-        fair_se[m] = _require_finite_float(
-            r.get("se"), f"fairness SE for method={m!r}, scope='overall'"
-        )
+    out: dict[str, dict[tuple[str, str], tuple[float, float, float]]] = {m: {} for m in METHODS}
 
-    out: dict[str, dict[tuple[str, str], tuple[float, float]]] = {m: {} for m in METHODS}
-
-    def _ingest(df, source, center_col):
-        sub = df[df["split"] == "test"]
-        for _, r in sub.iterrows():
+    def _ingest(df, source, center_col, lo_col, hi_col):
+        for _, r in df[df["split"] == "test"].iterrows():
             m = r["method"]
             if m not in out:
                 continue
             c = r.get(center_col)
-            if c is None:
-                continue
-            c = float(c)
-            if not math.isfinite(c):
-                continue
-            se = r.get("se")
+            if c is None or not math.isfinite(float(c)):
+                continue  # e.g. LOCF has no skill point (rendered as $0.0$)
             scope = str(r["scope"])
-            se = _require_finite_float(
-                se, f"{source} SE for method={m!r}, scope={scope!r}"
-            )
-            out[m][(source, scope)] = (c, se)
+            lo = _require_finite_float(r.get(lo_col), f"{source} lo for method={m!r}, scope={scope!r}")
+            hi = _require_finite_float(r.get(hi_col), f"{source} hi for method={m!r}, scope={scope!r}")
+            out[m][(source, scope)] = (float(c), lo, hi)
 
-    _ingest(tables["skill_scores"], "skill", "mean")
-    _ingest(tables["avg_rankings"], "rank", "mean")
-    for m in METHODS:
-        pt = points.get((m, "overall"))
-        if pt is not None:
-            if m not in fair_se:
-                raise ValueError(f"Missing fairness SE for method={m!r}, scope='overall'")
-            out[m][("fair", "overall")] = (float(pt), fair_se[m])
+    _ingest(skill_tbl, "skill", "point", "ci_lo", "ci_hi")
+    _ingest(rank_tbl, "rank", "point", "ci_lo", "ci_hi")
+    _ingest(fairness, "fair", "point", "bca_lo", "bca_hi")
     return out
 
 
@@ -222,17 +209,18 @@ def intensity(value: float, vmin: float, vmax: float, lower_better: bool) -> int
     return round(frac * 100)
 
 
-def fmt_cell(method, center, se, scale100, ref_zero, n, is_best) -> str:
+def fmt_cell(method, center, lo, hi, scale100, ref_zero, n, is_best) -> str:
+    """One LaTeX cell: optional color + ``$value^{+upper}_{-lower}$`` (percentile/BCa CI)."""
     if ref_zero and method == REFERENCE:
         return r"$0.0$"
     center = _require_finite_float(center, f"center for method={method!r}")
-    se = _require_finite_float(se, f"SE for method={method!r}")
     s = 100.0 if scale100 else 1.0
     num = f"{center * s:+.1f}" if scale100 else f"{center * s:.1f}"
-    se_s = f"{se * s:.1f}"
+    up = f"{(hi - center) * s:.1f}"
+    down = f"{(center - lo) * s:.1f}"
     body = rf"\mathbf{{{num}}}" if is_best else num
     color = rf"\cellcolor{{customblue!{n}}}" if n > 0 else ""
-    return rf"{color}${body}{{\scriptstyle \pm {se_s}}}$"
+    return rf"{color}${body}^{{+{up}}}_{{-{down}}}$"
 
 
 def build_body(data) -> str:
@@ -252,21 +240,24 @@ def build_body(data) -> str:
                 lines.append(r"    \hline")
             lines.append(rf"    \multicolumn{{{NCOL}}}{{l}}{{{GROUP_TITLE[grp]}}} \\")
             members = [m for m in section if METHODS[m][2] == grp]
-            members.sort(key=lambda m: -data[m].get(("skill", "overall"), (0.0, 0.0))[0])
+            members.sort(key=lambda m: -data[m].get(("skill", "overall"), (0.0, 0.0, 0.0))[0])
             for m in members:
                 cells = []
                 for ci, (_h, src, scope, _ctr, scale100, lower, ref_zero) in enumerate(COLUMNS):
+                    if ref_zero and m == REFERENCE:
+                        cells.append(fmt_cell(m, 0.0, 0.0, 0.0, scale100, ref_zero, 0, False))
+                        continue
                     key = (src, scope)
                     if key not in data[m]:
                         raise ValueError(
                             f"Missing table cell for method={m!r}, source={src!r}, scope={scope!r}"
                         )
-                    center, se = data[m][key]
+                    center, lo, hi = data[m][key]
                     vmin, vmax = bounds[ci]
                     n = intensity(center, vmin, vmax, lower)
                     best_val = vmin if lower else vmax
                     is_best = (center == best_val) and (m != REFERENCE)
-                    cells.append(fmt_cell(m, center, se, scale100, ref_zero, n, is_best))
+                    cells.append(fmt_cell(m, center, lo, hi, scale100, ref_zero, n, is_best))
                 lines.append(rf"    {METHODS[m][0]} & " + " & ".join(cells) + r" \\")
     return "\n".join(lines) + "\n"
 

--- a/scripts/paper_results/imputation/make_imputation_skill_by_scenario_table.py
+++ b/scripts/paper_results/imputation/make_imputation_skill_by_scenario_table.py
@@ -11,15 +11,15 @@ substrate parquets — so all rows are ranked within one consistent 17-method po
 Columns: Aggregate Skill Score $S$, Average Rank $R$, Fairness Skill Score
 $S_{\\text{fair}}$ (the **disparity-ratio** score used by the main table — the
 deprecated $S-\\lambda\\bar D$ score and its $\\bar D$ column are dropped), and
-per-scenario Skill Scores for the six masking scenarios. Values are bootstrap
-mean $\\pm$ SE ($B{=}1000$); $S_{\\text{fair}}$ is the deterministic point
-estimate $\\pm$ bootstrap SE.
+per-scenario Skill Scores for the six masking scenarios. Values are deterministic
+point estimates on the held-out test split; sub/superscripts give the $95\\%$
+bootstrap confidence interval ($B{=}1000$): the percentile interval for every
+column except $S_{\\text{fair}}$, which uses the BCa interval.
 
 Reductions are the canonical ones (``aggregate_skill_rank_fairness`` for
 skill/rank, ``compute_fairness_skill_scores`` for the disparity-ratio fairness),
 identical to ``make_imputation_latex_tables.py`` but over the dense-weekly
-superset and with ``bca=False`` (the table renders $\\pm$SE, so the BCa jackknife
-is unnecessary).
+superset.
 
 Usage:
     python scripts/paper_results/imputation/make_imputation_skill_by_scenario_table.py \
@@ -127,7 +127,6 @@ def reduce_from_hf(repo_id: str, revision: str | None) -> dict[str, dict[tuple[s
 
     from imputation_evaluation.evaluation.bootstrap_skill_rank import (
         aggregate_skill_rank_fairness,
-        compute_point_skill_rank,
         read_draws_parquet,
     )
 
@@ -137,7 +136,7 @@ def reduce_from_hf(repo_id: str, revision: str | None) -> dict[str, dict[tuple[s
         SENSITIVE_ATTRS,
         compute_fairness_skill_scores,
     )
-    from make_imputation_latex_tables import _attach_point  # noqa: E402
+    from make_imputation_latex_tables import attach_skill_rank_point  # noqa: E402
 
     draws_path = hf_hub_download(
         repo_id=repo_id, filename=DRAWS_PATH, repo_type="dataset", revision=revision
@@ -157,21 +156,10 @@ def reduce_from_hf(repo_id: str, revision: str | None) -> dict[str, dict[tuple[s
     ]
     per_user_df = pd.concat(per_method, ignore_index=True)
 
-    # Deterministic point (the reported center) for skill / rank, from the same
-    # leaderboard reducers on the unresampled all/all cohort; percentile CI comes
-    # from the bootstrap summary.
-    # Average rank is cross-method: compute the point over the same method pool as
-    # the bootstrap draws (restrict the substrate to those methods).
-    draw_methods = set(tables["avg_rankings"]["method"].astype(str)) | set(
-        tables["skill_scores"]["method"].astype(str)
-    )
-    pu_all = per_user_df[
-        (per_user_df["subgroup_attr"] == "all")
-        & (per_user_df["method"].astype(str).isin(draw_methods))
-    ].rename(columns={"E_per_user": "E"})
-    point = compute_point_skill_rank(pu_all, baseline_method=REFERENCE)
-    skill_tbl = _attach_point(tables["skill_scores"], point["skill_scores"])
-    rank_tbl = _attach_point(tables["avg_rankings"], point["avg_rankings"])
+    # Deterministic point (the reported center) for skill / rank; percentile CI
+    # comes from the bootstrap summary. See ``attach_skill_rank_point`` for the
+    # test-split + cross-method pool invariants.
+    skill_tbl, rank_tbl = attach_skill_rank_point(tables, per_user_df, baseline=REFERENCE)
 
     # Fairness: deterministic point + BCa interval (matches the main table). The
     # BCa jackknife needs the per-user substrate.

--- a/src/forecasting_evaluation/metrics/bootstrap_skill_rank.py
+++ b/src/forecasting_evaluation/metrics/bootstrap_skill_rank.py
@@ -588,6 +588,77 @@ def bootstrap_skill_rank(
     return result
 
 
+def compute_point_skill_rank(
+    *,
+    models: dict[str, dict[str, str]],
+    baseline_model: str,
+    binary_groups: list[tuple[str, tuple[int, ...]]],
+    per_user_metrics: pd.DataFrame,
+    clip_lower: float = 0.01,
+    clip_upper: float = 100.0,
+    min_pairs: int = 1,
+) -> dict[str, pd.DataFrame]:
+    """Deterministic point estimate of skill and rank from the per-user substrate.
+
+    Runs the exact point flow ``bootstrap_skill_rank`` uses to anchor its BCa
+    interval (identity-draw == point): ``_compute_long_skill_scores`` +
+    ``_build_model_summary`` for skill, ``_compute_all_ranks`` for rank. The
+    returned ``point`` column is merge-ready onto the CSVs written by
+    ``build_forecasting_bootstrap_from_hf`` — skill keyed by ``(model, scope)``
+    (scope = ``<name>_score``), rank by ``(model, scope, metric)``.
+
+    Args:
+        models: ``{name: {"path": ..., "display_name": ...}}``.
+        baseline_model: skill-score denominator (key in ``models``).
+        binary_groups: ``[(group_name, channel_indices), ...]`` for rank scopes.
+        per_user_metrics: canonical substrate frame (micro/user).
+        clip_lower: lower clip on the per-task error ratio.
+        clip_upper: upper clip on the per-task error ratio.
+        min_pairs: minimum paired units required to score a task.
+
+    Returns:
+        ``{"skill_scores": df[model, scope, point],
+           "avg_rankings": df[model, scope, metric, point]}``.
+    """
+    error_df = to_error_df(per_user_metrics, user_col="unit_id")
+    rank_user_df = to_rank_user_df(per_user_metrics, binary_groups=binary_groups)
+
+    point_summary = _build_model_summary(
+        long_df=_compute_long_skill_scores(
+            error_df=error_df,
+            models=models,
+            baseline_model=baseline_model,
+            clip_lower=clip_lower,
+            clip_upper=clip_upper,
+            min_pairs=min_pairs,
+        ),
+        models=models,
+        baseline_model=baseline_model,
+    )
+    skill_point = pd.DataFrame(
+        [
+            {"model": row["model"], "scope": col, "point": float(row[col])}
+            for _, row in point_summary.iterrows()
+            for col in point_summary.columns
+            if col.endswith("_score") and pd.notna(row[col])
+        ]
+    )
+    point_ranks = _compute_all_ranks(user_metric_df=rank_user_df)
+    rank_point = pd.DataFrame(
+        [
+            {
+                "model": row["model"],
+                "scope": row["scope"],
+                "metric": row["metric"],
+                "point": float(row["rank"]),
+            }
+            for _, row in point_ranks.iterrows()
+            if pd.notna(row["rank"])
+        ]
+    )
+    return {"skill_scores": skill_point, "avg_rankings": rank_point}
+
+
 def _summary_table(records: list[dict], key_cols: list[str], ci_level: float) -> pd.DataFrame:
     """Reduce per-draw value records to one summarised row per key tuple."""
     out_cols = key_cols + ["mean", "se", "ci_lo", "ci_hi", "n_boot"]

--- a/src/imputation_evaluation/evaluation/bootstrap_skill_rank.py
+++ b/src/imputation_evaluation/evaluation/bootstrap_skill_rank.py
@@ -991,7 +991,7 @@ def compute_per_task_paired_R(
 def compute_point_skill_rank(
     per_user_all: pd.DataFrame,
     *,
-    baseline_method: str = BASELINE_CONTINUOUS,
+    baseline_method: str,
     clip_lower: float = SKILL_CLIP_LOWER,
     clip_upper: float = SKILL_CLIP_UPPER,
 ) -> dict[str, pd.DataFrame]:
@@ -1010,9 +1010,10 @@ def compute_point_skill_rank(
             ``[method, scenario, channel, channel_type, user_id, E]`` — one row per
             (method, task, user). The value column must be named ``E`` (rename
             ``E_per_user`` upstream).
-        baseline_method: paired denominator for the skill ratio (default
-            :data:`BASELINE_CONTINUOUS` = ``"locf"``). The baseline appears in the
-            rank output but not the skill output (skill vs self is 0 by construction).
+        baseline_method: paired denominator for the skill ratio (required; the
+            Track-2 leaderboard baseline is :data:`BASELINE_CONTINUOUS` = ``"locf"``).
+            The baseline appears in the rank output but not the skill output
+            (skill vs self is 0 by construction).
         clip_lower: lower clip on the per-task ratio.
         clip_upper: upper clip on the per-task ratio.
 

--- a/src/imputation_evaluation/evaluation/bootstrap_skill_rank.py
+++ b/src/imputation_evaluation/evaluation/bootstrap_skill_rank.py
@@ -56,6 +56,7 @@ from imputation_evaluation.evaluation.paper_metrics_core import (
     EXCLUDE_BINARY_SCENARIOS,
     aggregate_task_ranks_to_scopes,
     build_baseline_errors,
+    compute_average_rankings,
     compute_skill_scores,
 )
 
@@ -985,6 +986,63 @@ def compute_per_task_paired_R(
     grouped["R"] = np.exp(grouped["mean"])
     grouped["n_users"] = grouped["size"].astype(int)
     return grouped[cols]
+
+
+def compute_point_skill_rank(
+    per_user_all: pd.DataFrame,
+    *,
+    baseline_method: str = BASELINE_CONTINUOUS,
+    clip_lower: float = SKILL_CLIP_LOWER,
+    clip_upper: float = SKILL_CLIP_UPPER,
+) -> dict[str, pd.DataFrame]:
+    """Deterministic point estimate of skill score and average rank per (method, scope).
+
+    Point-flow companion to the bootstrap skill / rank tables: runs the exact
+    leaderboard reducers on the **unresampled** cohort so the emitted ``point``
+    matches the bootstrap identity-draw estimate (see
+    :func:`paper_metrics_core.compute_average_rankings`). Reuses the same reducer
+    chain as ``scripts/paper_results/compute_imputation_paper_metrics.py``:
+    ``compute_per_task_paired_R`` -> ``compute_skill_scores(mode="paired")`` for
+    skill, and ``compute_average_rankings`` for rank.
+
+    Args:
+        per_user_all: ``subgroup_attr == "all"`` per-user error frame with columns
+            ``[method, scenario, channel, channel_type, user_id, E]`` — one row per
+            (method, task, user). The value column must be named ``E`` (rename
+            ``E_per_user`` upstream).
+        baseline_method: paired denominator for the skill ratio (default
+            :data:`BASELINE_CONTINUOUS` = ``"locf"``). The baseline appears in the
+            rank output but not the skill output (skill vs self is 0 by construction).
+        clip_lower: lower clip on the per-task ratio.
+        clip_upper: upper clip on the per-task ratio.
+
+    Returns:
+        ``{"skill_scores": df[method, scope, point],
+           "avg_rankings": df[method, scope, point]}``.
+    """
+    # The HF substrate stores string keys as pandas ``category`` dtype; coerce to
+    # plain str so the reducers' groupby/stack don't materialise the categorical
+    # cross-product.
+    per_user_all = per_user_all.copy()
+    for c in ("method", "scenario", "channel", "channel_type", "user_id"):
+        if c in per_user_all.columns and isinstance(
+            per_user_all[c].dtype, pd.CategoricalDtype
+        ):
+            per_user_all[c] = per_user_all[c].astype(str)
+
+    R_per_task = compute_per_task_paired_R(
+        per_user_all,
+        baseline_method=baseline_method,
+        clip_lower=clip_lower,
+        clip_upper=clip_upper,
+    )
+    skill = compute_skill_scores(
+        R_per_task, mode="paired", clip_lower=clip_lower, clip_upper=clip_upper
+    )
+    rank = compute_average_rankings(per_user_all)
+    skill_point = skill.rename(columns={"skill_score": "point"})[["method", "scope", "point"]]
+    rank_point = rank.rename(columns={"avg_rank": "point"})[["method", "scope", "point"]]
+    return {"skill_scores": skill_point, "avg_rankings": rank_point}
 
 
 def _per_method_cell_paired_collapsed_ratios(

--- a/tests/test_imputation_skill_by_scenario_table.py
+++ b/tests/test_imputation_skill_by_scenario_table.py
@@ -6,13 +6,14 @@ import pytest
 from scripts.paper_results.imputation import make_imputation_skill_by_scenario_table as table
 
 
-def test_fmt_cell_rejects_nan_se():
-    """NaN SEs must not render as zero-width uncertainty."""
-    with pytest.raises(ValueError, match="Non-finite SE"):
+def test_fmt_cell_rejects_nan_center():
+    """A non-finite center must fail loudly, not render as garbage."""
+    with pytest.raises(ValueError, match="Non-finite center"):
         table.fmt_cell(
             "mean",
-            center=0.2,
-            se=math.nan,
+            center=math.nan,
+            lo=0.1,
+            hi=0.3,
             scale100=True,
             ref_zero=False,
             n=0,


### PR DESCRIPTION
## Problem

The imputation and forecasting paper tables displayed the **bootstrap mean** as the reported center for Skill Score (`S`), Average Rank (`R`), and per-category / per-scenario skill columns, while only the Fairness Skill Score (`S_fair`) showed a deterministic **point** estimate. For these nonlinear/clipped statistics the bootstrap mean is a biased estimate of the full-sample quantity, and the appendix Methods already claimed *"point estimates on the held-out test split"* — so the tables silently contradicted the text. The `skill_scores_bootstrap.csv` / `avg_rankings_bootstrap.csv` didn't even carry a `point` column.

## Change

- New `compute_point_skill_rank()` point-flow helper in both tracks' `bootstrap_skill_rank.py` — runs the exact leaderboard reducers (`compute_per_task_paired_R` → `compute_skill_scores`; `compute_average_rankings`) on the unresampled cohort. Forecasting reuses the same point flow that anchors its BCa interval.
- The reducer/builder steps attach a `point` column to the skill/rank bootstrap CSVs; the table generators flip `center` from `mean` → `point`, keeping the existing **percentile** CIs (BCa unchanged for `S_fair`).
- The appendix skill-by-scenario table moves from symmetric **±SE** to the **asymmetric percentile CI** used by the other tables, with `S_fair` now point + BCa (matching the main table).
- Captions updated to state point estimate + percentile/BCa; imputation cache schema bumped so stale caches auto-rebuild.

## Notable

- **Cross-method rank-pool fix:** average rank is a cross-method statistic, so the point must be computed over the *same* method pool as the bootstrap draws. The per-method HF substrate carries an extra dense `lsm2_weekly` that is absent from the main table's draws; including it inflated every rank. Caught by a point-in-CI check and now guarded.
- **Effect by track:** imputation skill/category shift slightly (≤~0.4pp), rank unchanged; forecasting is caption + cosmetic only (its published numbers were already point-based). Every reported point lies within its CI on all three tables.

## Verification

- 47 imputation + forecasting parity/bootstrap tests pass.
- Regenerated all three tables from the HF substrate; 0 points fall outside their CIs; diffs reviewed.
- Tables compile cleanly (standalone wrapper).

Paper `.tex` changes live in the separate Overleaf repo and are **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)