### PR TITLE
docs(labels): refresh stale observed-value statistics in survey_documentation

### DIFF
--- a/data/labels/survey_documentation/anthropometrics/BMI_values.md
+++ b/data/labels/survey_documentation/anthropometrics/BMI_values.md
@@ -23,45 +23,45 @@ Not a survey variable. Computed from Body Mass (kg) and Height (m) automatically
 
 ## Observed values
 
-**Total observations**: 22,334 — **type-enforced**: 22,334 (**unique**: 3,235) — raw Python types seen: `float` (22,334).
+**Total observations**: 10,047 — **type-enforced**: 10,047 (**unique**: 2,477) — raw Python types seen: `float` (10,047).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
 |------|------:|
-| min | 10.40 |
-| q25 | 23.02 |
-| median | 25.85 |
-| mean | 27.14 |
-| q75 | 29.91 |
-| max | 125 |
-| std | 6.55 |
+| min | 11.74 |
+| q25 | 23.33 |
+| median | 26.11 |
+| mean | 27.24 |
+| q75 | 30.04 |
+| max | 58.04 |
+| std | 5.85 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `25.10` | 75 |
-| `24.37` | 69 |
-| `24.39` | 67 |
-| `23.67` | 66 |
-| `25.83` | 65 |
-| `23.01` | 64 |
-| `22.96` | 62 |
-| `25.10` | 62 |
-| `23.73` | 59 |
-| `26.50` | 59 |
-| `22.24` | 58 |
-| `22.89` | 58 |
-| `23.49` | 58 |
-| `25.09` | 58 |
-| `27.26` | 58 |
-| `21.52` | 57 |
-| `22.81` | 57 |
-| `23.71` | 57 |
-| `25.09` | 56 |
-| `27.32` | 56 |
+| `25.10` | 40 |
+| `22.96` | 35 |
+| `23.01` | 34 |
+| `25.83` | 34 |
+| `24.37` | 32 |
+| `23.67` | 32 |
+| `25.85` | 31 |
+| `23.73` | 29 |
+| `25.10` | 27 |
+| `27.26` | 27 |
+| `22.81` | 27 |
+| `22.89` | 27 |
+| `22.38` | 27 |
+| `23.49` | 27 |
+| `26.54` | 26 |
+| `26.50` | 26 |
+| `23.57` | 26 |
+| `25.09` | 26 |
+| `27.32` | 25 |
+| `27.20` | 25 |
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history
 - Commits touching source file: 117 total

--- a/data/labels/survey_documentation/anthropometrics/WeightKilograms.md
+++ b/data/labels/survey_documentation/anthropometrics/WeightKilograms.md
@@ -22,45 +22,45 @@ Not a survey variable. Collected automatically via HealthKit from Apple Watch/iP
 
 ## Observed values
 
-**Total observations**: 25,437 — **type-enforced**: 25,437 (**unique**: 353) — raw Python types seen: `float` (25,437).
+**Total observations**: 10,126 — **type-enforced**: 10,126 (**unique**: 314) — raw Python types seen: `float` (10,126).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
 |------|------:|
-| min | 30.00 |
-| q25 | 63.05 |
-| median | 77.11 |
-| mean | 77.04 |
-| q75 | 91.17 |
-| max | 300 |
-| std | 27.00 |
+| min | 31.30 |
+| q25 | 70.31 |
+| median | 81.65 |
+| mean | 84.09 |
+| q75 | 95.25 |
+| max | 223.6 |
+| std | 20.87 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `30.00` | 2,782 |
-| `74.84` | 486 |
-| `77.11` | 483 |
-| `81.65` | 460 |
-| `83.91` | 458 |
-| `68.04` | 448 |
-| `72.57` | 442 |
-| `79.38` | 426 |
-| `90.72` | 414 |
-| `86.18` | 407 |
-| `70.31` | 394 |
-| `63.50` | 347 |
-| `88.45` | 336 |
-| `95.25` | 307 |
-| `99.79` | 294 |
-| `65.77` | 289 |
-| `58.97` | 273 |
-| `92.99` | 271 |
-| `78.02` | 250 |
-| `61.23` | 246 |
+| `74.84` | 231 |
+| `81.65` | 199 |
+| `77.11` | 198 |
+| `83.91` | 195 |
+| `72.57` | 187 |
+| `86.18` | 181 |
+| `68.04` | 177 |
+| `79.38` | 177 |
+| `90.72` | 175 |
+| `70.31` | 168 |
+| `88.45` | 141 |
+| `95.25` | 134 |
+| `63.50` | 131 |
+| `92.99` | 128 |
+| `79.83` | 121 |
+| `65.77` | 119 |
+| `99.79` | 114 |
+| `78.02` | 114 |
+| `80.74` | 114 |
+| `76.20` | 106 |
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history
 - Commits touching source file: 117 total

--- a/data/labels/survey_documentation/cardiometabolic_labs/Hdl.md
+++ b/data/labels/survey_documentation/cardiometabolic_labs/Hdl.md
@@ -24,45 +24,45 @@
 
 ## Observed values
 
-**Total observations**: 9,187 — **type-enforced**: 9,187 (**unique**: 81) — raw Python types seen: `float` (9,187).
+**Total observations**: 3,342 — **type-enforced**: 3,342 (**unique**: 130) — raw Python types seen: `float` (3,342).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
 |------|------:|
-| min | 0.50 |
-| q25 | 2.22 |
-| median | 2.77 |
-| mean | 2.86 |
-| q75 | 3.50 |
+| min | 0.26 |
+| q25 | 1.06 |
+| median | 1.32 |
+| mean | 1.40 |
+| q75 | 1.68 |
 | max | 5.00 |
-| std | 0.99 |
+| std | 0.55 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `1.11` | 462 |
-| `2.77` | 434 |
-| `3.33` | 380 |
-| `4.44` | 345 |
-| `2.22` | 308 |
-| `2.50` | 297 |
-| `3.05` | 223 |
-| `2.33` | 218 |
-| `3.61` | 205 |
-| `2.66` | 197 |
-| `3.89` | 193 |
-| `2.61` | 192 |
-| `2.55` | 191 |
-| `2.28` | 187 |
-| `2.11` | 185 |
-| `2.89` | 185 |
-| `2.44` | 183 |
-| `5.00` | 178 |
-| `2.39` | 176 |
-| `1.94` | 174 |
+| `1.55` | 123 |
+| `1.29` | 117 |
+| `2.07` | 113 |
+| `1.16` | 106 |
+| `1.03` | 101 |
+| `1.14` | 86 |
+| `1.42` | 84 |
+| `1.24` | 80 |
+| `1.01` | 77 |
+| `0.52` | 76 |
+| `1.27` | 76 |
+| `1.09` | 74 |
+| `1.37` | 72 |
+| `1.22` | 71 |
+| `0.98` | 69 |
+| `1.11` | 68 |
+| `1.19` | 67 |
+| `1.45` | 67 |
+| `1.68` | 67 |
+| `1.32` | 63 |
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history
 - .h/.m commits: `06a6f76`, `0869e98`

--- a/data/labels/survey_documentation/cardiometabolic_labs/Ldl.md
+++ b/data/labels/survey_documentation/cardiometabolic_labs/Ldl.md
@@ -24,45 +24,45 @@
 
 ## Observed values
 
-**Total observations**: 6,845 — **type-enforced**: 6,845 (**unique**: 226) — raw Python types seen: `float` (6,845).
+**Total observations**: 2,755 — **type-enforced**: 2,755 (**unique**: 247) — raw Python types seen: `float` (2,755).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
 |------|------:|
-| min | 0.50 |
-| q25 | 4.44 |
-| median | 5.61 |
-| mean | 5.76 |
-| q75 | 6.99 |
-| max | 14.93 |
-| std | 2.00 |
+| min | 0.23 |
+| q25 | 2.04 |
+| median | 2.61 |
+| mean | 2.74 |
+| q75 | 3.26 |
+| max | 14.60 |
+| std | 1.09 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `5.55` | 178 |
-| `4.44` | 140 |
-| `5.00` | 113 |
-| `6.66` | 112 |
-| `6.11` | 104 |
-| `7.21` | 96 |
-| `5.49` | 91 |
-| `5.72` | 88 |
-| `3.89` | 84 |
-| `5.27` | 84 |
-| `6.38` | 83 |
-| `4.72` | 80 |
-| `5.88` | 80 |
-| `5.22` | 78 |
-| `5.38` | 78 |
-| `5.61` | 78 |
-| `4.16` | 77 |
-| `4.83` | 75 |
-| `4.94` | 75 |
-| `5.11` | 74 |
+| `2.59` | 59 |
+| `2.66` | 40 |
+| `2.07` | 39 |
+| `2.33` | 39 |
+| `2.46` | 38 |
+| `2.84` | 38 |
+| `2.74` | 38 |
+| `2.51` | 38 |
+| `1.81` | 37 |
+| `3.10` | 36 |
+| `2.43` | 35 |
+| `3.36` | 34 |
+| `2.97` | 32 |
+| `2.20` | 32 |
+| `2.09` | 31 |
+| `2.25` | 30 |
+| `3.05` | 30 |
+| `3.13` | 30 |
+| `2.56` | 30 |
+| `2.53` | 30 |
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history
 - .h/.m commits: `06a6f76`, `0869e98`

--- a/data/labels/survey_documentation/cardiometabolic_labs/SystolicBloodPressure.md
+++ b/data/labels/survey_documentation/cardiometabolic_labs/SystolicBloodPressure.md
@@ -24,7 +24,7 @@
 
 ## Observed values
 
-**Total observations**: 9,867 — **type-enforced**: 9,867 (**unique**: 101) — raw Python types seen: `float` (9,867).
+**Total observations**: 3,691 — **type-enforced**: 3,691 (**unique**: 88) — raw Python types seen: `float` (3,691).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
@@ -32,37 +32,37 @@
 | min | 70.00 |
 | q25 | 112 |
 | median | 120 |
-| mean | 120.9 |
+| mean | 120.8 |
 | q75 | 128 |
-| max | 200 |
-| std | 13.71 |
+| max | 199 |
+| std | 13.21 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `120` | 1,610 |
-| `110` | 819 |
-| `130` | 599 |
-| `118` | 415 |
-| `125` | 343 |
-| `128` | 312 |
-| `115` | 279 |
-| `100` | 274 |
-| `122` | 270 |
-| `140` | 267 |
-| `124` | 244 |
-| `116` | 240 |
-| `117` | 236 |
-| `112` | 225 |
-| `90.00` | 213 |
-| `135` | 207 |
-| `114` | 170 |
-| `121` | 151 |
-| `126` | 148 |
-| `127` | 147 |
+| `120` | 526 |
+| `110` | 296 |
+| `130` | 194 |
+| `118` | 166 |
+| `128` | 135 |
+| `125` | 128 |
+| `124` | 106 |
+| `122` | 105 |
+| `140` | 103 |
+| `100` | 100 |
+| `116` | 98 |
+| `115` | 97 |
+| `117` | 93 |
+| `112` | 82 |
+| `135` | 81 |
+| `114` | 69 |
+| `121` | 65 |
+| `90.00` | 62 |
+| `127` | 60 |
+| `132` | 55 |
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history
 - .h/.m commits: `06a6f76`, `0869e98`

--- a/data/labels/survey_documentation/cardiometabolic_labs/TotalCholesterol.md
+++ b/data/labels/survey_documentation/cardiometabolic_labs/TotalCholesterol.md
@@ -24,45 +24,45 @@
 
 ## Observed values
 
-**Total observations**: 9,937 — **type-enforced**: 9,937 (**unique**: 261) — raw Python types seen: `float` (9,937).
+**Total observations**: 3,558 — **type-enforced**: 3,558 (**unique**: 289) — raw Python types seen: `float` (3,558).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
 |------|------:|
-| min | 2.00 |
-| q25 | 7.77 |
-| median | 9.49 |
-| mean | 9.58 |
-| q75 | 11.10 |
+| min | 1.40 |
+| q25 | 3.75 |
+| median | 4.55 |
+| mean | 4.70 |
+| q75 | 5.30 |
 | max | 19.98 |
-| std | 2.33 |
+| std | 1.55 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `7.21` | 1,047 |
-| `8.32` | 328 |
-| `9.99` | 318 |
-| `11.10` | 314 |
-| `7.77` | 234 |
-| `9.44` | 194 |
-| `10.54` | 190 |
-| `8.88` | 181 |
-| `4.44` | 172 |
-| `9.71` | 140 |
-| `8.05` | 117 |
-| `11.65` | 116 |
-| `10.27` | 111 |
-| `7.49` | 109 |
-| `9.16` | 105 |
-| `12.21` | 95 |
-| `10.82` | 87 |
-| `10.71` | 82 |
-| `10.21` | 77 |
-| `9.77` | 76 |
+| `3.36` | 174 |
+| `2.07` | 100 |
+| `4.65` | 87 |
+| `5.17` | 82 |
+| `3.88` | 63 |
+| `4.40` | 58 |
+| `4.14` | 57 |
+| `4.53` | 51 |
+| `3.62` | 50 |
+| `4.91` | 47 |
+| `4.78` | 42 |
+| `4.89` | 38 |
+| `7.21` | 37 |
+| `4.81` | 37 |
+| `4.99` | 36 |
+| `4.27` | 36 |
+| `5.43` | 34 |
+| `4.55` | 33 |
+| `3.10` | 32 |
+| `4.76` | 31 |
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history
 - .h/.m commits: `06a6f76`, `0869e98`

--- a/data/labels/survey_documentation/cardiometabolic_labs/framingham_risk.md
+++ b/data/labels/survey_documentation/cardiometabolic_labs/framingham_risk.md
@@ -50,45 +50,45 @@ Each gender-ethnicity stratum has:
 
 ## Observed values
 
-**Total observations**: 5,968 — **type-enforced**: 5,968 (**unique**: 5,718) — raw Python types seen: `float` (5,968).
+**Total observations**: 2,239 — **type-enforced**: 2,239 (**unique**: 2,220) — raw Python types seen: `float` (2,239).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
 |------|------:|
-| min | 0.003377 |
+| min | 0.003791 |
 | q25 | 0.03 |
-| median | 0.06 |
-| mean | 0.08 |
+| median | 0.05 |
+| mean | 0.07 |
 | q75 | 0.10 |
-| max | 0.57 |
+| max | 0.68 |
 | std | 0.07 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `0.01` | 7 |
-| `0.02` | 4 |
-| `0.04` | 4 |
-| `0.04` | 4 |
-| `0.06` | 4 |
-| `0.09` | 4 |
-| `0.01` | 3 |
-| `0.02` | 3 |
-| `0.02` | 3 |
-| `0.02` | 3 |
-| `0.02` | 3 |
-| `0.02` | 3 |
-| `0.03` | 3 |
-| `0.03` | 3 |
-| `0.03` | 3 |
-| `0.04` | 3 |
-| `0.04` | 3 |
-| `0.04` | 3 |
-| `0.05` | 3 |
-| `0.05` | 3 |
+| `0.04` | 2 |
+| `0.07` | 2 |
+| `0.02` | 2 |
+| `0.03` | 2 |
+| `0.009575` | 2 |
+| `0.02` | 2 |
+| `0.02` | 2 |
+| `0.02` | 2 |
+| `0.006807` | 2 |
+| `0.04` | 2 |
+| `0.07` | 2 |
+| `0.02` | 2 |
+| `0.01` | 2 |
+| `0.07` | 2 |
+| `0.01` | 2 |
+| `0.04` | 2 |
+| `0.02` | 2 |
+| `0.03` | 2 |
+| `0.06` | 2 |
+| `0.15` | 1 |
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history (of source file or calculation)
 - **APHHeartAgeAndRiskFactors.m**: Recent material change

--- a/data/labels/survey_documentation/cardiometabolic_labs/summary.md
+++ b/data/labels/survey_documentation/cardiometabolic_labs/summary.md
@@ -8,7 +8,7 @@ Lab values and clinical measurements entered through the Heart Age form (cholest
 |----------|------|------|--------|---------|
 | [SystolicBloodPressure](SystolicBloodPressure.md) | target | continuous | Heart Age form | Systolic BP (mmHg) |
 | [blood_pressure_categories](blood_pressure_categories.md) | target | ordinal | Derived | AHA categories (normal / elevated / stage-1 / stage-2) |
-| [TotalCholesterol](TotalCholesterol.md) | target | continuous | Heart Age form | Total cholesterol (mg/dL) |
+| [TotalCholesterol](TotalCholesterol.md) | target | continuous | Heart Age form | Total cholesterol (mmol/L) |
 | [Hdl](Hdl.md) | target | continuous | Heart Age form | HDL cholesterol |
 | [Ldl](Ldl.md) | target | continuous | Heart Age form | LDL cholesterol (collected but not used in Framingham) |
 | [BloodGlucose](BloodGlucose.md) | context | continuous | Heart Age form | Blood glucose |

--- a/data/labels/survey_documentation/demographics/age.md
+++ b/data/labels/survey_documentation/demographics/age.md
@@ -24,45 +24,45 @@
 
 ## Observed values
 
-**Total observations**: 57,939 — **type-enforced**: 57,939 (**unique**: 77) — raw Python types seen: `int` (57,939).
+**Total observations**: 11,893 — **type-enforced**: 11,893 (**unique**: 72) — raw Python types seen: `int` (11,893).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
 |------|------:|
-| min | 17.00 |
-| q25 | 24.00 |
-| median | 32.00 |
-| mean | 35.35 |
-| q75 | 43.00 |
-| max | 93.00 |
-| std | 14.38 |
+| min | 18.00 |
+| q25 | 30.00 |
+| median | 39.00 |
+| mean | 41.90 |
+| q75 | 52.00 |
+| max | 90.00 |
+| std | 15.38 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `18.00` | 5,200 |
-| `30.00` | 3,193 |
-| `25.00` | 1,932 |
-| `26.00` | 1,872 |
-| `24.00` | 1,853 |
-| `29.00` | 1,811 |
-| `23.00` | 1,757 |
-| `27.00` | 1,744 |
-| `28.00` | 1,718 |
-| `31.00` | 1,662 |
-| `32.00` | 1,617 |
-| `22.00` | 1,581 |
-| `33.00` | 1,551 |
-| `35.00` | 1,519 |
-| `19.00` | 1,499 |
-| `20.00` | 1,468 |
-| `21.00` | 1,432 |
-| `34.00` | 1,427 |
-| `36.00` | 1,243 |
-| `37.00` | 1,217 |
+| `30.00` | 445 |
+| `33.00` | 352 |
+| `31.00` | 348 |
+| `32.00` | 345 |
+| `36.00` | 332 |
+| `35.00` | 321 |
+| `29.00` | 303 |
+| `40.00` | 300 |
+| `27.00` | 289 |
+| `25.00` | 286 |
+| `34.00` | 284 |
+| `39.00` | 283 |
+| `26.00` | 283 |
+| `28.00` | 283 |
+| `43.00` | 279 |
+| `37.00` | 272 |
+| `44.00` | 270 |
+| `41.00` | 260 |
+| `38.00` | 257 |
+| `45.00` | 251 |
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history
 - .h/.m commits: `06a6f76` (MHX-640 Added NSLocalizedString), `0869e98` (Squashed commit)

--- a/data/labels/survey_documentation/healthkit_watch_metrics/Watch_BasalEnergyBurned.md
+++ b/data/labels/survey_documentation/healthkit_watch_metrics/Watch_BasalEnergyBurned.md
@@ -22,47 +22,47 @@ Not a survey variable. Collected automatically via HealthKit from Apple Watch/iP
 
 ## Observed values
 
-**Total observations**: 381,354 — **type-enforced**: 381,354 (**unique**: 359,156) — raw Python types seen: `float` (381,354).
+**Total observations**: 269,912 — **type-enforced**: 269,912 (**unique**: 254,001) — raw Python types seen: `float` (269,912).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
 |------|------:|
-| min | -4666 |
-| q25 | 1455 |
-| median | 1784 |
-| mean | 1921 |
-| q75 | 2181 |
-| max | 9989 |
-| std | 992.1 |
+| min | 500.3 |
+| q25 | 1544 |
+| median | 1831 |
+| mean | 1958 |
+| q75 | 2211 |
+| max | 4500 |
+| std | 675.8 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `1595` | 134 |
-| `1697` | 130 |
-| `1529` | 106 |
-| `1286` | 105 |
-| `1600` | 105 |
+| `1697` | 112 |
+| `1529` | 105 |
 | `3148` | 102 |
-| `3138` | 90 |
-| `1753` | 88 |
-| `1782` | 88 |
-| `1577` | 86 |
+| `3138` | 92 |
 | `1524` | 83 |
-| `1633` | 78 |
 | `1816` | 76 |
-| `1340` | 75 |
-| `1508` | 75 |
-| `1779` | 75 |
-| `1814` | 74 |
+| `1340` | 76 |
+| `1508` | 73 |
+| `1779` | 73 |
 | `1534` | 72 |
 | `1513` | 71 |
-| `1281` | 70 |
+| `1774` | 69 |
+| `2814` | 66 |
+| `1662` | 66 |
+| `1759` | 64 |
+| `1633` | 63 |
+| `1692` | 63 |
+| `1635` | 59 |
+| `1506` | 59 |
+| `1504` | 57 |
 
 _Daily-resolution variant also available in `data/labels/healthkit_daily.json`; this table reflects `last_labels.json` (nearest-per-user measurement) for API consistency._
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history
 - Commits touching source file: 117 total

--- a/data/labels/survey_documentation/healthkit_watch_metrics/Watch_HeartRateVariabilitySDNN.md
+++ b/data/labels/survey_documentation/healthkit_watch_metrics/Watch_HeartRateVariabilitySDNN.md
@@ -22,47 +22,47 @@ Not a survey variable. Collected automatically via HealthKit from Apple Watch/iP
 
 ## Observed values
 
-**Total observations**: 264,783 — **type-enforced**: 264,783 (**unique**: 226,319) — raw Python types seen: `float` (264,783).
+**Total observations**: 197,454 — **type-enforced**: 197,454 (**unique**: 172,403) — raw Python types seen: `float` (197,454).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
 |------|------:|
-| min | 0.002341 |
-| q25 | 22.87 |
-| median | 29.60 |
-| mean | 34.53 |
-| q75 | 39.23 |
-| max | 444 |
-| std | 23.44 |
+| min | 5.18 |
+| q25 | 22.63 |
+| median | 29.36 |
+| mean | 33.48 |
+| q75 | 38.99 |
+| max | 200 |
+| std | 18.98 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `19.30` | 13 |
+| `19.30` | 11 |
 | `20.64` | 11 |
-| `22.16` | 11 |
-| `23.95` | 11 |
-| `24.71` | 11 |
-| `28.41` | 11 |
-| `28.69` | 11 |
-| `18.79` | 10 |
-| `22.18` | 10 |
-| `22.75` | 10 |
-| `23.03` | 10 |
-| `23.92` | 10 |
-| `23.93` | 10 |
-| `23.96` | 10 |
-| `24.41` | 10 |
-| `24.71` | 10 |
-| `25.91` | 10 |
-| `26.46` | 10 |
-| `26.58` | 10 |
-| `26.83` | 10 |
+| `24.77` | 9 |
+| `28.69` | 9 |
+| `24.80` | 9 |
+| `27.31` | 9 |
+| `25.91` | 9 |
+| `30.20` | 9 |
+| `24.71` | 9 |
+| `22.58` | 9 |
+| `28.00` | 9 |
+| `22.16` | 9 |
+| `19.81` | 8 |
+| `21.90` | 8 |
+| `23.91` | 8 |
+| `26.84` | 8 |
+| `22.01` | 8 |
+| `25.68` | 8 |
+| `29.06` | 8 |
+| `23.53` | 8 |
 
 _Daily-resolution variant also available in `data/labels/healthkit_daily.json`; this table reflects `last_labels.json` (nearest-per-user measurement) for API consistency._
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history
 - Commits touching source file: 117 total

--- a/data/labels/survey_documentation/healthkit_watch_metrics/Watch_RespiratoryRate.md
+++ b/data/labels/survey_documentation/healthkit_watch_metrics/Watch_RespiratoryRate.md
@@ -22,47 +22,47 @@ Not a survey variable. Collected automatically via HealthKit from Apple Watch/iP
 
 ## Observed values
 
-**Total observations**: 72,605 — **type-enforced**: 72,605 (**unique**: 3,265) — raw Python types seen: `float` (72,605).
+**Total observations**: 54,959 — **type-enforced**: 54,959 (**unique**: 2,797) — raw Python types seen: `float` (54,959).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
 |------|------:|
-| min | -1.00 |
+| min | 5.00 |
 | q25 | 14.00 |
-| median | 15.75 |
-| mean | 16.25 |
+| median | 15.86 |
+| mean | 16.24 |
 | q75 | 18.00 |
-| max | 106 |
-| std | 3.17 |
+| max | 39.00 |
+| std | 3.16 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `15.00` | 4,450 |
-| `14.00` | 3,471 |
-| `14.50` | 3,366 |
-| `17.00` | 3,342 |
-| `13.00` | 3,261 |
-| `15.50` | 3,102 |
-| `13.50` | 2,894 |
-| `16.00` | 2,822 |
-| `16.50` | 2,638 |
-| `17.50` | 2,164 |
-| `12.50` | 1,818 |
-| `18.00` | 1,625 |
-| `19.00` | 1,423 |
-| `18.50` | 1,394 |
-| `12.00` | 1,162 |
-| `11.50` | 1,041 |
-| `20.00` | 986 |
-| `20.50` | 953 |
-| `19.50` | 900 |
-| `15.25` | 782 |
+| `15.00` | 3,320 |
+| `17.00` | 2,687 |
+| `14.00` | 2,606 |
+| `14.50` | 2,530 |
+| `13.00` | 2,497 |
+| `15.50` | 2,329 |
+| `13.50` | 2,188 |
+| `16.00` | 2,095 |
+| `16.50` | 2,017 |
+| `17.50` | 1,706 |
+| `12.50` | 1,279 |
+| `18.00` | 1,224 |
+| `19.00` | 1,092 |
+| `18.50` | 1,033 |
+| `11.50` | 963 |
+| `12.00` | 947 |
+| `20.00` | 787 |
+| `20.50` | 737 |
+| `19.50` | 716 |
+| `21.00` | 610 |
 
 _Daily-resolution variant also available in `data/labels/healthkit_daily.json`; this table reflects `last_labels.json` (nearest-per-user measurement) for API consistency._
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history
 - Commits touching source file: 117 total

--- a/data/labels/survey_documentation/healthkit_watch_metrics/Watch_RestingHeartRate.md
+++ b/data/labels/survey_documentation/healthkit_watch_metrics/Watch_RestingHeartRate.md
@@ -22,47 +22,47 @@ Not a survey variable. Collected automatically via HealthKit from Apple Watch/iP
 
 ## Observed values
 
-**Total observations**: 275,147 — **type-enforced**: 275,147 (**unique**: 1,356) — raw Python types seen: `float` (275,147).
+**Total observations**: 205,617 — **type-enforced**: 205,617 (**unique**: 1,271) — raw Python types seen: `float` (205,617).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
 |------|------:|
-| min | 14.34 |
+| min | 31.50 |
 | q25 | 56.00 |
 | median | 62.00 |
-| mean | 63.04 |
-| q75 | 69.00 |
+| mean | 62.74 |
+| q75 | 68.50 |
 | max | 175 |
-| std | 9.71 |
+| std | 9.64 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `60.00` | 11,949 |
-| `59.00` | 10,479 |
-| `63.00` | 9,453 |
-| `58.00` | 9,252 |
-| `61.00` | 8,972 |
-| `57.00` | 8,750 |
-| `62.00` | 8,594 |
-| `66.00` | 8,459 |
-| `67.00` | 8,333 |
-| `64.00` | 8,152 |
-| `56.00` | 8,106 |
-| `68.00` | 7,577 |
-| `65.00` | 7,448 |
-| `55.00` | 7,175 |
-| `69.00` | 6,901 |
-| `54.00` | 6,672 |
-| `53.00` | 6,372 |
-| `70.00` | 6,077 |
-| `52.00` | 5,743 |
-| `71.00` | 5,568 |
+| `60.00` | 9,072 |
+| `59.00` | 8,129 |
+| `58.00` | 7,108 |
+| `63.00` | 6,941 |
+| `57.00` | 6,815 |
+| `61.00` | 6,800 |
+| `62.00` | 6,381 |
+| `56.00` | 6,296 |
+| `66.00` | 6,168 |
+| `67.00` | 6,128 |
+| `64.00` | 5,945 |
+| `68.00` | 5,569 |
+| `55.00` | 5,563 |
+| `65.00` | 5,470 |
+| `54.00` | 5,056 |
+| `69.00` | 5,055 |
+| `53.00` | 4,837 |
+| `52.00` | 4,381 |
+| `70.00` | 4,323 |
+| `71.00` | 3,896 |
 
 _Daily-resolution variant also available in `data/labels/healthkit_daily.json`; this table reflects `last_labels.json` (nearest-per-user measurement) for API consistency._
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history
 - Commits touching source file: 117 total

--- a/data/labels/survey_documentation/healthkit_watch_metrics/Watch_StandTime.md
+++ b/data/labels/survey_documentation/healthkit_watch_metrics/Watch_StandTime.md
@@ -22,47 +22,47 @@ Not a survey variable. Collected automatically via HealthKit from Apple Watch/iP
 
 ## Observed values
 
-**Total observations**: 180,442 — **type-enforced**: 180,442 (**unique**: 7,436) — raw Python types seen: `float` (180,442).
+**Total observations**: 134,955 — **type-enforced**: 134,955 (**unique**: 7,112) — raw Python types seen: `float` (134,955).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
 |------|------:|
 | min | 0.02 |
-| q25 | 1.13 |
-| median | 1.68 |
-| mean | 1.79 |
-| q75 | 2.31 |
-| max | 18.35 |
-| std | 0.93 |
+| q25 | 1.15 |
+| median | 1.71 |
+| mean | 1.82 |
+| q75 | 2.36 |
+| max | 14.00 |
+| std | 0.94 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `1.50` | 268 |
-| `1.45` | 247 |
-| `1.20` | 244 |
-| `1.27` | 244 |
-| `1.23` | 243 |
-| `1.43` | 242 |
-| `1.77` | 239 |
-| `1.32` | 236 |
-| `1.15` | 235 |
-| `1.62` | 235 |
-| `1.25` | 232 |
-| `1.57` | 232 |
-| `1.37` | 229 |
-| `1.05` | 228 |
-| `1.30` | 228 |
-| `1.52` | 228 |
-| `1.38` | 226 |
-| `1.00` | 223 |
-| `1.12` | 223 |
-| `1.40` | 223 |
+| `1.50` | 194 |
+| `1.62` | 183 |
+| `1.77` | 179 |
+| `1.43` | 178 |
+| `1.45` | 177 |
+| `1.25` | 177 |
+| `1.23` | 177 |
+| `1.15` | 176 |
+| `1.05` | 171 |
+| `1.30` | 170 |
+| `1.27` | 169 |
+| `1.38` | 167 |
+| `1.37` | 166 |
+| `1.12` | 166 |
+| `1.32` | 165 |
+| `1.20` | 164 |
+| `1.57` | 164 |
+| `1.52` | 163 |
+| `1.48` | 162 |
+| `1.40` | 161 |
 
 _Daily-resolution variant also available in `data/labels/healthkit_daily.json`; this table reflects `last_labels.json` (nearest-per-user measurement) for API consistency._
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history
 - Commits touching source file: 117 total

--- a/data/labels/survey_documentation/healthkit_watch_metrics/Watch_VO2Max.md
+++ b/data/labels/survey_documentation/healthkit_watch_metrics/Watch_VO2Max.md
@@ -22,47 +22,47 @@ Not a survey variable. Collected automatically via HealthKit from Apple Watch/iP
 
 ## Observed values
 
-**Total observations**: 91,622 — **type-enforced**: 91,622 (**unique**: 40,955) — raw Python types seen: `float` (91,622).
+**Total observations**: 68,782 — **type-enforced**: 68,782 (**unique**: 32,919) — raw Python types seen: `float` (68,782).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
 |------|------:|
 | min | 14.00 |
-| q25 | 27.86 |
-| median | 33.77 |
-| mean | 33.60 |
-| q75 | 39.09 |
-| max | 99.00 |
-| std | 8.03 |
+| q25 | 27.71 |
+| median | 33.92 |
+| mean | 33.75 |
+| q75 | 39.34 |
+| max | 59.89 |
+| std | 8.18 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `14.00` | 246 |
-| `30.99` | 33 |
-| `27.08` | 32 |
-| `26.59` | 31 |
-| `32.84` | 31 |
-| `26.43` | 30 |
-| `31.08` | 30 |
-| `31.67` | 30 |
-| `37.20` | 30 |
-| `25.92` | 29 |
-| `26.12` | 29 |
-| `26.41` | 29 |
-| `27.68` | 29 |
-| `29.16` | 29 |
-| `29.42` | 29 |
-| `29.60` | 29 |
-| `37.50` | 29 |
-| `25.65` | 28 |
-| `26.14` | 28 |
-| `27.01` | 28 |
+| `14.00` | 127 |
+| `25.92` | 27 |
+| `36.20` | 26 |
+| `37.50` | 26 |
+| `27.68` | 26 |
+| `37.20` | 26 |
+| `27.08` | 26 |
+| `31.67` | 25 |
+| `31.08` | 25 |
+| `26.92` | 25 |
+| `29.42` | 24 |
+| `26.59` | 23 |
+| `35.12` | 23 |
+| `30.42` | 23 |
+| `38.30` | 22 |
+| `25.81` | 22 |
+| `35.00` | 22 |
+| `27.83` | 22 |
+| `25.26` | 22 |
+| `27.97` | 22 |
 
 _Daily-resolution variant also available in `data/labels/healthkit_daily.json`; this table reflects `last_labels.json` (nearest-per-user measurement) for API consistency._
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history
 - Commits touching source file: 117 total

--- a/data/labels/survey_documentation/healthkit_watch_metrics/Watch_WalkingHeartRateAverage.md
+++ b/data/labels/survey_documentation/healthkit_watch_metrics/Watch_WalkingHeartRateAverage.md
@@ -22,47 +22,47 @@ Not a survey variable. Collected automatically via HealthKit from Apple Watch/iP
 
 ## Observed values
 
-**Total observations**: 263,606 — **type-enforced**: 263,606 (**unique**: 31,254) — raw Python types seen: `float` (263,606).
+**Total observations**: 196,697 — **type-enforced**: 196,697 (**unique**: 28,268) — raw Python types seen: `float` (196,697).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
 |------|------:|
 | min | 45.00 |
-| q25 | 88.29 |
-| median | 96.64 |
-| mean | 97.08 |
-| q75 | 105.2 |
+| q25 | 87.75 |
+| median | 96.17 |
+| mean | 96.61 |
+| q75 | 104.8 |
 | max | 202 |
-| std | 13.30 |
+| std | 13.38 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `90.00` | 454 |
-| `97.00` | 450 |
-| `105` | 421 |
-| `98.00` | 406 |
-| `97.50` | 375 |
-| `104` | 330 |
-| `90.50` | 294 |
-| `91.00` | 291 |
-| `89.50` | 287 |
-| `105.5` | 285 |
-| `99.00` | 277 |
-| `89.00` | 276 |
-| `106` | 267 |
-| `82.00` | 261 |
-| `96.00` | 260 |
-| `113` | 257 |
-| `104.5` | 253 |
-| `96.50` | 234 |
-| `112` | 231 |
-| `83.00` | 229 |
+| `90.00` | 349 |
+| `97.00` | 310 |
+| `105` | 296 |
+| `98.00` | 285 |
+| `97.50` | 269 |
+| `104` | 234 |
+| `90.50` | 217 |
+| `89.50` | 211 |
+| `89.00` | 207 |
+| `91.00` | 206 |
+| `105.5` | 195 |
+| `106` | 191 |
+| `99.00` | 190 |
+| `82.00` | 187 |
+| `113` | 186 |
+| `83.00` | 182 |
+| `96.00` | 178 |
+| `96.50` | 176 |
+| `104.5` | 174 |
+| `112` | 164 |
 
 _Daily-resolution variant also available in `data/labels/healthkit_daily.json`; this table reflects `last_labels.json` (nearest-per-user measurement) for API consistency._
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history
 - Commits touching source file: 117 total

--- a/data/labels/survey_documentation/physical_activity/vigorous_act.md
+++ b/data/labels/survey_documentation/physical_activity/vigorous_act.md
@@ -28,45 +28,45 @@ Continuous integer input (slider).
 
 ## Observed values
 
-**Total observations**: 42,497 — **type-enforced**: 42,497 (**unique**: 256) — raw Python types seen: `float` (42,497).
+**Total observations**: 9,633 — **type-enforced**: 9,633 (**unique**: 138) — raw Python types seen: `float` (9,633).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
 |------|------:|
 | min | 0 |
-| q25 | 2.00 |
+| q25 | 4.00 |
 | median | 30.00 |
-| mean | 73.89 |
+| mean | 71.70 |
 | q75 | 90.00 |
 | max | 1440 |
-| std | 136.8 |
+| std | 124.2 |
 
 **Top 20 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `0` | 9,700 |
-| `30.00` | 4,705 |
-| `60.00` | 4,128 |
-| `10.00` | 2,610 |
-| `20.00` | 2,292 |
-| `120` | 2,106 |
-| `15.00` | 1,715 |
-| `5.00` | 1,558 |
-| `90.00` | 1,334 |
-| `180` | 1,240 |
-| `100` | 964 |
-| `300` | 786 |
-| `150` | 778 |
-| `45.00` | 752 |
-| `200` | 714 |
-| `240` | 519 |
-| `1.00` | 501 |
-| `2.00` | 495 |
-| `50.00` | 482 |
-| `40.00` | 473 |
+| `0` | 2,134 |
+| `30.00` | 1,073 |
+| `60.00` | 929 |
+| `10.00` | 601 |
+| `20.00` | 516 |
+| `120` | 470 |
+| `15.00` | 400 |
+| `5.00` | 369 |
+| `90.00` | 333 |
+| `180` | 303 |
+| `100` | 225 |
+| `150` | 199 |
+| `300` | 170 |
+| `45.00` | 168 |
+| `200` | 155 |
+| `240` | 118 |
+| `40.00` | 117 |
+| `50.00` | 117 |
+| `2.00` | 100 |
+| `1.00` | 97 |
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history (file-level)
 - Total commits: 6

--- a/data/labels/survey_documentation/sleep/sleep_time.md
+++ b/data/labels/survey_documentation/sleep/sleep_time.md
@@ -27,7 +27,7 @@ Continuous integer input (slider).
 
 ## Observed values
 
-**Total observations**: 44,359 — **type-enforced**: 44,359 (**unique**: 101) — raw Python types seen: `float` (44,359).
+**Total observations**: 9,883 — **type-enforced**: 9,883 (**unique**: 16) — raw Python types seen: `float` (9,883).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
@@ -35,37 +35,33 @@ Continuous integer input (slider).
 | min | 0 |
 | q25 | 7.00 |
 | median | 8.00 |
-| mean | 1.55e+14 |
+| mean | 7.69 |
 | q75 | 8.00 |
-| max | 6.874e+18 |
-| std | 3.264e+16 |
+| max | 24.00 |
+| std | 1.22 |
 
-**Top 20 most frequent values**:
+**Top 16 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `8.00` | 21,478 |
-| `7.00` | 10,483 |
-| `9.00` | 5,245 |
-| `6.00` | 3,549 |
-| `10.00` | 1,875 |
-| `5.00` | 761 |
-| `12.00` | 295 |
-| `4.00` | 213 |
-| `11.00` | 111 |
-| `3.00` | 52 |
-| `2.00` | 38 |
-| `1.00` | 33 |
-| `0` | 16 |
-| `14.00` | 15 |
-| `50.00` | 14 |
-| `13.00` | 13 |
-| `15.00` | 12 |
-| `56.00` | 10 |
-| `40.00` | 9 |
-| `730` | 8 |
+| `8.00` | 4,836 |
+| `7.00` | 2,716 |
+| `9.00` | 953 |
+| `6.00` | 821 |
+| `10.00` | 272 |
+| `5.00` | 157 |
+| `12.00` | 41 |
+| `4.00` | 35 |
+| `24.00` | 16 |
+| `11.00` | 15 |
+| `3.00` | 9 |
+| `13.00` | 5 |
+| `0` | 2 |
+| `2.00` | 2 |
+| `16.00` | 2 |
+| `1.00` | 1 |
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history (file-level)
 - Total commits: 6

--- a/data/labels/survey_documentation/wellbeing/happiness.md
+++ b/data/labels/survey_documentation/wellbeing/happiness.md
@@ -22,7 +22,7 @@
 
 ## Observed values
 
-**Total observations**: 39,766 — **type-enforced**: 39,766 (**unique**: 11) — raw Python types seen: `float` (39,766).
+**Total observations**: 27,428 — **type-enforced**: 27,428 (**unique**: 11) — raw Python types seen: `float` (27,428).
 **Type-enforcement rejections**: 0 missing (`LabelValueError`), 0 unconvertible (`LabelTypeError`), 0 dictionary-miss (`KeyError`).
 
 | stat | value |
@@ -30,30 +30,30 @@
 | min | 0 |
 | q25 | 7.00 |
 | median | 8.00 |
-| mean | 7.56 |
+| mean | 7.53 |
 | q75 | 9.00 |
 | max | 10.00 |
-| std | 1.99 |
+| std | 1.96 |
 
 **Top 11 most frequent values**:
 
 | value | count |
 |------:|------:|
-| `8.00` | 10,263 |
-| `9.00` | 8,275 |
-| `7.00` | 6,396 |
-| `10.00` | 5,714 |
-| `6.00` | 3,370 |
-| `5.00` | 2,556 |
-| `4.00` | 1,293 |
-| `3.00` | 846 |
-| `2.00` | 501 |
-| `0` | 308 |
-| `1.00` | 244 |
+| `8.00` | 7,116 |
+| `9.00` | 5,855 |
+| `7.00` | 4,591 |
+| `10.00` | 3,511 |
+| `6.00` | 2,421 |
+| `5.00` | 1,871 |
+| `4.00` | 840 |
+| `3.00` | 502 |
+| `2.00` | 333 |
+| `0` | 218 |
+| `1.00` | 170 |
 
 _Daily-resolution variant also available in `data/labels/healthkit_daily.json`; this table reflects `last_labels.json` (nearest-per-user measurement) for API consistency._
 
-_Generated 2026-04-28 from `data/labels/last_labels.json` (md5 `0f65e8fe…`) and `data/labels/context_labels.json` (md5 `560ed125…`)._
+_Generated 2026-07-25 from `data/labels/last_labels.json` (md5 `521c157a…`) and `data/labels/context_labels.json` (md5 `220f5946…`)._
 
 ## Git history (file-level)
 - Commits: 4 (daily_check_coaching.json)


### PR DESCRIPTION
While working through reviewer comments on the paper I went to verify the cholesterol figures in `data/labels/survey_documentation/` and found the numbers there don't match the released dataset. That docs snapshot predates several label-preparation steps, so **18 pages publish statistics that no longer describe the data we ship**.

This PR regenerates those blocks. Nothing else.

## What changed

Regenerated from the released full-cohort label files — `last_labels.json` (md5 `521c157a…`) and `context_labels.json` (md5 `220f5946…`), the same bytes served by the public bundle. Per page, only these are rewritten:

- the `**Total observations** / type-enforced / unique / raw types` line
- the `**Type-enforcement rejections**` line
- the `| stat | value |` table
- the `**Top N most frequent values**` table
- the `_Generated …_` provenance footer

Prose, `## Source`, `## Question`, `## Answer options`, `## Git history` and `## Notes` are byte-identical. The diff contains no line outside those five kinds.

## Representative corrections

| Variable | Published | Released data |
|---|---|---|
| `Watch_BasalEnergyBurned` | min **−4666** kcal | 500.3 |
| `Watch_RespiratoryRate` | min **−1**, max **106** | 5, 39 |
| `Watch_HeartRateVariabilitySDNN` | min **0.002341** ms | 5.18 |
| `WeightKilograms` | min/max **30 / 300** (slider clamps) | 31.3 / 223.6 |
| `BMI_values` | max **125** | 58.04 |
| `age` | median **32** | 39 (de-identified birthdates) |
| `Watch_VO2Max` | max **99** | 59.89 |
| `TotalCholesterol` | median **9.49** | 4.55 mmol/L |
| `Hdl` / `Ldl` | median **2.77 / 5.61** | 1.32 / 2.61 mmol/L |

Full list of touched pages: `BMI_values`, `WeightKilograms`, `Hdl`, `Ldl`, `SystolicBloodPressure`, `TotalCholesterol`, `framingham_risk`, `age`, `Watch_BasalEnergyBurned`, `Watch_HeartRateVariabilitySDNN`, `Watch_RespiratoryRate`, `Watch_RestingHeartRate`, `Watch_StandTime`, `Watch_VO2Max`, `Watch_WalkingHeartRateAverage`, `vigorous_act`, `sleep_time`, `happiness`.

One additional one-word change, called out explicitly: `cardiometabolic_labs/summary.md` described TotalCholesterol as `(mg/dL)`, which the refreshed statistics in the same PR directly contradict. Changed to `(mmol/L)`.

## Scope / non-goals

- **No data, code or API change.** The released dataset is unaffected — it was already correct; only these markdown pages were stale.
- **Nothing outside `survey_documentation/`.** The bundle-side docs (`data/labels/README.md`, `RELEASE_NOTES.md`, which live in Google Drive and the Dataverse deposits) carry no per-variable statistics, so no dataset re-version is needed.
- Pages with categorical/ordinal value tables were checked and are unaffected.
